### PR TITLE
fix: propagate session refresh errors and bound axum body reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- `SessionManager::get_session` no longer silently discards
-  `update_session_expiry` failures; the updated `expires_at` is reflected
-  on the returned session so downstream code never observes a stale value.
-  Transient write errors and concurrent revocations both fall back to the
-  pre-refresh session with a `tracing::warn!`, so auth continues to work
-  across DB hiccups instead of surfacing a 500.
+- `SessionManager::get_session` previously discarded
+  `update_session_expiry` failures with `let _ = ...` and returned the
+  pre-refresh session, so callers observed a stale `expires_at` and real
+  DB errors were invisible. On the happy path the returned session now
+  reflects the persisted expiry. Transient write errors, re-read
+  failures, and concurrent revocations all emit a `tracing::warn!` and
+  fall back to the pre-refresh session instead of 500-ing the request.
 
 ### Behavior change
 
@@ -20,7 +21,8 @@ All notable changes to this project will be documented in this file.
   Requests that declare `Content-Length` above the cap are rejected with
   `413 Payload Too Large` before any bytes are buffered. Transport
   failures during the read (malformed chunked framing, broken
-  connection, etc.) continue to surface as `400 Bad Request`.
+  connection, etc.) now surface as `400 Bad Request` with the underlying
+  error captured via `tracing::warn!` for operators.
 
 ## [0.9.0](https://github.com/better-auth-rs/better-auth-rs/compare/v0.8.0...v0.9.0) - 2026-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+
+### Fixed
+
+- `SessionManager::get_session` no longer silently discards
+  `update_session_expiry` failures; the updated `expires_at` is reflected
+  on the returned session so downstream code never observes a stale value.
+  Transient write errors and concurrent revocations both fall back to the
+  pre-refresh session with a `tracing::warn!`, so auth continues to work
+  across DB hiccups instead of surfacing a 500.
+
+### Behavior change
+
+- The axum entry handler and the `AuthRequestExt` extractor now cap
+  request body reads at 1 MiB (matches upstream TS `better-auth@1.4.19`).
+  Requests that declare `Content-Length` above the cap are rejected with
+  `413 Payload Too Large` before any bytes are buffered. Transport
+  failures during the read (malformed chunked framing, broken
+  connection, etc.) continue to surface as `400 Bad Request`.
+
 ## [0.9.0](https://github.com/better-auth-rs/better-auth-rs/compare/v0.8.0...v0.9.0) - 2026-03-11
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,17 @@ All notable changes to this project will be documented in this file.
 
 ### Behavior change
 
-- The axum entry handler and the `AuthRequestExt` extractor now cap
-  request body reads at 1 MiB (matches upstream TS `better-auth@1.4.19`).
-  Requests that declare `Content-Length` above the cap are rejected with
-  `413 Payload Too Large` before any bytes are buffered. Transport
-  failures during the read (malformed chunked framing, broken
-  connection, etc.) now surface as `400 Bad Request` with the underlying
-  error captured via `tracing::warn!` for operators.
+- The axum entry handler caps request body reads at the configured
+  `AuthBuilder::body_limit(...)` ceiling (defaults to
+  `better_auth_core::config::DEFAULT_MAX_BODY_BYTES = 1 MiB`, matching
+  upstream TS `better-auth@1.4.19`). The `AuthRequestExt` extractor
+  uses the same default. Requests that declare `Content-Length` above
+  the cap are rejected with `413 Payload Too Large` before any bytes
+  are buffered. A `LengthLimitError` that surfaces during the read
+  (chunked body exceeding the cap) also returns `413`. Other transport
+  failures (malformed chunked framing, client disconnect) return
+  `400 Bad Request` with the underlying error captured via
+  `tracing::warn!` for operators.
 
 ## [0.9.0](https://github.com/better-auth-rs/better-auth-rs/compare/v0.8.0...v0.9.0) - 2026-03-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,7 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "tracing",
  "tracing-subscriber",
  "url",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "chrono",
  "cookie",
  "glob-match",
+ "http-body-util",
  "jsonwebtoken",
  "rand 0.8.5",
  "redis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,9 @@ sqlx = { workspace = true, optional = true }
 # Cache (optional)
 redis = { workspace = true, optional = true }
 
+# Observability
+tracing = { workspace = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
 serde_yaml = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ syn = { version = "2", features = ["full"] }
 default = ["native-tls"]
 native-tls = ["better-auth-api/native-tls"]
 rustls = ["better-auth-api/rustls"]
-axum = ["dep:axum", "dep:tower", "dep:url"]
+axum = ["dep:axum", "dep:tower", "dep:url", "better-auth-core/axum"]
 derive = ["better-auth-core/derive"]
 sqlx-postgres = ["dep:sqlx", "better-auth-core/sqlx-postgres"]
 redis-cache = ["dep:redis"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -47,6 +47,7 @@ redis = { workspace = true, optional = true }
 # Derive macros (optional)
 better-auth-derive = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
+http-body-util = { version = "0.1", optional = true }
 url = { workspace = true, optional = true }
 tracing.workspace = true
 
@@ -55,4 +56,4 @@ default = []
 derive = ["dep:better-auth-derive"]
 sqlx-postgres = ["dep:sqlx"]
 redis-cache = ["dep:redis"]
-axum = ["dep:axum", "dep:url"]
+axum = ["dep:axum", "dep:http-body-util", "dep:url"]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -597,6 +597,15 @@ impl AuthConfig {
     }
 }
 
+/// Default hard cap for request body reads.
+///
+/// Applied by the root-crate axum entry handler and by
+/// `AuthRequestExt::from_request` when no explicit limit is configured,
+/// so chunked bodies cannot exhaust memory before `BodyLimitMiddleware`
+/// runs. Matches the `BodyLimitConfig::default().max_bytes` value and
+/// upstream TypeScript `better-auth@1.4.19`.
+pub const DEFAULT_MAX_BODY_BYTES: usize = 1024 * 1024;
+
 /// Extract the origin (scheme + host + port) from a URL string.
 ///
 /// For example, `"https://example.com/path"` → `"https://example.com"`.

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -44,6 +44,9 @@ pub enum AuthError {
     RateLimited,
 
     #[error("{0}")]
+    PayloadTooLarge(String),
+
+    #[error("{0}")]
     NotImplemented(String),
 
     #[error("Configuration error: {0}")]
@@ -82,6 +85,8 @@ impl AuthError {
             Self::UserNotFound | Self::NotFound(_) => 404,
             // 409
             Self::Conflict(_) => 409,
+            // 413
+            Self::PayloadTooLarge(_) => 413,
             // 429
             Self::RateLimited => 429,
             // 501
@@ -138,6 +143,10 @@ impl AuthError {
 
     pub fn not_implemented(message: impl Into<String>) -> Self {
         Self::NotImplemented(message.into())
+    }
+
+    pub fn payload_too_large(message: impl Into<String>) -> Self {
+        Self::PayloadTooLarge(message.into())
     }
 
     pub fn plugin(plugin: &str, message: impl Into<String>) -> Self {

--- a/crates/core/src/extractors.rs
+++ b/crates/core/src/extractors.rs
@@ -3,6 +3,24 @@
 //! Provides type-safe request extraction that eliminates boilerplate
 //! in plugin handler functions.
 
+/// Returns `true` when an `axum::Error` from `axum::body::to_bytes` was
+/// caused by the read exceeding the size limit. Used by both the root
+/// axum handler and the `AuthRequestExt` extractor to distinguish 413
+/// Payload Too Large from 400 Bad Request (transport errors, malformed
+/// chunked framing, client disconnect).
+#[cfg(feature = "axum")]
+pub fn is_body_length_limit_error(err: &axum::Error) -> bool {
+    use std::error::Error;
+    let mut source: Option<&(dyn Error + 'static)> = err.source();
+    while let Some(e) = source {
+        if e.is::<http_body_util::LengthLimitError>() {
+            return true;
+        }
+        source = e.source();
+    }
+    false
+}
+
 #[cfg(feature = "axum")]
 mod axum_impl {
     use axum::{
@@ -187,28 +205,38 @@ mod axum_impl {
                 }
             }
 
-            // 1 MiB cap matches the root axum handler (`src/handlers/axum.rs`)
-            // and upstream TS better-auth. If Content-Length declares an
-            // oversize body, reject with 413 before buffering any of it.
-            const MAX_BODY_BYTES: usize = 1024 * 1024;
+            // The body cap in this extractor matches the root axum handler
+            // default (`DEFAULT_MAX_BODY_BYTES`). If `Content-Length`
+            // declares an oversize body, reject with 413 before buffering
+            // any of it. A `LengthLimitError` surfaced by `to_bytes`
+            // during the read also maps to 413; other transport-level
+            // errors (malformed chunked framing, client disconnect) map
+            // to 400.
             if let Some(len) = parts
                 .headers
                 .get(axum::http::header::CONTENT_LENGTH)
                 .and_then(|v| v.to_str().ok())
                 .and_then(|s| s.parse::<usize>().ok())
-                && len > MAX_BODY_BYTES
+                && len > crate::config::DEFAULT_MAX_BODY_BYTES
             {
                 return Err(AuthError::payload_too_large(format!(
                     "Request body exceeds the {}-byte limit",
-                    MAX_BODY_BYTES
+                    crate::config::DEFAULT_MAX_BODY_BYTES
                 )));
             }
 
-            let body_bytes = axum::body::to_bytes(body, MAX_BODY_BYTES)
+            let body_bytes = axum::body::to_bytes(body, crate::config::DEFAULT_MAX_BODY_BYTES)
                 .await
                 .map_err(|e| {
-                    tracing::warn!(error = %e, "Failed to read request body");
-                    AuthError::bad_request("Failed to read request body")
+                    if super::is_body_length_limit_error(&e) {
+                        AuthError::payload_too_large(format!(
+                            "Request body exceeds the {}-byte limit",
+                            crate::config::DEFAULT_MAX_BODY_BYTES
+                        ))
+                    } else {
+                        tracing::warn!(error = %e, "Failed to read request body");
+                        AuthError::bad_request("Failed to read request body")
+                    }
                 })?;
 
             let body_opt = if body_bytes.is_empty() {

--- a/crates/core/src/extractors.rs
+++ b/crates/core/src/extractors.rs
@@ -187,9 +187,29 @@ mod axum_impl {
                 }
             }
 
-            let body_bytes = axum::body::to_bytes(body, usize::MAX)
+            // 1 MiB cap matches the root axum handler (`src/handlers/axum.rs`)
+            // and upstream TS better-auth. If Content-Length declares an
+            // oversize body, reject with 413 before buffering any of it.
+            const MAX_BODY_BYTES: usize = 1024 * 1024;
+            if let Some(len) = parts
+                .headers
+                .get(axum::http::header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.parse::<usize>().ok())
+                && len > MAX_BODY_BYTES
+            {
+                return Err(AuthError::payload_too_large(format!(
+                    "Request body exceeds the {}-byte limit",
+                    MAX_BODY_BYTES
+                )));
+            }
+
+            let body_bytes = axum::body::to_bytes(body, MAX_BODY_BYTES)
                 .await
-                .map_err(|e| AuthError::bad_request(format!("Failed to read body: {}", e)))?;
+                .map_err(|e| {
+                    tracing::warn!(error = %e, "Failed to read request body");
+                    AuthError::bad_request("Failed to read request body")
+                })?;
 
             let body_opt = if body_bytes.is_empty() {
                 None

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -57,8 +57,16 @@ impl<DB: DatabaseAdapter> SessionManager<DB> {
             let now = Utc::now();
 
             if s.expires_at() < now || !s.active() {
-                // Session expired or inactive - delete it
-                self.database.delete_session(token).await?;
+                // Session expired or inactive — best-effort cleanup. A DB
+                // hiccup here shouldn't turn "your session is expired" into
+                // a 500; the row will be caught by the next access or the
+                // periodic `cleanup_expired_sessions` sweep.
+                if let Err(err) = self.database.delete_session(token).await {
+                    tracing::warn!(
+                        error = %err,
+                        "Failed to delete expired session; will be retried later"
+                    );
+                }
                 return Ok(None);
             }
 
@@ -89,11 +97,23 @@ impl<DB: DatabaseAdapter> SessionManager<DB> {
             {
                 Ok(()) => {
                     // Re-read so the returned session reflects the new expiry.
-                    // If the row was concurrently revoked (re-read returns None),
-                    // keep the pre-refresh session rather than pretending the
-                    // caller has no session mid-request.
-                    if let Some(refreshed) = self.database.get_session(token).await? {
-                        session = Some(refreshed);
+                    // Both failure modes fall back to the pre-refresh session:
+                    // a concurrent revoke (re-read returns None) shouldn't log
+                    // the user out mid-request, and a second DB hiccup
+                    // shouldn't turn a successful refresh into a 500.
+                    match self.database.get_session(token).await {
+                        Ok(Some(refreshed)) => session = Some(refreshed),
+                        Ok(None) => {
+                            tracing::warn!(
+                                "Session re-read after refresh returned None (concurrent revoke?); returning pre-refresh value"
+                            );
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                error = %err,
+                                "Session re-read after refresh failed; returning pre-refresh value"
+                            );
+                        }
                     }
                 }
                 Err(err) => {

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -51,39 +51,42 @@ impl<DB: DatabaseAdapter> SessionManager<DB> {
 
     /// Get session by token
     pub async fn get_session(&self, token: &str) -> AuthResult<Option<DB::Session>> {
-        let session = self.database.get_session(token).await?;
+        let mut session = self.database.get_session(token).await?;
 
-        // Check if session exists and is not expired
-        if let Some(ref session) = session {
+        let should_refresh = if let Some(ref s) = session {
             let now = Utc::now();
 
-            if session.expires_at() < now || !session.active() {
+            if s.expires_at() < now || !s.active() {
                 // Session expired or inactive - delete it
                 self.database.delete_session(token).await?;
                 return Ok(None);
             }
 
-            // Update session if configured to do so
             if !self.config.session.disable_session_refresh {
-                let should_refresh = match self.config.session.update_age {
+                match self.config.session.update_age {
                     Some(age) => {
                         // Only refresh if the session was last updated more than
                         // `update_age` ago.
-                        let updated = session.updated_at();
+                        let updated = s.updated_at();
                         Utc::now() - updated >= age
                     }
                     // No update_age set → refresh on every access.
                     None => true,
-                };
-
-                if should_refresh {
-                    let new_expires_at = Utc::now() + self.config.session.expires_in;
-                    let _ = self
-                        .database
-                        .update_session_expiry(token, new_expires_at)
-                        .await;
                 }
+            } else {
+                false
             }
+        } else {
+            false
+        };
+
+        if should_refresh {
+            let new_expires_at = Utc::now() + self.config.session.expires_in;
+            self.database
+                .update_session_expiry(token, new_expires_at)
+                .await?;
+            // Re-read so the returned session reflects the persisted expiry.
+            session = self.database.get_session(token).await?;
         }
 
         Ok(session)
@@ -204,5 +207,101 @@ impl<DB: DatabaseAdapter> SessionManager<DB> {
         }
 
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::{MemoryDatabaseAdapter, SessionOps, UserOps};
+    use crate::config::SessionConfig;
+    use crate::types::{CreateUser, User};
+    use chrono::Duration;
+
+    fn test_config(session: SessionConfig) -> Arc<AuthConfig> {
+        Arc::new(AuthConfig {
+            session,
+            ..AuthConfig::default()
+        })
+    }
+
+    async fn setup() -> (Arc<MemoryDatabaseAdapter>, User) {
+        let db = Arc::new(MemoryDatabaseAdapter::new());
+        let user = db
+            .create_user(CreateUser {
+                email: Some("test@example.com".into()),
+                name: Some("Test User".into()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        (db, user)
+    }
+
+    #[tokio::test]
+    async fn refresh_updates_returned_session_expires_at() {
+        let (db, user) = setup().await;
+        let config = test_config(SessionConfig {
+            expires_in: Duration::hours(1),
+            update_age: None,
+            ..SessionConfig::default()
+        });
+        let mgr = SessionManager::new(config, db.clone());
+
+        let initial = mgr.create_session(&user, None, None).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+        let refreshed = mgr.get_session(initial.token()).await.unwrap().unwrap();
+        assert!(refreshed.expires_at() > initial.expires_at());
+    }
+
+    #[tokio::test]
+    async fn refresh_is_throttled_by_update_age() {
+        let (db, user) = setup().await;
+        let config = test_config(SessionConfig {
+            expires_in: Duration::hours(1),
+            update_age: Some(Duration::hours(1)),
+            ..SessionConfig::default()
+        });
+        let mgr = SessionManager::new(config, db.clone());
+
+        let initial = mgr.create_session(&user, None, None).await.unwrap();
+        let observed = mgr.get_session(initial.token()).await.unwrap().unwrap();
+        assert_eq!(observed.expires_at(), initial.expires_at());
+    }
+
+    #[tokio::test]
+    async fn refresh_skipped_when_disabled() {
+        let (db, user) = setup().await;
+        let config = test_config(SessionConfig {
+            expires_in: Duration::hours(1),
+            update_age: None,
+            disable_session_refresh: true,
+            ..SessionConfig::default()
+        });
+        let mgr = SessionManager::new(config, db.clone());
+
+        let initial = mgr.create_session(&user, None, None).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+        let observed = mgr.get_session(initial.token()).await.unwrap().unwrap();
+        assert_eq!(observed.expires_at(), initial.expires_at());
+    }
+
+    #[tokio::test]
+    async fn expired_session_is_removed_and_returns_none() {
+        let (db, user) = setup().await;
+        let config = test_config(SessionConfig::default());
+        let mgr = SessionManager::new(config, db.clone());
+
+        let created = mgr.create_session(&user, None, None).await.unwrap();
+        db.update_session_expiry(created.token(), Utc::now() - Duration::seconds(1))
+            .await
+            .unwrap();
+
+        let result = mgr.get_session(created.token()).await.unwrap();
+        assert!(result.is_none());
+        let still_there = db.get_session(created.token()).await.unwrap();
+        assert!(still_there.is_none());
     }
 }

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -82,11 +82,31 @@ impl<DB: DatabaseAdapter> SessionManager<DB> {
 
         if should_refresh {
             let new_expires_at = Utc::now() + self.config.session.expires_in;
-            self.database
+            match self
+                .database
                 .update_session_expiry(token, new_expires_at)
-                .await?;
-            // Re-read so the returned session reflects the persisted expiry.
-            session = self.database.get_session(token).await?;
+                .await
+            {
+                Ok(()) => {
+                    // Re-read so the returned session reflects the new expiry.
+                    // If the row was concurrently revoked (re-read returns None),
+                    // keep the pre-refresh session rather than pretending the
+                    // caller has no session mid-request.
+                    if let Some(refreshed) = self.database.get_session(token).await? {
+                        session = Some(refreshed);
+                    }
+                }
+                Err(err) => {
+                    // Transient write failure (connection reset, contention,
+                    // etc.) must not fail the whole request. Keep the
+                    // pre-refresh session — auth still works, the refresh
+                    // window will be retried on the next call.
+                    tracing::warn!(
+                        error = %err,
+                        "Failed to refresh session expiry; returning pre-refresh session"
+                    );
+                }
+            }
         }
 
         Ok(session)

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -28,6 +28,11 @@ pub struct BetterAuth<DB: DatabaseAdapter> {
     database: Arc<DB>,
     session_manager: SessionManager<DB>,
     context: AuthContext<DB>,
+    /// Kept on the built instance so the axum entry handler can bound
+    /// `to_bytes` at the caller-configured limit instead of a hard-coded
+    /// 1 MiB (which would otherwise override the user's
+    /// `AuthBuilder::body_limit(...)` choice).
+    body_limit_config: BodyLimitConfig,
 }
 
 /// Initial builder for configuring BetterAuth.
@@ -196,10 +201,9 @@ impl<DB: DatabaseAdapter> TypedAuthBuilder<DB> {
         }
 
         // Build middleware chain (order matters: body limit → rate limit → CSRF → CORS → custom)
+        let body_limit_config = self.body_limit_config.unwrap_or_default();
         let mut middlewares: Vec<Box<dyn Middleware>> = vec![
-            Box::new(BodyLimitMiddleware::new(
-                self.body_limit_config.unwrap_or_default(),
-            )),
+            Box::new(BodyLimitMiddleware::new(body_limit_config.clone())),
             Box::new(RateLimitMiddleware::new(
                 self.rate_limit_config.unwrap_or_default(),
             )),
@@ -219,6 +223,7 @@ impl<DB: DatabaseAdapter> TypedAuthBuilder<DB> {
             database,
             session_manager,
             context,
+            body_limit_config,
         })
     }
 }
@@ -329,6 +334,14 @@ impl<DB: DatabaseAdapter> BetterAuth<DB> {
     /// Get the configuration.
     pub fn config(&self) -> &AuthConfig {
         &self.config
+    }
+
+    /// Get the body-limit configuration; the axum entry handler uses
+    /// this to cap `to_bytes` at the same ceiling the user configured on
+    /// `AuthBuilder::body_limit`, rather than overriding it with a
+    /// hard-coded value.
+    pub fn body_limit_config(&self) -> &BodyLimitConfig {
+        &self.body_limit_config
     }
 
     /// Get the database adapter.

--- a/src/handlers/axum.rs
+++ b/src/handlers/axum.rs
@@ -198,8 +198,12 @@ async fn convert_axum_request(req: Request) -> Result<AuthRequest, AuthError> {
         }
     }
 
-    // Convert body
-    let body_bytes = match axum::body::to_bytes(body, usize::MAX).await {
+    // Convert body. Bound the read size to avoid memory exhaustion via a
+    // malicious client sending an unbounded chunked body. 1 MiB matches the
+    // upstream TS Better Auth default and comfortably covers OAuth/JWT
+    // payloads plus reasonable user metadata.
+    const MAX_BODY_BYTES: usize = 1024 * 1024;
+    let body_bytes = match axum::body::to_bytes(body, MAX_BODY_BYTES).await {
         Ok(bytes) => {
             if bytes.is_empty() {
                 None

--- a/src/handlers/axum.rs
+++ b/src/handlers/axum.rs
@@ -201,7 +201,10 @@ async fn convert_axum_request(req: Request) -> Result<AuthRequest, AuthError> {
     // Convert body. Bound the read size to avoid memory exhaustion via a
     // malicious client sending an unbounded chunked body. 1 MiB matches the
     // upstream TS Better Auth default and comfortably covers OAuth/JWT
-    // payloads plus reasonable user metadata.
+    // payloads plus reasonable user metadata. When the cap is hit,
+    // `axum::body::to_bytes` returns an error — surface it as 413 rather
+    // than silently truncating to an empty body (which would then be
+    // reported downstream as a misleading "invalid JSON" 400).
     const MAX_BODY_BYTES: usize = 1024 * 1024;
     let body_bytes = match axum::body::to_bytes(body, MAX_BODY_BYTES).await {
         Ok(bytes) => {
@@ -211,7 +214,12 @@ async fn convert_axum_request(req: Request) -> Result<AuthRequest, AuthError> {
                 Some(bytes.to_vec())
             }
         }
-        Err(_) => None,
+        Err(err) => {
+            return Err(AuthError::payload_too_large(format!(
+                "Request body exceeds the {}-byte limit: {err}",
+                MAX_BODY_BYTES
+            )));
+        }
     };
 
     Ok(AuthRequest::from_parts(

--- a/src/handlers/axum.rs
+++ b/src/handlers/axum.rs
@@ -146,7 +146,17 @@ fn create_plugin_handler<DB: DatabaseAdapter>() -> impl Fn(
 > + Clone {
     |State(auth): State<Arc<BetterAuth<DB>>>, req: Request| {
         Box::pin(async move {
-            let max_bytes = auth.body_limit_config().max_bytes;
+            // `enabled = false` on the configured body limit means the
+            // caller has opted out of body-size enforcement entirely —
+            // honour that by using `usize::MAX`, the same posture the
+            // handler had before the 1 MiB cap was introduced. When
+            // enabled, use the configured ceiling.
+            let limit_cfg = auth.body_limit_config();
+            let max_bytes = if limit_cfg.enabled {
+                limit_cfg.max_bytes
+            } else {
+                usize::MAX
+            };
             match convert_axum_request(req, max_bytes).await {
                 Ok(auth_req) => match auth.handle_request(auth_req).await {
                     Ok(auth_response) => convert_auth_response(auth_response),

--- a/src/handlers/axum.rs
+++ b/src/handlers/axum.rs
@@ -146,7 +146,8 @@ fn create_plugin_handler<DB: DatabaseAdapter>() -> impl Fn(
 > + Clone {
     |State(auth): State<Arc<BetterAuth<DB>>>, req: Request| {
         Box::pin(async move {
-            match convert_axum_request(req).await {
+            let max_bytes = auth.body_limit_config().max_bytes;
+            match convert_axum_request(req, max_bytes).await {
                 Ok(auth_req) => match auth.handle_request(auth_req).await {
                     Ok(auth_response) => convert_auth_response(auth_response),
                     Err(err) => convert_auth_error(err),
@@ -158,7 +159,10 @@ fn create_plugin_handler<DB: DatabaseAdapter>() -> impl Fn(
 }
 
 #[cfg(feature = "axum")]
-async fn convert_axum_request(req: Request) -> Result<AuthRequest, AuthError> {
+async fn convert_axum_request(
+    req: Request,
+    max_body_bytes: usize,
+) -> Result<AuthRequest, AuthError> {
     use std::collections::HashMap;
 
     let (parts, body) = req.into_parts();
@@ -198,30 +202,31 @@ async fn convert_axum_request(req: Request) -> Result<AuthRequest, AuthError> {
         }
     }
 
-    // Bound the body read at 1 MiB to avoid memory exhaustion via a
-    // malicious client sending an unbounded chunked body. Matches upstream
-    // TS better-auth and the `AuthRequestExt` extractor in
-    // `crates/core/src/extractors.rs`.
+    // Bound the body read at the caller-configured limit
+    // (`AuthBuilder::body_limit(...)`; defaults to
+    // `DEFAULT_MAX_BODY_BYTES` = 1 MiB). `BodyLimitMiddleware` only
+    // inspects `Content-Length` and cannot cover chunked bodies, so
+    // this pre-parse cap is the only line of defence against
+    // memory-exhaustion DoS via `Transfer-Encoding: chunked`.
     //
     // Two paths:
     // - Content-Length declared > limit → 413 before reading anything.
-    // - `to_bytes` error during the read → 400 rather than 413, because
-    //   the error may be malformed chunked framing, disconnect, etc.;
-    //   conflating those with oversize lies to monitoring.
-    const MAX_BODY_BYTES: usize = 1024 * 1024;
+    // - `to_bytes` error during the read → 413 if the error is a
+    //   `LengthLimitError` (chunked body exceeded the cap), otherwise
+    //   400 (malformed chunked framing, client disconnect, etc.).
     if let Some(len) = parts
         .headers
         .get(axum::http::header::CONTENT_LENGTH)
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.parse::<usize>().ok())
-        && len > MAX_BODY_BYTES
+        && len > max_body_bytes
     {
         return Err(AuthError::payload_too_large(format!(
             "Request body exceeds the {}-byte limit",
-            MAX_BODY_BYTES
+            max_body_bytes
         )));
     }
-    let body_bytes = match axum::body::to_bytes(body, MAX_BODY_BYTES).await {
+    let body_bytes = match axum::body::to_bytes(body, max_body_bytes).await {
         Ok(bytes) => {
             if bytes.is_empty() {
                 None
@@ -230,6 +235,12 @@ async fn convert_axum_request(req: Request) -> Result<AuthRequest, AuthError> {
             }
         }
         Err(err) => {
+            if better_auth_core::extractors::is_body_length_limit_error(&err) {
+                return Err(AuthError::payload_too_large(format!(
+                    "Request body exceeds the {}-byte limit",
+                    max_body_bytes
+                )));
+            }
             tracing::warn!(error = %err, "Failed to read request body");
             return Err(AuthError::bad_request("Failed to read request body"));
         }

--- a/src/handlers/axum.rs
+++ b/src/handlers/axum.rs
@@ -198,14 +198,29 @@ async fn convert_axum_request(req: Request) -> Result<AuthRequest, AuthError> {
         }
     }
 
-    // Convert body. Bound the read size to avoid memory exhaustion via a
-    // malicious client sending an unbounded chunked body. 1 MiB matches the
-    // upstream TS Better Auth default and comfortably covers OAuth/JWT
-    // payloads plus reasonable user metadata. When the cap is hit,
-    // `axum::body::to_bytes` returns an error — surface it as 413 rather
-    // than silently truncating to an empty body (which would then be
-    // reported downstream as a misleading "invalid JSON" 400).
+    // Bound the body read at 1 MiB to avoid memory exhaustion via a
+    // malicious client sending an unbounded chunked body. Matches upstream
+    // TS better-auth and the `AuthRequestExt` extractor in
+    // `crates/core/src/extractors.rs`.
+    //
+    // Two paths:
+    // - Content-Length declared > limit → 413 before reading anything.
+    // - `to_bytes` error during the read → 400 rather than 413, because
+    //   the error may be malformed chunked framing, disconnect, etc.;
+    //   conflating those with oversize lies to monitoring.
     const MAX_BODY_BYTES: usize = 1024 * 1024;
+    if let Some(len) = parts
+        .headers
+        .get(axum::http::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<usize>().ok())
+        && len > MAX_BODY_BYTES
+    {
+        return Err(AuthError::payload_too_large(format!(
+            "Request body exceeds the {}-byte limit",
+            MAX_BODY_BYTES
+        )));
+    }
     let body_bytes = match axum::body::to_bytes(body, MAX_BODY_BYTES).await {
         Ok(bytes) => {
             if bytes.is_empty() {
@@ -215,10 +230,8 @@ async fn convert_axum_request(req: Request) -> Result<AuthRequest, AuthError> {
             }
         }
         Err(err) => {
-            return Err(AuthError::payload_too_large(format!(
-                "Request body exceeds the {}-byte limit: {err}",
-                MAX_BODY_BYTES
-            )));
+            tracing::warn!(error = %err, "Failed to read request body");
+            return Err(AuthError::bad_request("Failed to read request body"));
         }
     };
 


### PR DESCRIPTION
## Summary

Two small, independent fixes that predate PR #56. Extracted so master can receive them without waiting on the schema-native refactor.

- `SessionManager::get_session` (`crates/core/src/session.rs`) swallowed errors from `update_session_expiry` with `let _ = ...` and returned the pre-refresh session object, so callers observed a stale `expires_at` and real DB failures were invisible. Propagate the error via `?` and re-read the session after a successful write.
- `axum::body::to_bytes(body, usize::MAX)` (`src/handlers/axum.rs`) allowed any client to exhaust memory via an unbounded chunked body. `BodyLimitMiddleware` only inspects `Content-Length` and cannot cover chunked. Cap at 1 MiB, matching the upstream TS `better-auth` default.

## Commits

- `889d52b` `fix(core): propagate DB errors and refresh expires_at on session access`
- `d69dbe3` `fix(axum): bound request body reads to 1 MiB`

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace --lib`
- [x] `cargo test --workspace --tests`
- [x] New unit coverage in `crates/core/src/session.rs`:
  - `refresh_updates_returned_session_expires_at`
  - `refresh_is_throttled_by_update_age`
  - `refresh_skipped_when_disabled`
  - `expired_session_is_removed_and_returns_none`

## Notes

These issues are reachable on master today. Related to PR #56 Codex/AprilNEA reviews but deliberately implemented without the PR #56 abstractions (`wire::*`, `AuthSchema`) so they can land independently.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships two independent bug fixes: `SessionManager::get_session` now propagates DB write failures from session refresh (previously silently discarded with `let _ = …`), re-reads the session after a successful update so callers see the persisted `expires_at`, and falls back to the pre-refresh session with a `tracing::warn!` on transient failures; the axum entry handler's `to_bytes` call is now bounded by the user-configured `BodyLimitConfig` (defaulting to `DEFAULT_MAX_BODY_BYTES` = 1 MiB), `LengthLimitError` from chunked bodies is correctly mapped to 413 rather than 400, and a `Content-Length` pre-check avoids buffering oversized bodies.

- **`crates/core/src/session.rs`** — `get_session` now handles refresh write errors gracefully, re-reads on success, and adds four new unit tests covering the fixed scenarios.
- **`src/handlers/axum.rs`** — reads `auth.body_limit_config()` to determine the ceiling; honours `enabled = false` by falling back to `usize::MAX`; distinguishes `LengthLimitError` (413) from transport errors (400).
- **`crates/core/src/extractors.rs`** — new `is_body_length_limit_error` helper walks the error source chain; `AuthRequestExt` gains the same Content-Length pre-check and `to_bytes` cap as the main handler (at `DEFAULT_MAX_BODY_BYTES`).
- **`crates/core/src/config.rs`** — introduces `DEFAULT_MAX_BODY_BYTES = 1024 * 1024` as a single authoritative constant.
- **`src/core/auth.rs`** — `BetterAuth` stores and exposes `body_limit_config` so the axum handler can honour the user's choice.
- **`crates/core/Cargo.toml`** — gates `http-body-util` behind the `axum` feature for `LengthLimitError` detection.

<h3>Confidence Score: 4/5</h3>

Safe to merge; both core fixes are correct and prior review concerns (413 status, constant duplication) are fully addressed.

The two primary fixes (session refresh error propagation and axum body-read bounding) are well-implemented with appropriate fallback/warning behaviour and new unit test coverage. Previous thread concerns about the 413 vs 400 distinction and duplicated constants have been resolved. Three P2 style items remain: `ValidatedJson` has no body cap, `AuthRequestExt` ignores a user-configured body limit, and `revoke_session` needlessly triggers a refresh+re-read before deletion. None of these block correctness on the happy path.

crates/core/src/extractors.rs — `ValidatedJson` body-cap gap and `AuthRequestExt` configured-limit inconsistency.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/core/src/session.rs | Session refresh now propagates errors correctly and re-reads after success; `revoke_session` incurs an unnecessary DB refresh-then-re-read before deletion because it delegates existence check to `get_session`. |
| src/handlers/axum.rs | Correctly honours configured `BodyLimitConfig` (including `enabled=false`), applies Content-Length pre-check, and maps `LengthLimitError` to 413. |
| crates/core/src/extractors.rs | Adds `is_body_length_limit_error` and body-capping to `AuthRequestExt`; `ValidatedJson` delegates to `axum::Json` without a body cap, creating a gap for chunked-body DoS on that path; `AuthRequestExt` always uses `DEFAULT_MAX_BODY_BYTES` and doesn't honour a custom `BodyLimitConfig`. |
| crates/core/src/config.rs | Introduces `DEFAULT_MAX_BODY_BYTES = 1024 * 1024` as the single authoritative constant, referenced by extractors.rs; `BodyLimitConfig::default()` still hardcodes `1_048_576` independently but values match. |
| src/core/auth.rs | Stores `body_limit_config` on `BetterAuth` and exposes it via a getter; axum handler now reads from this instead of a hard-coded value. |
| crates/core/Cargo.toml | Correctly gates `http-body-util` behind the `axum` feature flag for `LengthLimitError` detection. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/core/src/extractors.rs`, line 130-133 ([link](https://github.com/better-auth-rs/better-auth-rs/blob/5975bcc9a7352208a34aabf69f38f04101127e76/crates/core/src/extractors.rs#L130-L133)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`ValidatedJson` bypasses the 1 MiB body cap**

   `ValidatedJson::from_request` delegates body reading to axum's built-in `Json::from_request`, which internally uses `axum::body::to_bytes(body, usize::MAX)` (or respects `DefaultBodyLimit` middleware if applied, default 2 MiB in axum 0.7+, but not guaranteed to be set). The explicit 1 MiB cap applied in `AuthRequestExt` (line 207) and `convert_axum_request` (line 224) does not cover this path.

   A plugin handler using `ValidatedJson<T>` directly is therefore not bounded by the same limit as the rest of the auth stack. Consider applying the same explicit cap before delegating to `Json::from_request`:

   ```rust
   async fn from_request(req: Request, _state: &S) -> Result<Self, Self::Rejection> {
       use axum::body;
       const MAX_BODY_BYTES: usize = 1024 * 1024;
       let (parts, body_raw) = req.into_parts();
       let bytes = body::to_bytes(body_raw, MAX_BODY_BYTES)
           .await
           .map_err(|e| AuthError::bad_request(format!("Failed to read body: {}", e)))?;
       let req = Request::from_parts(parts, body::Body::from(bytes));
       let Json(value) = Json::<T>::from_request(req, _state)
           .await
           .map_err(|e| AuthError::bad_request(format!("Invalid JSON: {}", e)))?;
       // ... validate ...
   }
   ```
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(axum): forward axum feature to core ..."](https://github.com/better-auth-rs/better-auth-rs/commit/3ab0ec21bf3316e78759f5c936d6c338474c0487) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28126668)</sub>

<!-- /greptile_comment -->