### PR TITLE
fix(api): enforce mutual exclusion of TLS backend features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,20 +52,25 @@ jobs:
   test-all-features:
     name: Test (All Features)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tls: [native-tls, rustls]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Run library unit tests (all features)
-        run: cargo test --workspace --lib --all-features
-      - name: Run integration tests (all features)
+      - name: Run library unit tests (${{ matrix.tls }} + all non-TLS features)
+        run: cargo test --workspace --lib --no-default-features --features "${{ matrix.tls }},axum,derive,sqlx-postgres,redis-cache"
+      - name: Run integration tests (${{ matrix.tls }} + all non-TLS features)
         run: |
-          cargo test --test compatibility_tests --all-features
-          cargo test --test integration_tests --all-features
-          cargo test --test derive_tests --all-features
-          cargo test --test axum_integration_tests --all-features
-          cargo test --test phase0_tests --all-features
-          cargo test --test meta_trait_tests --all-features
+          FEATURES="${{ matrix.tls }},axum,derive,sqlx-postgres,redis-cache"
+          cargo test --test compatibility_tests --no-default-features --features "$FEATURES"
+          cargo test --test integration_tests --no-default-features --features "$FEATURES"
+          cargo test --test derive_tests --no-default-features --features "$FEATURES"
+          cargo test --test axum_integration_tests --no-default-features --features "$FEATURES"
+          cargo test --test phase0_tests --no-default-features --features "$FEATURES"
+          cargo test --test meta_trait_tests --no-default-features --features "$FEATURES"
 
   compat:
     name: Compatibility Tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ repository = "https://github.com/better-auth-rs/better-auth-rs"
 [workspace.dependencies]
 # Sub-crates
 better-auth-core = { version = "0.9.0", path = "crates/core" }
-better-auth-api = { version = "0.9.0", path = "crates/api" }
+better-auth-api = { version = "0.9.0", path = "crates/api", default-features = false }
 better-auth-derive = { version = "0.9.0", path = "crates/derive" }
 
 # Asynchronous runtime

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -5,8 +5,9 @@
 #[cfg(all(feature = "native-tls", feature = "rustls"))]
 compile_error!(
     "features `native-tls` and `rustls` are mutually exclusive. \
-     Disable default features and enable only one: \
-     `default-features = false, features = [\"rustls\"]`."
+     Enable exactly one of them: \
+     for `native-tls` (default), remove the `rustls` feature; \
+     for `rustls`, set `default-features = false, features = [\"rustls\"]`."
 );
 
 #[cfg(not(any(feature = "native-tls", feature = "rustls")))]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -2,6 +2,19 @@
 //!
 //! Plugin implementations for the Better Auth authentication framework.
 
+#[cfg(all(feature = "native-tls", feature = "rustls"))]
+compile_error!(
+    "features `native-tls` and `rustls` are mutually exclusive. \
+     Disable default features and enable only one: \
+     `default-features = false, features = [\"rustls\"]`."
+);
+
+#[cfg(not(any(feature = "native-tls", feature = "rustls")))]
+compile_error!(
+    "one of the TLS backends must be enabled: \
+     enable either the `native-tls` (default) or `rustls` feature."
+);
+
 pub mod plugins;
 
 pub use plugins::account_management::AccountManagementPlugin;


### PR DESCRIPTION
## Summary

Follow-up to #66. The `native-tls` / `rustls` feature flags introduced there have two misconfiguration modes that silently produce broken or bloated builds:

- Enabling **both** features pulls two full TLS stacks into `reqwest` — worse than the pre-#66 status quo.
- Disabling default features without picking a replacement leaves `reqwest` with no TLS backend, so HTTPS requests fail at runtime with a non-obvious error.

Add `compile_error!` guards in `crates/api/src/lib.rs` so both cases fail loudly at build time with actionable messages.

## Test plan

- [x] `cargo check -p better-auth-api` (default / native-tls) — compiles
- [x] `cargo check -p better-auth-api --no-default-features --features rustls` — compiles
- [x] `cargo check -p better-auth-api --no-default-features` — fails with "one of the TLS backends must be enabled"
- [x] `cargo check -p better-auth-api --features rustls` (both enabled) — fails with "mutually exclusive"

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds compile-time guards in `crates/api/src/lib.rs` to enforce mutual exclusion of the `native-tls` and `rustls` TLS backend features in `better-auth-api`, and updates the workspace and CI configuration to match. It is a clean, targeted follow-up to #66.

- Added two `compile_error!` guards: one that fires when both TLS backends are enabled simultaneously, and one when neither is enabled.
- Set `default-features = false` on the `better-auth-api` workspace dependency so consumers cannot accidentally inherit TLS features through the workspace definition—feature selection must be explicit.
- Updated the `test-all-features` CI job from `--all-features` (which would now trigger the mutual-exclusion error) to a matrix strategy that tests `native-tls` and `rustls` independently using `--no-default-features --features "..."`.
- Added `fail-fast: false` to the matrix, ensuring one TLS variant's failures don't cancel the other.

<h3>Confidence Score: 5/5</h3>

Safe to merge — guards are correct, feature propagation is sound, and CI is properly updated.

All three changed files are correct and self-consistent. The compile_error! predicates precisely match the two failure modes described in the PR. The workspace default-features = false change is safe because the root package's native-tls default already propagates better-auth-api/native-tls. The CI matrix correctly covers both TLS backends without triggering the new mutual-exclusion guard, and fail-fast: false is a genuine improvement.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/api/src/lib.rs | Adds correct compile_error! guards for mutual TLS exclusion and missing TLS backend; both #[cfg] predicates are accurate. |
| Cargo.toml | Sets default-features = false on the better-auth-api workspace dependency; feature propagation through the root package's native-tls/rustls features is correct. |
| .github/workflows/ci.yml | Replaces --all-features (now broken by the mutual-exclusion guard) with an explicit matrix over native-tls/rustls, correctly listing all non-TLS features. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Cargo build of better-auth-api] --> B{Which TLS features are enabled?}
    B -->|both native-tls AND rustls| C["compile_error!\nMutually exclusive features"]
    B -->|neither native-tls NOR rustls| D["compile_error!\nNo TLS backend selected"]
    B -->|exactly native-tls| E[reqwest/default-tls enabled ✓]
    B -->|exactly rustls| F[reqwest/rustls-tls enabled ✓]

    G[Root package default features] -->|native-tls → better-auth-api/native-tls| E
    H[--no-default-features --features rustls] -->|rustls → better-auth-api/rustls| F

    subgraph CI Matrix
        I[matrix.tls = native-tls] --> J["--no-default-features\n--features native-tls,..."]
        K[matrix.tls = rustls] --> L["--no-default-features\n--features rustls,..."]
    end
    J --> E
    L --> F
```

<sub>Reviews (2): Last reviewed commit: ["fix(api): make rustls feature actually u..."](https://github.com/better-auth-rs/better-auth-rs/commit/3d27300a20ea53f69c4da72e6e299ec8dd32302e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28119709)</sub>

<!-- /greptile_comment -->