### PR TITLE
fix(security): enforce trusted-origin policy on callback URLs and stop serializing Account.password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,20 +47,25 @@ All notable changes to this project will be documented in this file.
 - `POST /sign-in/social`, `POST /link-social`, `POST /sign-in/email`,
   `POST /sign-up/email`, `POST /change-email`, and
   `POST /send-verification-email` now return `400 Bad Request` when
-  `callbackURL` is set to an origin that is not listed in
-  `trusted_origins` and is not same-origin with `base_url`. This is
-  stricter than upstream TypeScript `better-auth@1.4.19` for the OAuth
-  flows. Deployments that rely on cross-origin callbacks must add the
-  callback origin to `AuthConfig::trusted_origins` or set
+  `callbackURL` is not an absolute http(s) URL on a trusted origin
+  (same-origin with `base_url` or matching a `trusted_origins`
+  pattern). Absolute is required because the callback is either
+  forwarded to an OAuth provider as `redirect_uri` (the OAuth spec
+  mandates absolute URIs) or embedded in an outgoing email `href`
+  (mail clients have no base URL to resolve against). This is
+  stricter than upstream TypeScript `better-auth@1.4.19` for the
+  OAuth flows; deployments that rely on cross-origin callbacks must
+  add the callback origin to `AuthConfig::trusted_origins` or set
   `advanced.disable_origin_check = true`.
-- `POST /forget-password`, `GET /verify-email`, and
-  `GET /reset-password/:token` silently ignore an untrusted
-  `callbackURL` / `redirectTo` and fall back to a server-side URL
-  (`/forget-password` builds the reset email against `base_url`; the
-  GET endpoints fall through to their JSON responses). These endpoints
-  are reached via email-link clicks and/or sign-in enumeration-safety
-  paths — a hard 400 would either strand users or reveal email
-  existence, so we log a `tracing::warn!` and accept the request.
+- `POST /forget-password` applies the same absolute-URL requirement to
+  `redirectTo`; untrusted or relative values fall back to the server
+  base URL to preserve the enumeration-safety invariant.
+- `GET /verify-email` and `GET /reset-password/:token` silently ignore
+  an untrusted `callbackURL` and fall through to their JSON responses
+  (these endpoints are reached via email-link clicks — a hard 400
+  would strand users who already consumed a one-shot token). Relative
+  paths are still accepted here because the server issues the
+  redirect directly.
 
 ## [0.9.0](https://github.com/better-auth-rs/better-auth-rs/compare/v0.8.0...v0.9.0) - 2026-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+
+- `AuthConfig::is_redirect_target_trusted` now validates every user-supplied
+  `callbackURL` / `redirectTo` used in a server-issued 302 `Location` header
+  or an outgoing email link. Protocol-relative (`//evil.com`) and browser
+  backslash-normalised forms (`/\evil.com`) are rejected even when
+  `advanced.disable_origin_check` is enabled.
+- `extract_origin` now uses the WHATWG URL parser; this fixes the
+  previous hand-rolled version that kept query strings, fragments, and
+  userinfo in the returned origin (so `app.example.com@evil.com` could
+  masquerade as an app-origin URL).
+- `Account.password` (bcrypt/argon2 hash) is no longer serialized by
+  serde. Deserialization is unchanged.
+
 ### Fixed
 
 - `SessionManager::get_session` previously discarded
@@ -27,6 +41,22 @@ All notable changes to this project will be documented in this file.
   failures (malformed chunked framing, client disconnect) return
   `400 Bad Request` with the underlying error captured via
   `tracing::warn!` for operators.
+
+### Behavior change (breaking for some deployments)
+
+- `POST /sign-in/social`, `POST /link-social`, `POST /sign-in/email`,
+  `POST /sign-up/email`, `POST /change-email`, `POST /send-verification-email`,
+  and `POST /forget-password` now return `400 Bad Request` when
+  `callbackURL` / `redirectTo` is set to an origin that is not listed in
+  `trusted_origins` and is not same-origin with `base_url`. This is
+  stricter than upstream TypeScript `better-auth@1.4.19` for the OAuth
+  flows. Deployments that rely on cross-origin callbacks must add the
+  callback origin to `AuthConfig::trusted_origins` or set
+  `advanced.disable_origin_check = true`.
+- `GET /verify-email` and `GET /reset-password/:token` silently ignore
+  an untrusted callback and fall through to their JSON responses (these
+  endpoints are reached by email-link clicks, so a hard 400 would strand
+  users who have already consumed a one-shot token).
 
 ## [0.9.0](https://github.com/better-auth-rs/better-auth-rs/compare/v0.8.0...v0.9.0) - 2026-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,18 +45,22 @@ All notable changes to this project will be documented in this file.
 ### Behavior change (breaking for some deployments)
 
 - `POST /sign-in/social`, `POST /link-social`, `POST /sign-in/email`,
-  `POST /sign-up/email`, `POST /change-email`, `POST /send-verification-email`,
-  and `POST /forget-password` now return `400 Bad Request` when
-  `callbackURL` / `redirectTo` is set to an origin that is not listed in
+  `POST /sign-up/email`, `POST /change-email`, and
+  `POST /send-verification-email` now return `400 Bad Request` when
+  `callbackURL` is set to an origin that is not listed in
   `trusted_origins` and is not same-origin with `base_url`. This is
   stricter than upstream TypeScript `better-auth@1.4.19` for the OAuth
   flows. Deployments that rely on cross-origin callbacks must add the
   callback origin to `AuthConfig::trusted_origins` or set
   `advanced.disable_origin_check = true`.
-- `GET /verify-email` and `GET /reset-password/:token` silently ignore
-  an untrusted callback and fall through to their JSON responses (these
-  endpoints are reached by email-link clicks, so a hard 400 would strand
-  users who have already consumed a one-shot token).
+- `POST /forget-password`, `GET /verify-email`, and
+  `GET /reset-password/:token` silently ignore an untrusted
+  `callbackURL` / `redirectTo` and fall back to a server-side URL
+  (`/forget-password` builds the reset email against `base_url`; the
+  GET endpoints fall through to their JSON responses). These endpoints
+  are reached via email-link clicks and/or sign-in enumeration-safety
+  paths — a hard 400 would either strand users or reveal email
+  existence, so we log a `tracing::warn!` and accept the request.
 
 ## [0.9.0](https://github.com/better-auth-rs/better-auth-rs/compare/v0.8.0...v0.9.0) - 2026-03-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,7 @@ dependencies = [
  "cookie",
  "glob-match",
  "http-body-util",
+ "idna",
  "jsonwebtoken",
  "rand 0.8.5",
  "redis",

--- a/crates/api/src/plugins/email_password.rs
+++ b/crates/api/src/plugins/email_password.rs
@@ -840,7 +840,10 @@ mod tests {
             "Password123!",
             "https://evil.example.com/cb",
         );
-        let err_existing = plugin.handle_sign_in(&bad_for_existing, &ctx).await.unwrap_err();
+        let err_existing = plugin
+            .handle_sign_in(&bad_for_existing, &ctx)
+            .await
+            .unwrap_err();
         assert_eq!(err_existing.status_code(), 400);
 
         let bad_for_missing = create_signin_request_with_callback(
@@ -848,7 +851,10 @@ mod tests {
             "Password123!",
             "https://evil.example.com/cb",
         );
-        let err_missing = plugin.handle_sign_in(&bad_for_missing, &ctx).await.unwrap_err();
+        let err_missing = plugin
+            .handle_sign_in(&bad_for_missing, &ctx)
+            .await
+            .unwrap_err();
         assert_eq!(err_missing.status_code(), 400);
         assert_eq!(err_existing.to_string(), err_missing.to_string());
     }

--- a/crates/api/src/plugins/email_password.rs
+++ b/crates/api/src/plugins/email_password.rs
@@ -272,13 +272,14 @@ pub(crate) async fn sign_up_core<DB: DatabaseAdapter>(
 
     // Validate callbackURL even though sign-up does not currently use it:
     // the request type accepts the field, so we must not let a caller
-    // think an untrusted value was accepted. Keeps the security contract
-    // stable if we ever wire sign-up into send_verification_email.
+    // think an untrusted value was accepted. Require an absolute URL so
+    // the contract matches `send_verification_email` / `/sign-in/email`
+    // when sign-up eventually wires this through.
     if let Some(ref url) = body.callback_url
-        && !ctx.config.is_redirect_target_trusted(url)
+        && !ctx.config.is_absolute_trusted_callback_url(url)
     {
         return Err(AuthError::bad_request(
-            "callbackURL is not a trusted origin",
+            "callbackURL must be an absolute http(s) URL on a trusted origin",
         ));
     }
 
@@ -347,15 +348,16 @@ async fn sign_in_with_user_core<DB: DatabaseAdapter>(
     callback_url: Option<&str>,
     ctx: &AuthContext<DB>,
 ) -> AuthResult<SignInCoreResult<DB::User>> {
-    // If the caller supplied a callbackURL it may end up embedded in a
-    // verification email (via `send_verification_on_sign_in`). Reject
-    // untrusted targets before doing any DB work or emitting mail — the
-    // same policy as `/send-verification-email` and `/change-email`.
+    // Defence in depth: `sign_in_core` already validated the callback,
+    // but helper functions called directly (`sign_in_username_core`
+    // passes `None`) must still honour the same contract. Require an
+    // absolute http(s) URL on a trusted origin so any future caller
+    // that plumbs a raw request value through can't regress.
     if let Some(url) = callback_url
-        && !ctx.config.is_redirect_target_trusted(url)
+        && !ctx.config.is_absolute_trusted_callback_url(url)
     {
         return Err(AuthError::bad_request(
-            "callbackURL is not a trusted origin",
+            "callbackURL must be an absolute http(s) URL on a trusted origin",
         ));
     }
 
@@ -420,12 +422,14 @@ pub(crate) async fn sign_in_core<DB: DatabaseAdapter>(
     // Validate callbackURL BEFORE the user lookup so that "unknown user"
     // and "untrusted callback" return the same 400 regardless of whether
     // the email exists — prevents the enumeration oracle that would
-    // otherwise differ 401 vs 400.
+    // otherwise differ 401 vs 400. The callback ends up in a
+    // verification-email `href` when the user is unverified, so require
+    // an absolute URL.
     if let Some(ref url) = body.callback_url
-        && !ctx.config.is_redirect_target_trusted(url)
+        && !ctx.config.is_absolute_trusted_callback_url(url)
     {
         return Err(AuthError::bad_request(
-            "callbackURL is not a trusted origin",
+            "callbackURL must be an absolute http(s) URL on a trusted origin",
         ));
     }
 

--- a/crates/api/src/plugins/email_password.rs
+++ b/crates/api/src/plugins/email_password.rs
@@ -270,6 +270,18 @@ pub(crate) async fn sign_up_core<DB: DatabaseAdapter>(
         return Err(AuthError::forbidden("User registration is not enabled"));
     }
 
+    // Validate callbackURL even though sign-up does not currently use it:
+    // the request type accepts the field, so we must not let a caller
+    // think an untrusted value was accepted. Keeps the security contract
+    // stable if we ever wire sign-up into send_verification_email.
+    if let Some(ref url) = body.callback_url
+        && !ctx.config.is_redirect_target_trusted(url)
+    {
+        return Err(AuthError::bad_request(
+            "callbackURL is not a trusted origin",
+        ));
+    }
+
     password_utils::validate_password(
         &body.password,
         config.password_min_length,
@@ -335,6 +347,18 @@ async fn sign_in_with_user_core<DB: DatabaseAdapter>(
     callback_url: Option<&str>,
     ctx: &AuthContext<DB>,
 ) -> AuthResult<SignInCoreResult<DB::User>> {
+    // If the caller supplied a callbackURL it may end up embedded in a
+    // verification email (via `send_verification_on_sign_in`). Reject
+    // untrusted targets before doing any DB work or emitting mail — the
+    // same policy as `/send-verification-email` and `/change-email`.
+    if let Some(url) = callback_url
+        && !ctx.config.is_redirect_target_trusted(url)
+    {
+        return Err(AuthError::bad_request(
+            "callbackURL is not a trusted origin",
+        ));
+    }
+
     // Verify password
     let stored_hash = user.password_hash().ok_or(AuthError::InvalidCredentials)?;
 

--- a/crates/api/src/plugins/email_password.rs
+++ b/crates/api/src/plugins/email_password.rs
@@ -417,6 +417,18 @@ pub(crate) async fn sign_in_core<DB: DatabaseAdapter>(
     email_verification: Option<&EmailVerificationPlugin>,
     ctx: &AuthContext<DB>,
 ) -> AuthResult<SignInCoreResult<DB::User>> {
+    // Validate callbackURL BEFORE the user lookup so that "unknown user"
+    // and "untrusted callback" return the same 400 regardless of whether
+    // the email exists — prevents the enumeration oracle that would
+    // otherwise differ 401 vs 400.
+    if let Some(ref url) = body.callback_url
+        && !ctx.config.is_redirect_target_trusted(url)
+    {
+        return Err(AuthError::bad_request(
+            "callbackURL is not a trusted origin",
+        ));
+    }
+
     let user = ctx
         .database
         .get_user_by_email(&body.email)
@@ -791,5 +803,76 @@ mod tests {
         );
         let err = plugin.handle_sign_in(&bad_req, &ctx).await.unwrap_err();
         assert_eq!(err.to_string(), AuthError::InvalidCredentials.to_string());
+    }
+
+    fn create_signin_request_with_callback(
+        email: &str,
+        password: &str,
+        callback_url: &str,
+    ) -> AuthRequest {
+        let body = serde_json::json!({
+            "email": email,
+            "password": password,
+            "callbackURL": callback_url,
+        });
+        AuthRequest::from_parts(
+            HttpMethod::Post,
+            "/sign-in/email".to_string(),
+            HashMap::new(),
+            Some(body.to_string().into_bytes()),
+            HashMap::new(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_sign_in_rejects_untrusted_callback_url_without_email_oracle() {
+        // callback URL is rejected for both existing and non-existing users,
+        // proving the check lives before the user lookup and does not create
+        // an enumeration oracle.
+        let plugin = EmailPasswordPlugin::new();
+        let ctx = create_test_context();
+
+        let signup_req = create_signup_request("sign-in-cb@test.com", "Password123!");
+        plugin.handle_sign_up(&signup_req, &ctx).await.unwrap();
+
+        let bad_for_existing = create_signin_request_with_callback(
+            "sign-in-cb@test.com",
+            "Password123!",
+            "https://evil.example.com/cb",
+        );
+        let err_existing = plugin.handle_sign_in(&bad_for_existing, &ctx).await.unwrap_err();
+        assert_eq!(err_existing.status_code(), 400);
+
+        let bad_for_missing = create_signin_request_with_callback(
+            "does-not-exist@test.com",
+            "Password123!",
+            "https://evil.example.com/cb",
+        );
+        let err_missing = plugin.handle_sign_in(&bad_for_missing, &ctx).await.unwrap_err();
+        assert_eq!(err_missing.status_code(), 400);
+        assert_eq!(err_existing.to_string(), err_missing.to_string());
+    }
+
+    #[tokio::test]
+    async fn test_sign_up_rejects_untrusted_callback_url() {
+        let plugin = EmailPasswordPlugin::new();
+        let ctx = create_test_context();
+
+        let body = serde_json::json!({
+            "name": "Sign Up CB",
+            "email": "signup-cb@test.com",
+            "password": "Password123!",
+            "callbackURL": "https://evil.example.com/cb",
+        });
+        let req = AuthRequest::from_parts(
+            HttpMethod::Post,
+            "/sign-up/email".to_string(),
+            HashMap::new(),
+            Some(body.to_string().into_bytes()),
+            HashMap::new(),
+        );
+
+        let err = plugin.handle_sign_up(&req, &ctx).await.unwrap_err();
+        assert_eq!(err.status_code(), 400);
     }
 }

--- a/crates/api/src/plugins/email_verification/handlers.rs
+++ b/crates/api/src/plugins/email_verification/handlers.rs
@@ -36,6 +36,14 @@ pub(super) async fn send_verification_email_core<DB: DatabaseAdapter>(
         expires_at,
     };
 
+    if let Some(ref callback_url) = body.callback_url
+        && !ctx.config.is_redirect_target_trusted(callback_url)
+    {
+        return Err(AuthError::bad_request(
+            "callbackURL is not a trusted origin",
+        ));
+    }
+
     ctx.database
         .create_verification(create_verification)
         .await?;
@@ -143,13 +151,21 @@ pub(super) async fn verify_email_core<DB: DatabaseAdapter>(
         None
     };
 
-    // If callback URL is provided, redirect
+    // If callback URL is provided and trusted, redirect. Untrusted callbacks
+    // fall through to the JSON branch to avoid reflecting an attacker-chosen
+    // origin into a server-issued Location header (open redirect).
     if let Some(ref callback_url) = query.callback_url {
-        let redirect_url = format!("{}?verified=true", callback_url);
-        return Ok(VerifyEmailResult::Redirect {
-            url: redirect_url,
-            session_token: session_info.map(|(_, t)| t),
-        });
+        if ctx.config.is_redirect_target_trusted(callback_url) {
+            let redirect_url = format!("{}?verified=true", callback_url);
+            return Ok(VerifyEmailResult::Redirect {
+                url: redirect_url,
+                session_token: session_info.map(|(_, t)| t),
+            });
+        }
+        tracing::warn!(
+            callback_url = %callback_url,
+            "Ignoring untrusted callbackURL on /verify-email"
+        );
     }
 
     // Return JSON

--- a/crates/api/src/plugins/email_verification/handlers.rs
+++ b/crates/api/src/plugins/email_verification/handlers.rs
@@ -14,14 +14,18 @@ pub(super) async fn send_verification_email_core<DB: DatabaseAdapter>(
     config: &EmailVerificationConfig,
     ctx: &AuthContext<DB>,
 ) -> AuthResult<StatusResponse> {
-    // Validate callbackURL before any DB work or user enumeration: keeps
+    // Validate callbackURL before any DB work or user enumeration. Keeps
     // the response uniform across unknown/verified/valid emails when the
     // supplied callback is untrusted, and avoids wasted writes.
+    //
+    // The callback is embedded in the outgoing email `href`, so require
+    // an absolute http(s) URL — a relative path can't be resolved by
+    // a mail client and would produce a dead link.
     if let Some(ref callback_url) = body.callback_url
-        && !ctx.config.is_redirect_target_trusted(callback_url)
+        && !ctx.config.is_absolute_trusted_callback_url(callback_url)
     {
         return Err(AuthError::bad_request(
-            "callbackURL is not a trusted origin",
+            "callbackURL must be an absolute http(s) URL on a trusted origin",
         ));
     }
 

--- a/crates/api/src/plugins/email_verification/handlers.rs
+++ b/crates/api/src/plugins/email_verification/handlers.rs
@@ -14,6 +14,17 @@ pub(super) async fn send_verification_email_core<DB: DatabaseAdapter>(
     config: &EmailVerificationConfig,
     ctx: &AuthContext<DB>,
 ) -> AuthResult<StatusResponse> {
+    // Validate callbackURL before any DB work or user enumeration: keeps
+    // the response uniform across unknown/verified/valid emails when the
+    // supplied callback is untrusted, and avoids wasted writes.
+    if let Some(ref callback_url) = body.callback_url
+        && !ctx.config.is_redirect_target_trusted(callback_url)
+    {
+        return Err(AuthError::bad_request(
+            "callbackURL is not a trusted origin",
+        ));
+    }
+
     // Check if user exists
     let user = ctx
         .database
@@ -35,14 +46,6 @@ pub(super) async fn send_verification_email_core<DB: DatabaseAdapter>(
         value: verification_token.clone(),
         expires_at,
     };
-
-    if let Some(ref callback_url) = body.callback_url
-        && !ctx.config.is_redirect_target_trusted(callback_url)
-    {
-        return Err(AuthError::bad_request(
-            "callbackURL is not a trusted origin",
-        ));
-    }
 
     ctx.database
         .create_verification(create_verification)
@@ -151,9 +154,13 @@ pub(super) async fn verify_email_core<DB: DatabaseAdapter>(
         None
     };
 
-    // If callback URL is provided and trusted, redirect. Untrusted callbacks
-    // fall through to the JSON branch to avoid reflecting an attacker-chosen
-    // origin into a server-issued Location header (open redirect).
+    // Policy note: unlike /send-verification-email and /change-email which
+    // reject untrusted callbacks with 400, this endpoint (GET /verify-email)
+    // is reached by users clicking a link in their mailbox. A hard 400 here
+    // would strand them after they've already consumed the verification
+    // token. Silent fallback to the JSON response preserves the successful
+    // verification and avoids reflecting an attacker-chosen origin into a
+    // server-issued Location header.
     if let Some(ref callback_url) = query.callback_url {
         if ctx.config.is_redirect_target_trusted(callback_url) {
             let redirect_url = format!("{}?verified=true", callback_url);

--- a/crates/api/src/plugins/email_verification/tests.rs
+++ b/crates/api/src/plugins/email_verification/tests.rs
@@ -723,9 +723,7 @@ async fn test_verify_email_no_auto_sign_in_no_session() {
 async fn test_verify_email_auto_sign_in_redirect_includes_cookie() {
     let plugin = EmailVerificationPlugin::new().auto_sign_in_after_verification(true);
 
-    let mut config = test_helpers::create_test_config();
-    config.trusted_origins = vec!["https://myapp.com".to_string()];
-    let ctx = test_helpers::create_test_context_with_config(config);
+    let ctx = test_helpers::create_test_context_with_trusted_origins(&["https://myapp.com"]);
     let _user = ctx
         .database
         .create_user(
@@ -767,9 +765,7 @@ async fn test_verify_email_auto_sign_in_redirect_includes_cookie() {
 async fn test_verify_email_redirect_without_auto_sign_in_no_cookie() {
     let plugin = EmailVerificationPlugin::new().auto_sign_in_after_verification(false);
 
-    let mut config = test_helpers::create_test_config();
-    config.trusted_origins = vec!["https://myapp.com".to_string()];
-    let ctx = test_helpers::create_test_context_with_config(config);
+    let ctx = test_helpers::create_test_context_with_trusted_origins(&["https://myapp.com"]);
     let _user = ctx
         .database
         .create_user(
@@ -838,9 +834,12 @@ async fn test_verify_email_rejects_untrusted_callback_url() {
         test_helpers::create_auth_request(HttpMethod::Get, "/verify-email", None, None, query);
     let response = plugin.handle_verify_email(&req, &ctx).await.unwrap();
 
-    // Untrusted callback must not become a server-issued Location.
-    assert_ne!(response.status, 302);
+    // Untrusted callback must fall through to the JSON response, not
+    // become a server-issued Location.
+    assert_eq!(response.status, 200);
     assert!(!response.headers.contains_key("Location"));
+    let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+    assert_eq!(body["status"], true);
 }
 
 // ------------------------------------------------------------------

--- a/crates/api/src/plugins/email_verification/tests.rs
+++ b/crates/api/src/plugins/email_verification/tests.rs
@@ -723,7 +723,9 @@ async fn test_verify_email_no_auto_sign_in_no_session() {
 async fn test_verify_email_auto_sign_in_redirect_includes_cookie() {
     let plugin = EmailVerificationPlugin::new().auto_sign_in_after_verification(true);
 
-    let ctx = test_helpers::create_test_context();
+    let mut config = test_helpers::create_test_config();
+    config.trusted_origins = vec!["https://myapp.com".to_string()];
+    let ctx = test_helpers::create_test_context_with_config(config);
     let _user = ctx
         .database
         .create_user(
@@ -765,7 +767,9 @@ async fn test_verify_email_auto_sign_in_redirect_includes_cookie() {
 async fn test_verify_email_redirect_without_auto_sign_in_no_cookie() {
     let plugin = EmailVerificationPlugin::new().auto_sign_in_after_verification(false);
 
-    let ctx = test_helpers::create_test_context();
+    let mut config = test_helpers::create_test_config();
+    config.trusted_origins = vec!["https://myapp.com".to_string()];
+    let ctx = test_helpers::create_test_context_with_config(config);
     let _user = ctx
         .database
         .create_user(
@@ -798,6 +802,45 @@ async fn test_verify_email_redirect_without_auto_sign_in_no_cookie() {
 
     assert_eq!(response.status, 302);
     assert!(!response.headers.contains_key("Set-Cookie"));
+}
+
+#[tokio::test]
+async fn test_verify_email_rejects_untrusted_callback_url() {
+    let plugin = EmailVerificationPlugin::new();
+    let ctx = test_helpers::create_test_context();
+    let _user = ctx
+        .database
+        .create_user(
+            CreateUser::new()
+                .with_email("untrusted-cb@test.com")
+                .with_name("U"),
+        )
+        .await
+        .unwrap();
+
+    let token_value = format!("verify_{}", Uuid::new_v4());
+    ctx.database
+        .create_verification(CreateVerification {
+            identifier: "untrusted-cb@test.com".to_string(),
+            value: token_value.clone(),
+            expires_at: Utc::now() + Duration::hours(1),
+        })
+        .await
+        .unwrap();
+
+    let mut query = HashMap::new();
+    query.insert("token".to_string(), token_value);
+    query.insert(
+        "callbackURL".to_string(),
+        "https://evil.example.com/pwned".to_string(),
+    );
+    let req =
+        test_helpers::create_auth_request(HttpMethod::Get, "/verify-email", None, None, query);
+    let response = plugin.handle_verify_email(&req, &ctx).await.unwrap();
+
+    // Untrusted callback must not become a server-issued Location.
+    assert_ne!(response.status, 302);
+    assert!(!response.headers.contains_key("Location"));
 }
 
 // ------------------------------------------------------------------
@@ -913,6 +956,40 @@ async fn test_send_verification_email_already_verified_returns_error() {
         .unwrap();
 
     let body = serde_json::json!({ "email": "verified@test.com" });
+    let mut headers = HashMap::new();
+    headers.insert("content-type".to_string(), "application/json".to_string());
+    let req = AuthRequest::from_parts(
+        HttpMethod::Post,
+        "/send-verification-email".to_string(),
+        headers,
+        Some(body.to_string().into_bytes()),
+        HashMap::new(),
+    );
+    let err = plugin
+        .handle_send_verification_email(&req, &ctx)
+        .await
+        .unwrap_err();
+    assert_eq!(err.status_code(), 400);
+}
+
+#[tokio::test]
+async fn test_send_verification_email_rejects_untrusted_callback_url() {
+    let plugin = EmailVerificationPlugin::new();
+    let ctx = test_helpers::create_test_context();
+    let _user = ctx
+        .database
+        .create_user(
+            CreateUser::new()
+                .with_email("sve-cb@test.com")
+                .with_name("S"),
+        )
+        .await
+        .unwrap();
+
+    let body = serde_json::json!({
+        "email": "sve-cb@test.com",
+        "callbackURL": "https://evil.example.com/grab",
+    });
     let mut headers = HashMap::new();
     headers.insert("content-type".to_string(), "application/json".to_string());
     let req = AuthRequest::from_parts(

--- a/crates/api/src/plugins/mod.rs
+++ b/crates/api/src/plugins/mod.rs
@@ -47,6 +47,17 @@ pub(crate) mod test_helpers {
         AuthContext::new(config, database)
     }
 
+    /// Test context whose `trusted_origins` accepts the given absolute
+    /// origins. Use in tests that exercise `is_redirect_target_trusted`
+    /// happy-path handling for callbackURLs under a custom origin.
+    pub fn create_test_context_with_trusted_origins(
+        origins: &[&str],
+    ) -> AuthContext<MemoryDatabaseAdapter> {
+        let mut config = create_test_config();
+        config.trusted_origins = origins.iter().map(|s| (*s).to_string()).collect();
+        create_test_context_with_config(config)
+    }
+
     pub async fn create_user(
         ctx: &AuthContext<MemoryDatabaseAdapter>,
         create_user: CreateUser,

--- a/crates/api/src/plugins/oauth/handlers.rs
+++ b/crates/api/src/plugins/oauth/handlers.rs
@@ -119,6 +119,18 @@ fn build_authorization_url(
 // Core functions
 // ---------------------------------------------------------------------------
 
+/// Initiate a social sign-in flow for an anonymous user.
+///
+/// # Errors
+///
+/// Returns `400 Bad Request` when `body.callback_url` is set and is not a
+/// trusted redirect target (see
+/// [`AuthConfig::is_redirect_target_trusted`]). This is stricter than the
+/// upstream TypeScript `better-auth@1.4.19`, which forwards the raw value
+/// to the OAuth provider. Deployments that rely on a cross-origin OAuth
+/// callback must list the callback origin in
+/// [`AuthConfig::trusted_origins`] or set
+/// `advanced.disable_origin_check = true`.
 pub(crate) async fn social_sign_in_core<DB: DatabaseAdapter>(
     body: &SocialSignInRequest,
     config: &OAuthConfig,
@@ -129,6 +141,11 @@ pub(crate) async fn social_sign_in_core<DB: DatabaseAdapter>(
     if let Some(ref url) = body.callback_url
         && !ctx.config.is_redirect_target_trusted(url)
     {
+        tracing::warn!(
+            callback_url = %url,
+            provider = %provider_name,
+            "Rejected untrusted callbackURL on /sign-in/social"
+        );
         return Err(AuthError::bad_request(
             "callbackURL is not a trusted origin",
         ));
@@ -150,6 +167,11 @@ pub(crate) async fn social_sign_in_core<DB: DatabaseAdapter>(
     .await
 }
 
+/// Link a social account to the currently signed-in user.
+///
+/// Rejects untrusted `body.callback_url` in the same way as
+/// [`social_sign_in_core`]; see its docs for the policy and the deviation
+/// from upstream TypeScript `better-auth`.
 pub(crate) async fn link_social_core<DB: DatabaseAdapter>(
     body: &LinkSocialRequest,
     session: &DB::Session,
@@ -161,6 +183,11 @@ pub(crate) async fn link_social_core<DB: DatabaseAdapter>(
     if let Some(ref url) = body.callback_url
         && !ctx.config.is_redirect_target_trusted(url)
     {
+        tracing::warn!(
+            callback_url = %url,
+            provider = %provider_name,
+            "Rejected untrusted callbackURL on /link-social"
+        );
         return Err(AuthError::bad_request(
             "callbackURL is not a trusted origin",
         ));

--- a/crates/api/src/plugins/oauth/handlers.rs
+++ b/crates/api/src/plugins/oauth/handlers.rs
@@ -138,16 +138,19 @@ pub(crate) async fn social_sign_in_core<DB: DatabaseAdapter>(
 ) -> AuthResult<SocialSignInResponse> {
     let provider_name = &body.provider;
 
+    // OAuth providers require `redirect_uri` to be an absolute URI; a
+    // relative callback would pass a looser trust check but fail at
+    // token exchange, leaving an orphaned OAuth state row behind.
     if let Some(ref url) = body.callback_url
-        && !ctx.config.is_redirect_target_trusted(url)
+        && !ctx.config.is_absolute_trusted_callback_url(url)
     {
         tracing::warn!(
             callback_url = %url,
             provider = %provider_name,
-            "Rejected untrusted callbackURL on /sign-in/social"
+            "Rejected callbackURL on /sign-in/social (must be absolute http(s) URL on a trusted origin)"
         );
         return Err(AuthError::bad_request(
-            "callbackURL is not a trusted origin",
+            "callbackURL must be an absolute http(s) URL on a trusted origin",
         ));
     }
 
@@ -181,15 +184,15 @@ pub(crate) async fn link_social_core<DB: DatabaseAdapter>(
     let provider_name = &body.provider;
 
     if let Some(ref url) = body.callback_url
-        && !ctx.config.is_redirect_target_trusted(url)
+        && !ctx.config.is_absolute_trusted_callback_url(url)
     {
         tracing::warn!(
             callback_url = %url,
             provider = %provider_name,
-            "Rejected untrusted callbackURL on /link-social"
+            "Rejected callbackURL on /link-social (must be absolute http(s) URL on a trusted origin)"
         );
         return Err(AuthError::bad_request(
-            "callbackURL is not a trusted origin",
+            "callbackURL must be an absolute http(s) URL on a trusted origin",
         ));
     }
 

--- a/crates/api/src/plugins/oauth/handlers.rs
+++ b/crates/api/src/plugins/oauth/handlers.rs
@@ -126,6 +126,14 @@ pub(crate) async fn social_sign_in_core<DB: DatabaseAdapter>(
 ) -> AuthResult<SocialSignInResponse> {
     let provider_name = &body.provider;
 
+    if let Some(ref url) = body.callback_url
+        && !ctx.config.is_redirect_target_trusted(url)
+    {
+        return Err(AuthError::bad_request(
+            "callbackURL is not a trusted origin",
+        ));
+    }
+
     let callback_url = body
         .callback_url
         .clone()
@@ -149,6 +157,14 @@ pub(crate) async fn link_social_core<DB: DatabaseAdapter>(
     ctx: &AuthContext<DB>,
 ) -> AuthResult<SocialSignInResponse> {
     let provider_name = &body.provider;
+
+    if let Some(ref url) = body.callback_url
+        && !ctx.config.is_redirect_target_trusted(url)
+    {
+        return Err(AuthError::bad_request(
+            "callbackURL is not a trusted origin",
+        ));
+    }
 
     let callback_url = body
         .callback_url

--- a/crates/api/src/plugins/oauth/mod.rs
+++ b/crates/api/src/plugins/oauth/mod.rs
@@ -11,6 +11,8 @@ use better_auth_core::plugin::{AuthState, AxumPlugin};
 pub mod encryption;
 mod handlers;
 mod providers;
+#[cfg(test)]
+mod tests;
 mod types;
 
 pub use providers::{OAuthConfig, OAuthProvider, OAuthStateStrategy, OAuthUserInfo};

--- a/crates/api/src/plugins/oauth/tests.rs
+++ b/crates/api/src/plugins/oauth/tests.rs
@@ -1,0 +1,89 @@
+use super::handlers::social_sign_in_core;
+use super::providers::{OAuthConfig, OAuthProvider};
+use super::types::SocialSignInRequest;
+use crate::plugins::test_helpers;
+
+fn test_oauth_config_with_google() -> OAuthConfig {
+    let mut cfg = OAuthConfig::default();
+    cfg.providers.insert(
+        "google".to_string(),
+        OAuthProvider::google("test-client-id", "test-client-secret"),
+    );
+    cfg
+}
+
+#[tokio::test]
+async fn sign_in_social_rejects_untrusted_callback_url() {
+    let oauth = test_oauth_config_with_google();
+    let ctx = test_helpers::create_test_context();
+
+    let body = SocialSignInRequest {
+        provider: "google".to_string(),
+        callback_url: Some("https://evil.example.com/cb".to_string()),
+        scopes: None,
+    };
+
+    let err = social_sign_in_core(&body, &oauth, &ctx).await.unwrap_err();
+    assert_eq!(err.status_code(), 400);
+}
+
+#[tokio::test]
+async fn sign_in_social_allows_relative_callback_url() {
+    let oauth = test_oauth_config_with_google();
+    let ctx = test_helpers::create_test_context();
+
+    let body = SocialSignInRequest {
+        provider: "google".to_string(),
+        callback_url: Some("/oauth/callback".to_string()),
+        scopes: None,
+    };
+
+    let response = social_sign_in_core(&body, &oauth, &ctx).await.unwrap();
+    assert!(response.redirect);
+    assert!(response.url.starts_with("https://accounts.google.com/"));
+}
+
+#[tokio::test]
+async fn sign_in_social_allows_trusted_origin_callback_url() {
+    let oauth = test_oauth_config_with_google();
+    let ctx = test_helpers::create_test_context_with_trusted_origins(&["https://admin.test.com"]);
+
+    let body = SocialSignInRequest {
+        provider: "google".to_string(),
+        callback_url: Some("https://admin.test.com/oauth/cb".to_string()),
+        scopes: None,
+    };
+
+    let response = social_sign_in_core(&body, &oauth, &ctx).await.unwrap();
+    assert!(response.redirect);
+}
+
+#[tokio::test]
+async fn sign_in_social_defaults_when_no_callback_url() {
+    let oauth = test_oauth_config_with_google();
+    let ctx = test_helpers::create_test_context();
+
+    let body = SocialSignInRequest {
+        provider: "google".to_string(),
+        callback_url: None,
+        scopes: None,
+    };
+
+    let response = social_sign_in_core(&body, &oauth, &ctx).await.unwrap();
+    assert!(response.redirect);
+}
+
+#[tokio::test]
+async fn sign_in_social_rejects_backslash_authority_bypass() {
+    let oauth = test_oauth_config_with_google();
+    let ctx = test_helpers::create_test_context();
+
+    let body = SocialSignInRequest {
+        provider: "google".to_string(),
+        callback_url: Some("/\\evil.example.com".to_string()),
+        scopes: None,
+    };
+
+    let err = social_sign_in_core(&body, &oauth, &ctx).await.unwrap_err();
+    assert_eq!(err.status_code(), 400);
+}

--- a/crates/api/src/plugins/oauth/tests.rs
+++ b/crates/api/src/plugins/oauth/tests.rs
@@ -32,7 +32,9 @@ async fn sign_in_social_rejects_untrusted_callback_url() {
 }
 
 #[tokio::test]
-async fn sign_in_social_allows_relative_callback_url() {
+async fn sign_in_social_rejects_relative_callback_url() {
+    // OAuth `redirect_uri` must be absolute; a relative path would pass
+    // any general redirect trust check but fail at token exchange.
     let oauth = test_oauth_config_with_google();
     let ctx = test_helpers::create_test_context();
 
@@ -42,9 +44,8 @@ async fn sign_in_social_allows_relative_callback_url() {
         scopes: None,
     };
 
-    let response = social_sign_in_core(&body, &oauth, &ctx).await.unwrap();
-    assert!(response.redirect);
-    assert!(response.url.starts_with("https://accounts.google.com/"));
+    let err = social_sign_in_core(&body, &oauth, &ctx).await.unwrap_err();
+    assert_eq!(err.status_code(), 400);
 }
 
 #[tokio::test]

--- a/crates/api/src/plugins/oauth/tests.rs
+++ b/crates/api/src/plugins/oauth/tests.rs
@@ -1,6 +1,10 @@
-use super::handlers::social_sign_in_core;
+use better_auth_core::adapters::{MemoryDatabaseAdapter, SessionOps, UserOps};
+use better_auth_core::types::{CreateSession, CreateUser, Session};
+use chrono::{Duration, Utc};
+
+use super::handlers::{link_social_core, social_sign_in_core};
 use super::providers::{OAuthConfig, OAuthProvider};
-use super::types::SocialSignInRequest;
+use super::types::{LinkSocialRequest, SocialSignInRequest};
 use crate::plugins::test_helpers;
 
 fn test_oauth_config_with_google() -> OAuthConfig {
@@ -86,4 +90,63 @@ async fn sign_in_social_rejects_backslash_authority_bypass() {
 
     let err = social_sign_in_core(&body, &oauth, &ctx).await.unwrap_err();
     assert_eq!(err.status_code(), 400);
+}
+
+async fn seed_session(ctx: &better_auth_core::AuthContext<MemoryDatabaseAdapter>) -> Session {
+    let user = ctx
+        .database
+        .create_user(
+            CreateUser::new()
+                .with_email("link@test.com")
+                .with_name("Link"),
+        )
+        .await
+        .unwrap();
+    ctx.database
+        .create_session(CreateSession {
+            user_id: user.id.clone(),
+            expires_at: Utc::now() + Duration::hours(1),
+            ip_address: None,
+            user_agent: None,
+            impersonated_by: None,
+            active_organization_id: None,
+        })
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn link_social_rejects_untrusted_callback_url() {
+    let oauth = test_oauth_config_with_google();
+    let ctx = test_helpers::create_test_context();
+    let session = seed_session(&ctx).await;
+
+    let body = LinkSocialRequest {
+        provider: "google".to_string(),
+        callback_url: Some("https://evil.example.com/cb".to_string()),
+        scopes: None,
+    };
+
+    let err = link_social_core(&body, &session, &oauth, &ctx)
+        .await
+        .unwrap_err();
+    assert_eq!(err.status_code(), 400);
+}
+
+#[tokio::test]
+async fn link_social_allows_trusted_origin_callback_url() {
+    let oauth = test_oauth_config_with_google();
+    let ctx = test_helpers::create_test_context_with_trusted_origins(&["https://admin.test.com"]);
+    let session = seed_session(&ctx).await;
+
+    let body = LinkSocialRequest {
+        provider: "google".to_string(),
+        callback_url: Some("https://admin.test.com/oauth/cb".to_string()),
+        scopes: None,
+    };
+
+    let response = link_social_core(&body, &session, &oauth, &ctx)
+        .await
+        .unwrap();
+    assert!(response.redirect);
 }

--- a/crates/api/src/plugins/password_management/handlers.rs
+++ b/crates/api/src/plugins/password_management/handlers.rs
@@ -48,6 +48,8 @@ pub(crate) async fn forget_password_core<DB: DatabaseAdapter>(
         if ctx.config.is_redirect_target_trusted(redirect_to) {
             format!("{}?token={}", redirect_to, reset_token)
         } else {
+            // Untrusted origin — fall back to server-side base URL so the
+            // reset email still reaches a valid endpoint.
             tracing::warn!(
                 redirect_to = %redirect_to,
                 "Ignoring untrusted redirect_to"

--- a/crates/api/src/plugins/password_management/handlers.rs
+++ b/crates/api/src/plugins/password_management/handlers.rs
@@ -18,6 +18,22 @@ pub(crate) async fn forget_password_core<DB: DatabaseAdapter>(
     config: &PasswordManagementConfig,
     ctx: &AuthContext<DB>,
 ) -> AuthResult<StatusResponse> {
+    // Resolve the effective redirect_to BEFORE any DB work — keeps the
+    // "don't reveal whether the email exists" guarantee (whatever we do
+    // must be identical for real and unknown emails) while also avoiding
+    // a wasted verification-token write when redirect_to is untrusted.
+    let trusted_redirect = body.redirect_to.as_deref().and_then(|url| {
+        if ctx.config.is_redirect_target_trusted(url) {
+            Some(url)
+        } else {
+            tracing::warn!(
+                redirect_to = %url,
+                "Ignoring untrusted redirect_to"
+            );
+            None
+        }
+    });
+
     // Check if user exists
     let user = match ctx.database.get_user_by_email(&body.email).await? {
         Some(user) => user,
@@ -42,28 +58,14 @@ pub(crate) async fn forget_password_core<DB: DatabaseAdapter>(
         .create_verification(create_verification)
         .await?;
 
-    // Build reset URL — only allow redirect_to that is a trusted redirect
-    // target to prevent open-redirect / token-exfiltration attacks.
-    let reset_url = if let Some(redirect_to) = &body.redirect_to {
-        if ctx.config.is_redirect_target_trusted(redirect_to) {
-            format!("{}?token={}", redirect_to, reset_token)
-        } else {
-            // Untrusted origin — fall back to server-side base URL so the
-            // reset email still reaches a valid endpoint.
-            tracing::warn!(
-                redirect_to = %redirect_to,
-                "Ignoring untrusted redirect_to"
-            );
-            format!(
-                "{}/reset-password?token={}",
-                ctx.config.base_url, reset_token
-            )
-        }
-    } else {
-        format!(
+    // Build reset URL. Untrusted `redirect_to` was already filtered to
+    // `None`, so this branch only ever reflects a value we have checked.
+    let reset_url = match trusted_redirect {
+        Some(redirect_to) => format!("{}?token={}", redirect_to, reset_token),
+        None => format!(
             "{}/reset-password?token={}",
             ctx.config.base_url, reset_token
-        )
+        ),
     };
 
     if config.send_email_notifications {

--- a/crates/api/src/plugins/password_management/handlers.rs
+++ b/crates/api/src/plugins/password_management/handlers.rs
@@ -42,14 +42,12 @@ pub(crate) async fn forget_password_core<DB: DatabaseAdapter>(
         .create_verification(create_verification)
         .await?;
 
-    // Build reset URL — only allow redirect_to when it shares the same
-    // origin as the configured base_url to prevent open-redirect /
-    // token-exfiltration attacks.
+    // Build reset URL — only allow redirect_to that is a trusted redirect
+    // target to prevent open-redirect / token-exfiltration attacks.
     let reset_url = if let Some(redirect_to) = &body.redirect_to {
-        if redirect_to.starts_with('/') || redirect_to.starts_with(&ctx.config.base_url) {
+        if ctx.config.is_redirect_target_trusted(redirect_to) {
             format!("{}?token={}", redirect_to, reset_token)
         } else {
-            // Untrusted origin — fall back to server-side base URL.
             tracing::warn!(
                 redirect_to = %redirect_to,
                 "Ignoring untrusted redirect_to"
@@ -174,26 +172,38 @@ pub(crate) async fn reset_password_token_core<DB: DatabaseAdapter>(
     query: &ResetPasswordTokenQuery,
     ctx: &AuthContext<DB>,
 ) -> AuthResult<ResetPasswordTokenResult> {
+    // Only use the supplied callbackURL if it is a trusted redirect target —
+    // otherwise it becomes an open-redirect vector that also leaks the reset
+    // token into an attacker-controlled origin.
+    let callback_url = match query.callback_url.as_deref() {
+        Some(url) if ctx.config.is_redirect_target_trusted(url) => Some(url),
+        Some(url) => {
+            tracing::warn!(
+                callback_url = %url,
+                "Ignoring untrusted callbackURL on /reset-password/:token"
+            );
+            None
+        }
+        None => None,
+    };
+
     // Validate the reset token exists and is not expired
     match find_user_by_reset_token(token, ctx).await? {
         Some((_user, _verification)) => {}
         None => {
-            // Redirect to callback URL with error if provided
-            if let Some(callback_url) = &query.callback_url {
-                let redirect_url = format!("{}?error=INVALID_TOKEN", callback_url);
+            if let Some(cb) = callback_url {
+                let redirect_url = format!("{}?error=INVALID_TOKEN", cb);
                 return Ok(ResetPasswordTokenResult::Redirect(redirect_url));
             }
             return Err(AuthError::bad_request("Invalid or expired reset token"));
         }
     };
 
-    // If callback URL is provided, redirect with valid token
-    if let Some(callback_url) = &query.callback_url {
-        let redirect_url = format!("{}?token={}", callback_url, token);
+    if let Some(cb) = callback_url {
+        let redirect_url = format!("{}?token={}", cb, token);
         return Ok(ResetPasswordTokenResult::Redirect(redirect_url));
     }
 
-    // Otherwise return the token directly
     Ok(ResetPasswordTokenResult::Json(ResetPasswordTokenResponse {
         token: token.to_string(),
     }))

--- a/crates/api/src/plugins/password_management/handlers.rs
+++ b/crates/api/src/plugins/password_management/handlers.rs
@@ -21,14 +21,18 @@ pub(crate) async fn forget_password_core<DB: DatabaseAdapter>(
     // Resolve the effective redirect_to BEFORE any DB work — keeps the
     // "don't reveal whether the email exists" guarantee (whatever we do
     // must be identical for real and unknown emails) while also avoiding
-    // a wasted verification-token write when redirect_to is untrusted.
+    // a wasted verification-token write when redirect_to is unusable.
+    //
+    // The reset URL is embedded in an outgoing email `href`, so
+    // redirect_to must be an absolute http(s) URL on a trusted origin;
+    // relative paths don't resolve in a mail client.
     let trusted_redirect = body.redirect_to.as_deref().and_then(|url| {
-        if ctx.config.is_redirect_target_trusted(url) {
+        if ctx.config.is_absolute_trusted_callback_url(url) {
             Some(url)
         } else {
             tracing::warn!(
                 redirect_to = %url,
-                "Ignoring untrusted redirect_to"
+                "Ignoring untrusted or non-absolute redirect_to"
             );
             None
         }

--- a/crates/api/src/plugins/password_management/tests.rs
+++ b/crates/api/src/plugins/password_management/tests.rs
@@ -505,6 +505,33 @@ async fn test_reset_password_token_endpoint_invalid_token() {
 }
 
 #[tokio::test]
+async fn test_reset_password_token_rejects_untrusted_callback_url() {
+    // Untrusted callbackURL on an invalid token must not redirect to the
+    // attacker origin; it falls through to the 400 path.
+    let plugin = PasswordManagementPlugin::new();
+    let (ctx, _user, _session) = create_test_context_with_user().await;
+
+    let mut query = HashMap::new();
+    query.insert(
+        "callbackURL".to_string(),
+        "https://evil.example.com/steal".to_string(),
+    );
+    let req = AuthRequest::from_parts(
+        HttpMethod::Get,
+        "/reset-password/token".to_string(),
+        HashMap::new(),
+        None,
+        query,
+    );
+
+    let err = plugin
+        .handle_reset_password_token("invalid_token", &req, &ctx)
+        .await
+        .unwrap_err();
+    assert_eq!(err.status_code(), 400);
+}
+
+#[tokio::test]
 async fn test_password_validation() {
     let plugin = PasswordManagementPlugin::new();
     let mut config = AuthConfig::new("test-secret");

--- a/crates/api/src/plugins/password_management/tests.rs
+++ b/crates/api/src/plugins/password_management/tests.rs
@@ -94,12 +94,7 @@ async fn test_forget_password_untrusted_redirect_to_falls_back_to_base_url() {
 
     #[async_trait::async_trait]
     impl SendResetPassword for UrlCapture {
-        async fn send(
-            &self,
-            _user: &serde_json::Value,
-            url: &str,
-            _token: &str,
-        ) -> AuthResult<()> {
+        async fn send(&self, _user: &serde_json::Value, url: &str, _token: &str) -> AuthResult<()> {
             *self.captured.lock().unwrap() = Some(url.to_string());
             Ok(())
         }
@@ -148,12 +143,7 @@ async fn test_forget_password_rejects_hostname_prefix_attack() {
 
     #[async_trait::async_trait]
     impl SendResetPassword for UrlCapture {
-        async fn send(
-            &self,
-            _user: &serde_json::Value,
-            url: &str,
-            _token: &str,
-        ) -> AuthResult<()> {
+        async fn send(&self, _user: &serde_json::Value, url: &str, _token: &str) -> AuthResult<()> {
             *self.captured.lock().unwrap() = Some(url.to_string());
             Ok(())
         }

--- a/crates/api/src/plugins/password_management/tests.rs
+++ b/crates/api/src/plugins/password_management/tests.rs
@@ -84,6 +84,111 @@ async fn test_forget_password_success() {
 }
 
 #[tokio::test]
+async fn test_forget_password_untrusted_redirect_to_falls_back_to_base_url() {
+    // A custom sender captures the reset URL embedded in the email.
+    use std::sync::Mutex;
+
+    struct UrlCapture {
+        captured: Arc<Mutex<Option<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl SendResetPassword for UrlCapture {
+        async fn send(
+            &self,
+            _user: &serde_json::Value,
+            url: &str,
+            _token: &str,
+        ) -> AuthResult<()> {
+            *self.captured.lock().unwrap() = Some(url.to_string());
+            Ok(())
+        }
+    }
+
+    let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let sender: Arc<dyn SendResetPassword> = Arc::new(UrlCapture {
+        captured: captured.clone(),
+    });
+
+    let plugin = PasswordManagementPlugin::new().send_reset_password(sender);
+    let (ctx, _user, _session) = create_test_context_with_user().await;
+
+    let body = serde_json::json!({
+        "email": "test@example.com",
+        "redirectTo": "https://evil.example.com/reset"
+    });
+    let req = test_helpers::create_auth_request_no_query(
+        HttpMethod::Post,
+        "/forget-password",
+        None,
+        Some(body.to_string().into_bytes()),
+    );
+
+    let response = plugin.handle_forget_password(&req, &ctx).await.unwrap();
+    assert_eq!(response.status, 200);
+
+    let captured_url = captured.lock().unwrap().clone().expect("sender invoked");
+    // Untrusted redirect_to falls back to server base_url — never
+    // embedded in the email, never leaking the reset token off-origin.
+    assert!(captured_url.starts_with("http://localhost:3000/reset-password?token="));
+    assert!(!captured_url.contains("evil.example.com"));
+}
+
+#[tokio::test]
+async fn test_forget_password_rejects_hostname_prefix_attack() {
+    // `base_url.starts_with("https://app.com")` used to let
+    // `"https://app.com.evil.com/x"` through — fixing that is the main
+    // point of upgrading the half-baked `starts_with` check to
+    // `is_redirect_target_trusted`.
+    use std::sync::Mutex;
+
+    struct UrlCapture {
+        captured: Arc<Mutex<Option<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl SendResetPassword for UrlCapture {
+        async fn send(
+            &self,
+            _user: &serde_json::Value,
+            url: &str,
+            _token: &str,
+        ) -> AuthResult<()> {
+            *self.captured.lock().unwrap() = Some(url.to_string());
+            Ok(())
+        }
+    }
+
+    let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let sender: Arc<dyn SendResetPassword> = Arc::new(UrlCapture {
+        captured: captured.clone(),
+    });
+
+    let plugin = PasswordManagementPlugin::new().send_reset_password(sender);
+    let (ctx, _user, _session) = create_test_context_with_user().await;
+
+    // `http://localhost:3000.evil.com/...` looks "prefix-identical" to
+    // `http://localhost:3000` but the origin is `localhost:3000.evil.com`.
+    let body = serde_json::json!({
+        "email": "test@example.com",
+        "redirectTo": "http://localhost:3000.evil.com/reset"
+    });
+    let req = test_helpers::create_auth_request_no_query(
+        HttpMethod::Post,
+        "/forget-password",
+        None,
+        Some(body.to_string().into_bytes()),
+    );
+
+    let response = plugin.handle_forget_password(&req, &ctx).await.unwrap();
+    assert_eq!(response.status, 200);
+
+    let captured_url = captured.lock().unwrap().clone().expect("sender invoked");
+    assert!(!captured_url.contains("evil.com"));
+    assert!(captured_url.starts_with("http://localhost:3000/reset-password"));
+}
+
+#[tokio::test]
 async fn test_forget_password_unknown_email() {
     let plugin = PasswordManagementPlugin::new();
     let (ctx, _user, _session) = create_test_context_with_user().await;
@@ -529,6 +634,78 @@ async fn test_reset_password_token_rejects_untrusted_callback_url() {
         .await
         .unwrap_err();
     assert_eq!(err.status_code(), 400);
+}
+
+#[tokio::test]
+async fn test_reset_password_token_valid_with_untrusted_callback_returns_json() {
+    // Valid token + untrusted callback must NOT 302 to evil.com — that
+    // would exfiltrate the reset token. Falls through to JSON response.
+    let plugin = PasswordManagementPlugin::new();
+    let (ctx, user, _session) = create_test_context_with_user().await;
+    let reset_token = create_reset_token(&ctx, user.email.as_deref().unwrap()).await;
+
+    let mut query = HashMap::new();
+    query.insert(
+        "callbackURL".to_string(),
+        "https://evil.example.com/steal".to_string(),
+    );
+    let req = AuthRequest::from_parts(
+        HttpMethod::Get,
+        "/reset-password/token".to_string(),
+        HashMap::new(),
+        None,
+        query,
+    );
+
+    let response = plugin
+        .handle_reset_password_token(&reset_token, &req, &ctx)
+        .await
+        .unwrap();
+    assert_eq!(response.status, 200);
+    assert!(
+        !response
+            .headers
+            .iter()
+            .any(|(k, _)| k.eq_ignore_ascii_case("Location"))
+    );
+    let body: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+    assert_eq!(body["token"], reset_token);
+}
+
+#[tokio::test]
+async fn test_reset_password_token_invalid_with_trusted_callback_redirects_with_error() {
+    // Invalid token + trusted callback should 302 to the callback with
+    // ?error=INVALID_TOKEN — confirms the error-redirect branch still
+    // works after the callback-URL trust gate.
+    let plugin = PasswordManagementPlugin::new();
+    let (ctx, _user, _session) = create_test_context_with_user().await;
+
+    let mut query = HashMap::new();
+    query.insert(
+        "callbackURL".to_string(),
+        "http://localhost:3000/reset".to_string(),
+    );
+    let req = AuthRequest::from_parts(
+        HttpMethod::Get,
+        "/reset-password/token".to_string(),
+        HashMap::new(),
+        None,
+        query,
+    );
+
+    let response = plugin
+        .handle_reset_password_token("bogus_token", &req, &ctx)
+        .await
+        .unwrap();
+    assert_eq!(response.status, 302);
+    let location = response
+        .headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("Location"))
+        .map(|(_, v)| v.clone())
+        .expect("Location header");
+    assert!(location.contains("http://localhost:3000/reset"));
+    assert!(location.contains("error=INVALID_TOKEN"));
 }
 
 #[tokio::test]

--- a/crates/api/src/plugins/user_management/handlers.rs
+++ b/crates/api/src/plugins/user_management/handlers.rs
@@ -85,6 +85,14 @@ pub(crate) async fn change_email_core<DB: DatabaseAdapter>(
     config: &UserManagementConfig,
     ctx: &AuthContext<DB>,
 ) -> AuthResult<StatusMessageResponse> {
+    if let Some(ref url) = body.callback_url
+        && !ctx.config.is_redirect_target_trusted(url)
+    {
+        return Err(AuthError::bad_request(
+            "callbackURL is not a trusted origin",
+        ));
+    }
+
     // Prevent changing to the same email
     if user.email().map(|e| e == body.new_email).unwrap_or(false) {
         return Err(AuthError::bad_request(

--- a/crates/api/src/plugins/user_management/handlers.rs
+++ b/crates/api/src/plugins/user_management/handlers.rs
@@ -85,16 +85,17 @@ pub(crate) async fn change_email_core<DB: DatabaseAdapter>(
     config: &UserManagementConfig,
     ctx: &AuthContext<DB>,
 ) -> AuthResult<StatusMessageResponse> {
-    // Validate callbackURL up front. Even the `update_without_verification`
-    // branch does this: if a caller supplies `callbackURL`, the API
-    // contract is that we act on it — silently ignoring an untrusted
-    // value lets the next refactor accidentally wire it into an email
-    // without anyone realising validation was skipped.
+    // Validate callbackURL up front. The verification flow embeds it in
+    // an email `href`, so it must be an absolute http(s) URL on a
+    // trusted origin — a relative path can't be resolved by a mail
+    // client. Validating even in the `update_without_verification`
+    // branch keeps the API contract stable: if a caller supplies
+    // `callbackURL`, we act on it or reject it.
     if let Some(ref url) = body.callback_url
-        && !ctx.config.is_redirect_target_trusted(url)
+        && !ctx.config.is_absolute_trusted_callback_url(url)
     {
         return Err(AuthError::bad_request(
-            "callbackURL is not a trusted origin",
+            "callbackURL must be an absolute http(s) URL on a trusted origin",
         ));
     }
 

--- a/crates/api/src/plugins/user_management/handlers.rs
+++ b/crates/api/src/plugins/user_management/handlers.rs
@@ -85,6 +85,19 @@ pub(crate) async fn change_email_core<DB: DatabaseAdapter>(
     config: &UserManagementConfig,
     ctx: &AuthContext<DB>,
 ) -> AuthResult<StatusMessageResponse> {
+    // Validate callbackURL up front. Even the `update_without_verification`
+    // branch does this: if a caller supplies `callbackURL`, the API
+    // contract is that we act on it — silently ignoring an untrusted
+    // value lets the next refactor accidentally wire it into an email
+    // without anyone realising validation was skipped.
+    if let Some(ref url) = body.callback_url
+        && !ctx.config.is_redirect_target_trusted(url)
+    {
+        return Err(AuthError::bad_request(
+            "callbackURL is not a trusted origin",
+        ));
+    }
+
     // Prevent changing to the same email
     if user.email().map(|e| e == body.new_email).unwrap_or(false) {
         return Err(AuthError::bad_request(
@@ -105,9 +118,6 @@ pub(crate) async fn change_email_core<DB: DatabaseAdapter>(
     }
 
     // If update_without_verification is true, update the email immediately.
-    // In this branch the supplied callbackURL is never used, so we don't
-    // validate it — rejecting an untrusted callback here would 400 clients
-    // who legitimately rely on the immediate-update flow.
     if config.change_email.update_without_verification {
         let update_user = UpdateUser {
             email: Some(body.new_email.clone()),
@@ -122,8 +132,10 @@ pub(crate) async fn change_email_core<DB: DatabaseAdapter>(
         });
     }
 
-    // The verification flow embeds callbackURL in the outgoing email, so
-    // it must be a trusted redirect target before we generate any token.
+    // Defence in depth: this check is already covered at the top of the
+    // function, but keep it adjacent to the `create_verification_token`
+    // call so future splits of this function can't silently drop the
+    // guard. The helper is idempotent on valid input.
     if let Some(ref url) = body.callback_url
         && !ctx.config.is_redirect_target_trusted(url)
     {

--- a/crates/api/src/plugins/user_management/handlers.rs
+++ b/crates/api/src/plugins/user_management/handlers.rs
@@ -85,14 +85,6 @@ pub(crate) async fn change_email_core<DB: DatabaseAdapter>(
     config: &UserManagementConfig,
     ctx: &AuthContext<DB>,
 ) -> AuthResult<StatusMessageResponse> {
-    if let Some(ref url) = body.callback_url
-        && !ctx.config.is_redirect_target_trusted(url)
-    {
-        return Err(AuthError::bad_request(
-            "callbackURL is not a trusted origin",
-        ));
-    }
-
     // Prevent changing to the same email
     if user.email().map(|e| e == body.new_email).unwrap_or(false) {
         return Err(AuthError::bad_request(
@@ -112,7 +104,10 @@ pub(crate) async fn change_email_core<DB: DatabaseAdapter>(
         ));
     }
 
-    // If update_without_verification is true, update the email immediately
+    // If update_without_verification is true, update the email immediately.
+    // In this branch the supplied callbackURL is never used, so we don't
+    // validate it — rejecting an untrusted callback here would 400 clients
+    // who legitimately rely on the immediate-update flow.
     if config.change_email.update_without_verification {
         let update_user = UpdateUser {
             email: Some(body.new_email.clone()),
@@ -125,6 +120,16 @@ pub(crate) async fn change_email_core<DB: DatabaseAdapter>(
             status: true,
             message: "Email updated successfully".to_string(),
         });
+    }
+
+    // The verification flow embeds callbackURL in the outgoing email, so
+    // it must be a trusted redirect target before we generate any token.
+    if let Some(ref url) = body.callback_url
+        && !ctx.config.is_redirect_target_trusted(url)
+    {
+        return Err(AuthError::bad_request(
+            "callbackURL is not a trusted origin",
+        ));
     }
 
     // Create verification token

--- a/crates/api/src/plugins/user_management/handlers.rs
+++ b/crates/api/src/plugins/user_management/handlers.rs
@@ -132,18 +132,6 @@ pub(crate) async fn change_email_core<DB: DatabaseAdapter>(
         });
     }
 
-    // Defence in depth: this check is already covered at the top of the
-    // function, but keep it adjacent to the `create_verification_token`
-    // call so future splits of this function can't silently drop the
-    // guard. The helper is idempotent on valid input.
-    if let Some(ref url) = body.callback_url
-        && !ctx.config.is_redirect_target_trusted(url)
-    {
-        return Err(AuthError::bad_request(
-            "callbackURL is not a trusted origin",
-        ));
-    }
-
     // Create verification token
     let identifier = format!("change_email:{}:{}", user.id(), body.new_email);
     let expires_at = Utc::now() + Duration::hours(24);

--- a/crates/api/src/plugins/user_management/tests.rs
+++ b/crates/api/src/plugins/user_management/tests.rs
@@ -60,6 +60,40 @@ async fn test_change_email_same_email() {
 }
 
 #[tokio::test]
+async fn test_change_email_rejects_untrusted_callback_even_when_update_without_verification() {
+    // Even in the `update_without_verification = true` fast path the
+    // callbackURL is part of the request contract; rejecting untrusted
+    // values keeps the guarantee that a caller can never submit an
+    // untrusted origin without learning about it.
+    let plugin = UserManagementPlugin::new()
+        .change_email_enabled(true)
+        .update_without_verification(true);
+    let (ctx, _user, session) = test_helpers::create_test_context_with_user(
+        CreateUser::new()
+            .with_email("test@example.com")
+            .with_name("Test User")
+            .with_email_verified(true),
+        Duration::hours(24),
+    )
+    .await;
+
+    let body = serde_json::json!({
+        "newEmail": "new@example.com",
+        "callbackURL": "https://evil.example.com/steal",
+    });
+    let req = test_helpers::create_auth_request(
+        HttpMethod::Post,
+        "/change-email",
+        Some(&session.token),
+        Some(body.to_string().into_bytes()),
+        HashMap::new(),
+    );
+
+    let err = plugin.handle_change_email(&req, &ctx).await.unwrap_err();
+    assert_eq!(err.status_code(), 400);
+}
+
+#[tokio::test]
 async fn test_change_email_rejects_untrusted_callback_url() {
     let plugin = UserManagementPlugin::new().change_email_enabled(true);
     let (ctx, _user, session) = test_helpers::create_test_context_with_user(

--- a/crates/api/src/plugins/user_management/tests.rs
+++ b/crates/api/src/plugins/user_management/tests.rs
@@ -60,6 +60,34 @@ async fn test_change_email_same_email() {
 }
 
 #[tokio::test]
+async fn test_change_email_rejects_untrusted_callback_url() {
+    let plugin = UserManagementPlugin::new().change_email_enabled(true);
+    let (ctx, _user, session) = test_helpers::create_test_context_with_user(
+        CreateUser::new()
+            .with_email("test@example.com")
+            .with_name("Test User")
+            .with_email_verified(true),
+        Duration::hours(24),
+    )
+    .await;
+
+    let body = serde_json::json!({
+        "newEmail": "new@example.com",
+        "callbackURL": "https://evil.example.com/steal",
+    });
+    let req = test_helpers::create_auth_request(
+        HttpMethod::Post,
+        "/change-email",
+        Some(&session.token),
+        Some(body.to_string().into_bytes()),
+        HashMap::new(),
+    );
+
+    let err = plugin.handle_change_email(&req, &ctx).await.unwrap_err();
+    assert_eq!(err.status_code(), 400);
+}
+
+#[tokio::test]
 async fn test_change_email_unauthenticated() {
     let plugin = UserManagementPlugin::new().change_email_enabled(true);
     let (ctx, _user, _session) = test_helpers::create_test_context_with_user(

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -48,7 +48,7 @@ redis = { workspace = true, optional = true }
 better-auth-derive = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 http-body-util = { version = "0.1", optional = true }
-url = { workspace = true, optional = true }
+url = { workspace = true }
 tracing.workspace = true
 
 [features]
@@ -56,4 +56,4 @@ default = []
 derive = ["dep:better-auth-derive"]
 sqlx-postgres = ["dep:sqlx"]
 redis-cache = ["dep:redis"]
-axum = ["dep:axum", "dep:http-body-util", "dep:url"]
+axum = ["dep:axum", "dep:http-body-util"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -49,6 +49,7 @@ better-auth-derive = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 http-body-util = { version = "0.1", optional = true }
 url = { workspace = true }
+idna = "1"
 tracing.workspace = true
 
 [features]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -587,21 +587,28 @@ impl AuthConfig {
     /// redirect (302 `Location`) or an absolute link embedded in an outgoing
     /// email. Safe targets are:
     ///
-    /// - any value when `advanced.disable_origin_check` is enabled;
-    /// - relative paths starting with `/` (but not protocol-relative `//...`);
-    /// - absolute URLs whose origin matches [`base_url`](Self::base_url) or a
-    ///   [`trusted_origins`](Self::trusted_origins) pattern.
+    /// - a relative path starting with `/` whose second character is not
+    ///   `/` or `\` (authority smuggling — `//evil.com`, `/\evil.com` —
+    ///   is rejected even when the caller opts out of origin checks;
+    ///   browsers normalise `\` to `/` in the authority component);
+    /// - an absolute `http`/`https` URL whose origin matches
+    ///   [`base_url`](Self::base_url) or a
+    ///   [`trusted_origins`](Self::trusted_origins) pattern;
+    /// - any path/URL when `advanced.disable_origin_check` is set, with
+    ///   the authority-smuggling exception above.
     ///
-    /// Prevents open-redirect via user-supplied `callbackURL` / `redirectTo`.
+    /// Other schemes (`javascript:`, `data:`, `file:`, …) are always
+    /// rejected. Prevents open-redirect via user-supplied `callbackURL`
+    /// / `redirectTo`.
     pub fn is_redirect_target_trusted(&self, target: &str) -> bool {
+        // Authority smuggling must NEVER be accepted, even under
+        // `disable_origin_check`. That flag is an opt-out of same-origin
+        // checks, not a licence to let the caller pick the host.
+        if is_authority_smuggling(target) {
+            return false;
+        }
         if self.advanced.disable_origin_check {
             return true;
-        }
-        // Protocol-relative URLs (//evil.com/...) must never be treated as
-        // same-origin; the browser resolves them against the current origin's
-        // scheme but the host is attacker-controlled.
-        if target.starts_with("//") {
-            return false;
         }
         if target.starts_with('/') {
             return true;
@@ -640,14 +647,56 @@ pub const DEFAULT_MAX_BODY_BYTES: usize = 1024 * 1024;
 ///
 /// For example, `"https://example.com/path"` → `"https://example.com"`.
 ///
-/// This is used by [`AuthConfig::is_origin_trusted`] and the CSRF middleware
-/// so that origin comparison is centralised in one place.
+/// Uses the WHATWG URL parser so query strings, fragments, and userinfo
+/// are stripped correctly (the hand-rolled version this replaced returned
+/// `"https://app.example.com?foo=bar"` for `"https://app.example.com?foo=bar"`,
+/// and kept userinfo, which let an `app.example.com@evil.com` authority
+/// masquerade as an app-origin URL in string comparisons).
+///
+/// Only `http` and `https` origins are returned; opaque or unusual schemes
+/// (`javascript:`, `data:`, `file:`) return `None` so they cannot sneak
+/// through the origin-comparison path.
+///
+/// This is used by [`AuthConfig::is_origin_trusted`],
+/// [`AuthConfig::is_redirect_target_trusted`], and the CSRF middleware so
+/// that origin comparison is centralised in one place.
 pub fn extract_origin(url: &str) -> Option<String> {
-    let scheme_end = url.find("://")?;
-    let rest = &url[scheme_end + 3..];
-    let host_end = rest.find('/').unwrap_or(rest.len());
-    let origin = format!("{}{}", &url[..scheme_end + 3], &rest[..host_end]);
-    Some(origin)
+    let parsed = ::url::Url::parse(url).ok()?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return None;
+    }
+    match parsed.origin() {
+        ::url::Origin::Tuple(..) => Some(parsed.origin().ascii_serialization()),
+        ::url::Origin::Opaque(_) => None,
+    }
+}
+
+/// Detect attacker-controlled authority smuggling in a redirect target.
+///
+/// Returns `true` for:
+/// - protocol-relative URLs (`//evil.com/x`) — browser resolves against
+///   the current origin's scheme but the host is caller-controlled;
+/// - `/\evil.com` and similar backslash bypasses — Chrome, Safari, and
+///   Edge follow WHATWG authority-state parsing and normalise `\` to `/`.
+///
+/// Used by [`AuthConfig::is_redirect_target_trusted`] to reject these
+/// forms even when origin checks are otherwise disabled.
+fn is_authority_smuggling(target: &str) -> bool {
+    let trimmed = target.trim_start_matches(|c: char| c.is_whitespace());
+    if trimmed.starts_with("//") || trimmed.starts_with(r"\\") {
+        return true;
+    }
+    if let Some(rest) = trimmed.strip_prefix('/')
+        && (rest.starts_with('/') || rest.starts_with('\\'))
+    {
+        return true;
+    }
+    if let Some(rest) = trimmed.strip_prefix('\\')
+        && (rest.starts_with('/') || rest.starts_with('\\'))
+    {
+        return true;
+    }
+    false
 }
 
 #[cfg(test)]
@@ -702,10 +751,69 @@ mod tests {
     }
 
     #[test]
-    fn redirect_target_bypass_when_disable_origin_check() {
+    fn redirect_target_bypass_does_not_cover_authority_smuggling() {
+        // `disable_origin_check` is an opt-out of same-origin checks, NOT
+        // a licence for the caller to pick the host. Protocol-relative
+        // and backslash-bypass forms must still be rejected.
         let mut cfg = config_with(vec![]);
         cfg.advanced.disable_origin_check = true;
         assert!(cfg.is_redirect_target_trusted("https://evil.com/cb"));
-        assert!(cfg.is_redirect_target_trusted("//evil.com"));
+        assert!(cfg.is_redirect_target_trusted("/dashboard"));
+        assert!(!cfg.is_redirect_target_trusted("//evil.com"));
+        assert!(!cfg.is_redirect_target_trusted("/\\evil.com"));
+        assert!(!cfg.is_redirect_target_trusted("\\\\evil.com"));
+    }
+
+    #[test]
+    fn redirect_target_rejects_backslash_authority_bypass() {
+        // Browsers (Chrome, Safari, Edge) normalise `\` to `/` in the
+        // authority component, so `Location: /\evil.com` navigates to
+        // `//evil.com`. Must be rejected.
+        let cfg = config_with(vec![]);
+        assert!(!cfg.is_redirect_target_trusted("/\\evil.com"));
+        assert!(!cfg.is_redirect_target_trusted("/\\\\evil.com"));
+        assert!(!cfg.is_redirect_target_trusted("\\evil.com"));
+        assert!(!cfg.is_redirect_target_trusted("\\\\evil.com"));
+        assert!(!cfg.is_redirect_target_trusted("\\/evil.com"));
+        // Whitespace-padded variants browsers may strip.
+        assert!(!cfg.is_redirect_target_trusted("  //evil.com"));
+        assert!(!cfg.is_redirect_target_trusted("\t/\\evil.com"));
+    }
+
+    #[test]
+    fn redirect_target_strips_userinfo_when_comparing_origin() {
+        // `app.example.com@evil.com` — the real host is `evil.com`; the
+        // old hand-rolled parser kept the whole string as the "origin"
+        // and would silently compare against `https://app.example.com`.
+        let cfg = config_with(vec![]);
+        assert!(!cfg.is_redirect_target_trusted("https://app.example.com@evil.com/x"));
+    }
+
+    #[test]
+    fn redirect_target_allows_same_origin_with_query_and_fragment() {
+        // The old hand-rolled `extract_origin` returned the whole URL for
+        // these inputs, so legitimate same-origin URLs with `?` or `#`
+        // were silently rejected. url::Url::parse fixes this.
+        let cfg = config_with(vec![]);
+        assert!(cfg.is_redirect_target_trusted("https://app.example.com?retry=1"));
+        assert!(cfg.is_redirect_target_trusted("https://app.example.com#/route"));
+        assert!(cfg.is_redirect_target_trusted("https://app.example.com/path?x=1#y"));
+    }
+
+    #[test]
+    fn redirect_target_rejects_non_http_schemes() {
+        let cfg = config_with(vec![]);
+        assert!(!cfg.is_redirect_target_trusted("javascript:alert(1)"));
+        assert!(!cfg.is_redirect_target_trusted("data:text/html,x"));
+        assert!(!cfg.is_redirect_target_trusted("file:///etc/passwd"));
+        assert!(!cfg.is_redirect_target_trusted("ftp://example.com/"));
+    }
+
+    #[test]
+    fn redirect_target_preserves_non_default_port_in_origin_match() {
+        let cfg = config_with(vec!["https://admin.example.com:8443"]);
+        assert!(cfg.is_redirect_target_trusted("https://admin.example.com:8443/x"));
+        // Different port → not the same origin.
+        assert!(!cfg.is_redirect_target_trusted("https://admin.example.com/x"));
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -720,19 +720,47 @@ fn extract_pattern_origin(pattern: &str) -> String {
     let Some(scheme_end) = pattern.find("://") else {
         return String::new();
     };
-    let scheme = &pattern[..scheme_end];
+    let scheme = pattern[..scheme_end].to_ascii_lowercase();
     let rest = &pattern[scheme_end + 3..];
     let host_end = rest.find('/').unwrap_or(rest.len());
     let authority = &rest[..host_end];
 
-    // Strip default ports for http/https to match `extract_origin`.
-    let authority = match scheme {
-        "http" => authority.strip_suffix(":80").unwrap_or(authority),
-        "https" => authority.strip_suffix(":443").unwrap_or(authority),
-        _ => authority,
+    // Split host from port so IDN normalisation only runs on the host.
+    let (host, port_suffix) = match authority.rfind(':') {
+        Some(idx)
+            if authority[idx + 1..]
+                .chars()
+                .all(|c| c.is_ascii_digit() || c == '*') =>
+        {
+            (&authority[..idx], &authority[idx..])
+        }
+        _ => (authority, ""),
     };
 
-    format!("{}://{}", scheme, authority)
+    // IDN-canonicalise each label that does not contain a glob wildcard
+    // so `https://*.bücher.example` matches callbacks that
+    // `url::Url::parse` normalises to `https://shop.xn--bcher-kva.example`.
+    // Labels that contain `*` / `**` stay raw, otherwise we would break
+    // the glob. Purely ASCII labels pass through unchanged.
+    let canonical_host: String = host
+        .split('.')
+        .map(|label| {
+            if label.contains('*') || label.is_ascii() {
+                label.to_ascii_lowercase()
+            } else {
+                idna::domain_to_ascii(label).unwrap_or_else(|_| label.to_ascii_lowercase())
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(".");
+
+    // Strip default ports for http/https to match `extract_origin`.
+    let port_suffix = match (scheme.as_str(), port_suffix) {
+        ("http", ":80") | ("https", ":443") => "",
+        _ => port_suffix,
+    };
+
+    format!("{}://{}{}", scheme, canonical_host, port_suffix)
 }
 
 /// Detect attacker-controlled authority smuggling in a redirect target.
@@ -926,6 +954,25 @@ mod tests {
         // But well-formed http(s) and relative paths still pass.
         assert!(cfg.is_redirect_target_trusted("/dashboard"));
         assert!(cfg.is_redirect_target_trusted("https://evil.com/cb"));
+    }
+
+    #[test]
+    fn trusted_origins_wildcard_idn_matches_punycode_callback() {
+        // A wildcard pattern with a Unicode label should still match a
+        // callback origin that `url::Url::parse` canonicalises to
+        // punycode. Wildcard labels themselves are preserved verbatim.
+        let cfg = config_with(vec!["https://*.bücher.example"]);
+        assert!(cfg.is_origin_trusted("https://shop.xn--bcher-kva.example"));
+        assert!(cfg.is_redirect_target_trusted("https://shop.xn--bcher-kva.example/path"));
+    }
+
+    #[test]
+    fn trusted_origins_pattern_lowercases_scheme_and_host() {
+        // `url::Url::origin()` lowercases scheme + host; patterns typed
+        // with mixed case should still match.
+        let cfg = config_with(vec!["HTTPS://APP.Example.COM"]);
+        assert!(cfg.is_origin_trusted("https://app.example.com"));
+        assert!(cfg.is_redirect_target_trusted("https://app.example.com/x"));
     }
 
     #[test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -582,6 +582,36 @@ impl AuthConfig {
     pub fn is_path_disabled(&self, path: &str) -> bool {
         self.disabled_paths.iter().any(|disabled| disabled == path)
     }
+
+    /// Check whether `target` is safe to use as the value of a server-issued
+    /// redirect (302 `Location`) or an absolute link embedded in an outgoing
+    /// email. Safe targets are:
+    ///
+    /// - any value when `advanced.disable_origin_check` is enabled;
+    /// - relative paths starting with `/` (but not protocol-relative `//...`);
+    /// - absolute URLs whose origin matches [`base_url`](Self::base_url) or a
+    ///   [`trusted_origins`](Self::trusted_origins) pattern.
+    ///
+    /// Prevents open-redirect via user-supplied `callbackURL` / `redirectTo`.
+    pub fn is_redirect_target_trusted(&self, target: &str) -> bool {
+        if self.advanced.disable_origin_check {
+            return true;
+        }
+        // Protocol-relative URLs (//evil.com/...) must never be treated as
+        // same-origin; the browser resolves them against the current origin's
+        // scheme but the host is attacker-controlled.
+        if target.starts_with("//") {
+            return false;
+        }
+        if target.starts_with('/') {
+            return true;
+        }
+        match extract_origin(target) {
+            Some(origin) => self.is_origin_trusted(&origin),
+            None => false,
+        }
+    }
+
     pub fn validate(&self) -> Result<(), AuthError> {
         if self.secret.is_empty() {
             return Err(AuthError::config("Secret key cannot be empty"));
@@ -618,4 +648,64 @@ pub fn extract_origin(url: &str) -> Option<String> {
     let host_end = rest.find('/').unwrap_or(rest.len());
     let origin = format!("{}{}", &url[..scheme_end + 3], &rest[..host_end]);
     Some(origin)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_with(trusted: Vec<&str>) -> AuthConfig {
+        AuthConfig {
+            base_url: "https://app.example.com".into(),
+            trusted_origins: trusted.into_iter().map(String::from).collect(),
+            ..AuthConfig::default()
+        }
+    }
+
+    #[test]
+    fn redirect_target_allows_relative_path() {
+        let cfg = config_with(vec![]);
+        assert!(cfg.is_redirect_target_trusted("/dashboard"));
+        assert!(cfg.is_redirect_target_trusted("/reset-password?token=abc"));
+    }
+
+    #[test]
+    fn redirect_target_rejects_protocol_relative() {
+        let cfg = config_with(vec![]);
+        assert!(!cfg.is_redirect_target_trusted("//evil.com/x"));
+        assert!(!cfg.is_redirect_target_trusted("//evil.com"));
+    }
+
+    #[test]
+    fn redirect_target_allows_base_url_origin() {
+        let cfg = config_with(vec![]);
+        assert!(cfg.is_redirect_target_trusted("https://app.example.com/dashboard"));
+    }
+
+    #[test]
+    fn redirect_target_allows_trusted_origin() {
+        let cfg = config_with(vec!["https://admin.example.com"]);
+        assert!(cfg.is_redirect_target_trusted("https://admin.example.com/callback"));
+    }
+
+    #[test]
+    fn redirect_target_rejects_untrusted_origin() {
+        let cfg = config_with(vec!["https://admin.example.com"]);
+        assert!(!cfg.is_redirect_target_trusted("https://evil.com/cb"));
+    }
+
+    #[test]
+    fn redirect_target_rejects_unparseable_absolute() {
+        let cfg = config_with(vec![]);
+        assert!(!cfg.is_redirect_target_trusted("javascript:alert(1)"));
+        assert!(!cfg.is_redirect_target_trusted("data:text/html,x"));
+    }
+
+    #[test]
+    fn redirect_target_bypass_when_disable_origin_check() {
+        let mut cfg = config_with(vec![]);
+        cfg.advanced.disable_origin_check = true;
+        assert!(cfg.is_redirect_target_trusted("https://evil.com/cb"));
+        assert!(cfg.is_redirect_target_trusted("//evil.com"));
+    }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -640,6 +640,25 @@ impl AuthConfig {
         }
     }
 
+    /// Stricter variant of [`is_redirect_target_trusted`] that requires
+    /// an absolute `http`/`https` URL. Use this for `callbackURL` values
+    /// that are **embedded in an email body** or **forwarded to an OAuth
+    /// provider as `redirect_uri`** — in both contexts a relative path
+    /// produces a broken link (mail clients have no base URL to resolve
+    /// against; OAuth spec requires absolute URIs).
+    ///
+    /// For server-issued `Location` redirects (GET handlers reached via
+    /// email link clicks), relative paths are fine; use the less strict
+    /// [`is_redirect_target_trusted`] there.
+    pub fn is_absolute_trusted_callback_url(&self, target: &str) -> bool {
+        if !self.is_redirect_target_trusted(target) {
+            return false;
+        }
+        // `extract_origin` returns `Some(_)` only for well-formed http/https
+        // absolute URLs; relative paths return `None`.
+        extract_origin(target).is_some()
+    }
+
     pub fn validate(&self) -> Result<(), AuthError> {
         if self.secret.is_empty() {
             return Err(AuthError::config("Secret key cannot be empty"));
@@ -994,6 +1013,27 @@ mod tests {
         let cfg = config_with(vec!["https://bücher.example"]);
         assert!(cfg.is_origin_trusted("https://xn--bcher-kva.example"));
         assert!(cfg.is_redirect_target_trusted("https://xn--bcher-kva.example/book"));
+    }
+
+    #[test]
+    fn absolute_trusted_callback_url_rejects_relative_paths() {
+        // Relative paths are fine for server-issued 302 Location headers
+        // but break when embedded in an email body (mail clients have no
+        // base URL) or forwarded to an OAuth provider as `redirect_uri`
+        // (spec requires absolute). The stricter helper must reject
+        // them even when the origin check would otherwise accept.
+        let cfg = config_with(vec!["https://admin.example.com"]);
+        // Still accepted by the looser redirect helper…
+        assert!(cfg.is_redirect_target_trusted("/dashboard"));
+        // …but not by the email / OAuth helper.
+        assert!(!cfg.is_absolute_trusted_callback_url("/dashboard"));
+        assert!(!cfg.is_absolute_trusted_callback_url("/reset?token=x"));
+        // Absolute trusted URL passes both.
+        assert!(cfg.is_absolute_trusted_callback_url("https://admin.example.com/cb"));
+        // Absolute untrusted URL rejected by both.
+        assert!(!cfg.is_absolute_trusted_callback_url("https://evil.com/cb"));
+        // Non-http schemes rejected by both.
+        assert!(!cfg.is_absolute_trusted_callback_url("javascript:alert(1)"));
     }
 
     #[test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -563,10 +563,12 @@ impl AuthConfig {
     ///    extracting the origin portion from the pattern).
     ///
     /// Glob patterns are supported — `*` matches any characters except `/`,
-    /// `**` matches any characters including `/`. Patterns containing `*`
-    /// are parsed using naive string splitting rather than the strict
-    /// WHATWG URL parser so that `http://localhost:*` and `*://app.com`
-    /// keep working.
+    /// `**` matches any characters including `/`. Non-wildcard patterns
+    /// are parsed with the strict WHATWG URL parser so scheme, host, and
+    /// default port match exactly what runtime callback URLs normalise
+    /// to. Wildcard patterns fall back to naïve scheme/authority
+    /// splitting so `http://localhost:*` and `*://app.com` still work;
+    /// their non-wildcard host labels are still IDN-canonicalised.
     pub fn is_origin_trusted(&self, origin: &str) -> bool {
         // Check base_url origin
         if let Some(base_origin) = extract_origin(&self.base_url)
@@ -791,6 +793,15 @@ fn is_authority_smuggling(target: &str) -> bool {
     {
         return true;
     }
+    // Percent-encoded `/` and `\` in the authority-start position let a
+    // double-decoding proxy (some nginx configurations, some CDNs) see
+    // `//evil.com` or `/\evil.com` after the first decode pass while
+    // the Rust-side string still looks like a harmless path. Defence in
+    // depth: reject the encoded forms too.
+    let encoded_bypass = ["/%2f", "/%2F", "/%5c", "/%5C", "%2f", "%2F", "%5c", "%5C"];
+    if encoded_bypass.iter().any(|p| trimmed.starts_with(p)) {
+        return true;
+    }
     false
 }
 
@@ -983,6 +994,20 @@ mod tests {
         let cfg = config_with(vec!["https://bücher.example"]);
         assert!(cfg.is_origin_trusted("https://xn--bcher-kva.example"));
         assert!(cfg.is_redirect_target_trusted("https://xn--bcher-kva.example/book"));
+    }
+
+    #[test]
+    fn redirect_target_rejects_percent_encoded_authority_bypass() {
+        // Double-decoding proxies can turn `/%2Fevil.com` into
+        // `//evil.com` before the next hop sees it; reject the
+        // percent-encoded forms so the extra decode pass can't
+        // rehydrate an authority smuggler.
+        let cfg = config_with(vec![]);
+        assert!(!cfg.is_redirect_target_trusted("/%2Fevil.com"));
+        assert!(!cfg.is_redirect_target_trusted("/%2fevil.com"));
+        assert!(!cfg.is_redirect_target_trusted("/%5Cevil.com"));
+        assert!(!cfg.is_redirect_target_trusted("/%5cevil.com"));
+        assert!(!cfg.is_redirect_target_trusted("%2Fevil.com"));
     }
 
     #[test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -563,7 +563,10 @@ impl AuthConfig {
     ///    extracting the origin portion from the pattern).
     ///
     /// Glob patterns are supported — `*` matches any characters except `/`,
-    /// `**` matches any characters including `/`.
+    /// `**` matches any characters including `/`. Patterns containing `*`
+    /// are parsed using naive string splitting rather than the strict
+    /// WHATWG URL parser so that `http://localhost:*` and `*://app.com`
+    /// keep working.
     pub fn is_origin_trusted(&self, origin: &str) -> bool {
         // Check base_url origin
         if let Some(base_origin) = extract_origin(&self.base_url)
@@ -573,7 +576,7 @@ impl AuthConfig {
         }
         // Check trusted_origins patterns
         self.trusted_origins.iter().any(|pattern| {
-            let pattern_origin = extract_origin(pattern).unwrap_or_default();
+            let pattern_origin = extract_pattern_origin(pattern);
             glob_match::glob_match(&pattern_origin, origin)
         })
     }
@@ -601,6 +604,16 @@ impl AuthConfig {
     /// rejected. Prevents open-redirect via user-supplied `callbackURL`
     /// / `redirectTo`.
     pub fn is_redirect_target_trusted(&self, target: &str) -> bool {
+        // Reject control characters (CR/LF, NUL, TAB, etc.) and the
+        // double-quote character outright. Any of them would let the
+        // caller break out of the Location header or the surrounding
+        // email-HTML `href="..."` attribute once this value is
+        // interpolated by a downstream `format!`. WHATWG URL parsers
+        // strip most of these silently but our callers treat the string
+        // as opaque, so the guard must live here.
+        if target.chars().any(|c| c.is_control() || c == '"') {
+            return false;
+        }
         // Authority smuggling must NEVER be accepted, even under
         // `disable_origin_check`. That flag is an opt-out of same-origin
         // checks, not a licence to let the caller pick the host.
@@ -669,6 +682,22 @@ pub fn extract_origin(url: &str) -> Option<String> {
         ::url::Origin::Tuple(..) => Some(parsed.origin().ascii_serialization()),
         ::url::Origin::Opaque(_) => None,
     }
+}
+
+/// Naïve origin extractor used only for matching `trusted_origins`
+/// patterns. Unlike [`extract_origin`] this does not invoke a strict URL
+/// parser, so glob patterns with non-RFC characters (`*`, wildcard
+/// ports) survive. For any value an operator is likely to configure —
+/// `https://*.example.com`, `http://localhost:*`, `*://app.com` — we
+/// return the `"scheme://authority"` prefix unchanged and let
+/// `glob_match` do the final comparison.
+fn extract_pattern_origin(pattern: &str) -> String {
+    let Some(scheme_end) = pattern.find("://") else {
+        return String::new();
+    };
+    let rest = &pattern[scheme_end + 3..];
+    let host_end = rest.find('/').unwrap_or(rest.len());
+    format!("{}{}", &pattern[..scheme_end + 3], &rest[..host_end])
 }
 
 /// Detect attacker-controlled authority smuggling in a redirect target.
@@ -815,5 +844,35 @@ mod tests {
         assert!(cfg.is_redirect_target_trusted("https://admin.example.com:8443/x"));
         // Different port → not the same origin.
         assert!(!cfg.is_redirect_target_trusted("https://admin.example.com/x"));
+    }
+
+    #[test]
+    fn redirect_target_rejects_control_chars_and_quotes() {
+        // CR/LF would split a Location header; `"` would break out of
+        // an `href="..."` attribute in the rendered email.
+        let cfg = config_with(vec![]);
+        assert!(!cfg.is_redirect_target_trusted("/path\r\nEvil-Header: x"));
+        assert!(!cfg.is_redirect_target_trusted("/path\nEvil: x"));
+        assert!(!cfg.is_redirect_target_trusted("/path\"><script>"));
+        assert!(!cfg.is_redirect_target_trusted("/path\u{0000}null"));
+        assert!(!cfg.is_redirect_target_trusted("https://app.example.com/x\r\n"));
+    }
+
+    #[test]
+    fn trusted_origins_supports_port_and_scheme_globs() {
+        // Regression for switching extract_origin to url::Url::parse —
+        // `http://localhost:*` and similar wildcard patterns must stay
+        // usable. Strict URL parsing would reject them.
+        let cfg = config_with(vec![
+            "http://localhost:*",
+            "https://*.example.com",
+            "*://api.staging.test",
+        ]);
+        assert!(cfg.is_origin_trusted("http://localhost:3000"));
+        assert!(cfg.is_origin_trusted("http://localhost:8080"));
+        assert!(cfg.is_origin_trusted("https://app.example.com"));
+        assert!(cfg.is_origin_trusted("http://api.staging.test"));
+        assert!(cfg.is_origin_trusted("https://api.staging.test"));
+        assert!(!cfg.is_origin_trusted("http://localhost.evil.com"));
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -691,13 +691,29 @@ pub fn extract_origin(url: &str) -> Option<String> {
 /// `https://*.example.com`, `http://localhost:*`, `*://app.com` — we
 /// return the `"scheme://authority"` prefix unchanged and let
 /// `glob_match` do the final comparison.
+///
+/// Default ports (`:80` for `http`, `:443` for `https`) are stripped so
+/// that a pattern like `https://admin.example.com:443` still matches the
+/// origin produced by `extract_origin("https://admin.example.com/x")`,
+/// which is `https://admin.example.com` — `url::Url::origin()` omits
+/// default ports per the WHATWG URL spec.
 fn extract_pattern_origin(pattern: &str) -> String {
     let Some(scheme_end) = pattern.find("://") else {
         return String::new();
     };
+    let scheme = &pattern[..scheme_end];
     let rest = &pattern[scheme_end + 3..];
     let host_end = rest.find('/').unwrap_or(rest.len());
-    format!("{}{}", &pattern[..scheme_end + 3], &rest[..host_end])
+    let authority = &rest[..host_end];
+
+    // Strip default ports for http/https to match `extract_origin`.
+    let authority = match scheme {
+        "http" => authority.strip_suffix(":80").unwrap_or(authority),
+        "https" => authority.strip_suffix(":443").unwrap_or(authority),
+        _ => authority,
+    };
+
+    format!("{}://{}", scheme, authority)
 }
 
 /// Detect attacker-controlled authority smuggling in a redirect target.
@@ -712,15 +728,18 @@ fn extract_pattern_origin(pattern: &str) -> String {
 /// forms even when origin checks are otherwise disabled.
 fn is_authority_smuggling(target: &str) -> bool {
     let trimmed = target.trim_start_matches(|c: char| c.is_whitespace());
-    if trimmed.starts_with("//") || trimmed.starts_with(r"\\") {
+    // Any leading backslash is suspect. Browsers normalise `\` to `/` in
+    // the authority state, so `\evil.com`, `\\evil.com`, and `\/evil.com`
+    // all resolve to different attacker-controllable targets depending on
+    // the surrounding context. Reject the whole class up-front rather
+    // than enumerating every two-character combination.
+    if trimmed.starts_with('\\') {
+        return true;
+    }
+    if trimmed.starts_with("//") {
         return true;
     }
     if let Some(rest) = trimmed.strip_prefix('/')
-        && (rest.starts_with('/') || rest.starts_with('\\'))
-    {
-        return true;
-    }
-    if let Some(rest) = trimmed.strip_prefix('\\')
         && (rest.starts_with('/') || rest.starts_with('\\'))
     {
         return true;
@@ -856,6 +875,33 @@ mod tests {
         assert!(!cfg.is_redirect_target_trusted("/path\"><script>"));
         assert!(!cfg.is_redirect_target_trusted("/path\u{0000}null"));
         assert!(!cfg.is_redirect_target_trusted("https://app.example.com/x\r\n"));
+    }
+
+    #[test]
+    fn trusted_origins_with_explicit_default_ports_still_match() {
+        // `url::Url::origin` strips `:443` / `:80`; `extract_pattern_origin`
+        // now does the same so a `trusted_origins` entry that spells out
+        // the default port still matches callbacks that don't.
+        let cfg = config_with(vec![
+            "https://admin.example.com:443",
+            "http://legacy.example.com:80",
+        ]);
+        assert!(cfg.is_origin_trusted("https://admin.example.com"));
+        assert!(cfg.is_origin_trusted("http://legacy.example.com"));
+        assert!(cfg.is_redirect_target_trusted("https://admin.example.com/cb"));
+        assert!(cfg.is_redirect_target_trusted("http://legacy.example.com/cb"));
+    }
+
+    #[test]
+    fn redirect_target_rejects_bare_backslash_under_disable_origin_check() {
+        // `\evil.com` is normalised by browsers to path-start + "/evil.com"
+        // — same-origin in practice, but the authority-smuggling guard's
+        // documented contract ("even under disable_origin_check, the
+        // caller cannot pick the host") must hold.
+        let mut cfg = config_with(vec![]);
+        cfg.advanced.disable_origin_check = true;
+        assert!(!cfg.is_redirect_target_trusted("\\evil.com"));
+        assert!(!cfg.is_redirect_target_trusted("  \\evil.com"));
     }
 
     #[test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -621,7 +621,13 @@ impl AuthConfig {
             return false;
         }
         if self.advanced.disable_origin_check {
-            return true;
+            // Even with origin checks disabled, reject non-http(s) URLs.
+            // `javascript:`, `data:`, `file:`, and other schemes would
+            // execute in the caller's browser / expose local files if
+            // reflected into a Location header. Relative paths and
+            // well-formed http/https URLs are allowed; `extract_origin`
+            // already filters the unsafe schemes.
+            return target.starts_with('/') || extract_origin(target).is_some();
         }
         if target.starts_with('/') {
             return true;
@@ -698,6 +704,19 @@ pub fn extract_origin(url: &str) -> Option<String> {
 /// which is `https://admin.example.com` — `url::Url::origin()` omits
 /// default ports per the WHATWG URL spec.
 fn extract_pattern_origin(pattern: &str) -> String {
+    // When the pattern is a well-formed absolute URL with no glob
+    // wildcards, round-trip it through `extract_origin` so the result
+    // uses exactly the same normalisation (punycode host, lower-case
+    // scheme, omitted default port) as the runtime origin comparisons
+    // produced by `url::Url::parse`. Otherwise (bare hostnames, glob
+    // wildcards like `http://localhost:*`, non-http schemes, …) fall
+    // back to a naïve scheme://authority split so wildcards survive.
+    if !pattern.contains('*')
+        && let Some(canonical) = extract_origin(pattern)
+    {
+        return canonical;
+    }
+
     let Some(scheme_end) = pattern.find("://") else {
         return String::new();
     };
@@ -890,6 +909,33 @@ mod tests {
         assert!(cfg.is_origin_trusted("http://legacy.example.com"));
         assert!(cfg.is_redirect_target_trusted("https://admin.example.com/cb"));
         assert!(cfg.is_redirect_target_trusted("http://legacy.example.com/cb"));
+    }
+
+    #[test]
+    fn redirect_target_bypass_still_rejects_dangerous_schemes() {
+        // `disable_origin_check = true` opts out of origin comparison
+        // but MUST NOT open the gate to `javascript:`, `data:`,
+        // `file:`, or other non-http schemes — the rustdoc promises
+        // those are always rejected.
+        let mut cfg = config_with(vec![]);
+        cfg.advanced.disable_origin_check = true;
+        assert!(!cfg.is_redirect_target_trusted("javascript:alert(1)"));
+        assert!(!cfg.is_redirect_target_trusted("data:text/html,<script>x</script>"));
+        assert!(!cfg.is_redirect_target_trusted("file:///etc/passwd"));
+        assert!(!cfg.is_redirect_target_trusted("ftp://example.com/"));
+        // But well-formed http(s) and relative paths still pass.
+        assert!(cfg.is_redirect_target_trusted("/dashboard"));
+        assert!(cfg.is_redirect_target_trusted("https://evil.com/cb"));
+    }
+
+    #[test]
+    fn trusted_origins_punycode_idn_matches_punycode_callback() {
+        // `url::Url` converts IDN hosts to punycode. A pattern that
+        // spells the domain in Unicode should still match a callback
+        // URL that the parser normalises to `xn--...`.
+        let cfg = config_with(vec!["https://bücher.example"]);
+        assert!(cfg.is_origin_trusted("https://xn--bcher-kva.example"));
+        assert!(cfg.is_redirect_target_trusted("https://xn--bcher-kva.example/book"));
     }
 
     #[test]

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -86,6 +86,7 @@ pub struct Account {
     #[serde(rename = "refreshTokenExpiresAt")]
     pub refresh_token_expires_at: Option<DateTime<Utc>>,
     pub scope: Option<String>,
+    #[serde(skip_serializing, default)]
     pub password: Option<String>,
     #[serde(rename = "createdAt")]
     pub created_at: DateTime<Utc>,
@@ -654,4 +655,53 @@ pub struct ListUsersParams {
     pub filter_field: Option<String>,
     pub filter_value: Option<String>,
     pub filter_operator: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn account_password_is_never_serialized() {
+        let account = Account {
+            id: "a".into(),
+            account_id: "b".into(),
+            provider_id: "credential".into(),
+            user_id: "u".into(),
+            access_token: None,
+            refresh_token: None,
+            id_token: None,
+            access_token_expires_at: None,
+            refresh_token_expires_at: None,
+            scope: None,
+            password: Some("argon2$v=19$m=19456,t=2,p=1$xxxx".into()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        let json = serde_json::to_value(&account).unwrap();
+        assert!(
+            json.get("password").is_none(),
+            "password must never appear in serialized Account JSON; got: {json}"
+        );
+    }
+
+    #[test]
+    fn account_deserializes_without_password_field() {
+        let json = serde_json::json!({
+            "id": "a",
+            "accountId": "b",
+            "providerId": "google",
+            "userId": "u",
+            "accessToken": null,
+            "refreshToken": null,
+            "idToken": null,
+            "accessTokenExpiresAt": null,
+            "refreshTokenExpiresAt": null,
+            "scope": null,
+            "createdAt": "2025-01-01T00:00:00Z",
+            "updatedAt": "2025-01-01T00:00:00Z",
+        });
+        let account: Account = serde_json::from_value(json).unwrap();
+        assert!(account.password.is_none());
+    }
 }


### PR DESCRIPTION
## Summary

Close the open-redirect and deep-defense gaps that currently exist on master. Implemented independently of PR #56 so master does not have to wait on the schema-native refactor.

- Introduce `AuthConfig::is_redirect_target_trusted` (complements the existing `is_origin_trusted`) and make every handler that builds a 302 Location or embeds a URL in an outgoing email go through it.
- Start respecting `advanced.disable_origin_check`, which was defined but never read.
- Stop serializing `Account.password` (bcrypt/argon2 hash). Today no handler leaks it, but the struct derives `Serialize`; this is defense in depth.

## What changed

**`crates/core/src/config.rs`** — new `is_redirect_target_trusted(target)` helper:

- relative paths (`/reset`): allowed
- protocol-relative (`//evil.com/x`): rejected
- absolute URLs: allowed only if origin matches `base_url` or a `trusted_origins` pattern
- any value: allowed when `advanced.disable_origin_check` is set

**Handler changes** — all consume the helper:

| Endpoint | Policy on untrusted callback | Rationale |
| --- | --- | --- |
| `GET /verify-email` | Silent fallback to JSON | User-initiated email click; friendlier than 400 |
| `POST /send-verification-email` | 400 | Backend-initiated; caller must fix config |
| `POST /change-email` | 400 | Same as above |
| `POST /forget-password` | Fall back to server base URL | Preserves existing behavior but now honours `trusted_origins` + `disable_origin_check` |
| `GET /reset-password/:token` | Drop callback before redirect | Prevents open redirect **and** reset-token exfiltration |
| `POST /sign-in/social`, `POST /link-social` | 400 | Stricter than upstream TS; see **breaking change** below |

**`crates/core/src/types.rs`** — `Account.password` gains `#[serde(skip_serializing, default)]`.

## Breaking change (OAuth callback)

`POST /sign-in/social` and `POST /link-social` now reject untrusted `callbackURL`. Upstream TypeScript `better-auth` does not validate at this point. If your deployment relies on a cross-subdomain OAuth callback (e.g. `auth.app.com` initiates, `accounts.app.com/cb` completes), add the callback origin to `trusted_origins` or set `advanced.disable_origin_check = true`. No existing test in this repo exercised a cross-origin path.

## Commits

- `5b6b96b` `feat(core): add AuthConfig::is_redirect_target_trusted helper`
- `4c825db` `fix(core): never serialize Account.password`
- `5f111bb` `fix(security): validate callbackURL on redirect and email-link surfaces`
- `dcc29ad` `fix(security): require trusted origin for OAuth callback_url`

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace --lib` — 293 passed
- [x] `cargo test --workspace --tests` — all green

New coverage:

- `config::tests::redirect_target_*` (7 cases: relative, protocol-relative, base_url, trusted_origins, untrusted, unparseable, disable_origin_check bypass)
- `types::tests::account_password_is_never_serialized`
- `types::tests::account_deserializes_without_password_field`
- `email_verification::tests::test_verify_email_rejects_untrusted_callback_url`
- `email_verification::tests::test_send_verification_email_rejects_untrusted_callback_url`
- `password_management::tests::test_reset_password_token_rejects_untrusted_callback_url`
- `user_management::tests::test_change_email_rejects_untrusted_callback_url`

Two existing tests (`test_verify_email_auto_sign_in_redirect_includes_cookie`, `test_verify_email_redirect_without_auto_sign_in_no_cookie`) were updated to add `myapp.com` to `trusted_origins` — previously they implicitly asserted the (insecure) "accept any callback" behavior.

## Notes

Related to PR #56 reviews (Codex P1/P2 and @AprilNEA CHANGES_REQUESTED). Implemented without any of the PR #56 abstractions (`wire::*`, `AuthSchema`, `AccountView`) so it can land independently on master.

OAuth handler coverage here is unit-test-only on the rejection path; end-to-end flow remains covered by existing integration tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes two security gaps on master: an open-redirect vulnerability on every handler that builds a `302 Location` or embeds a URL in an outgoing email, and defense-in-depth leakage of the `Account.password` bcrypt/argon2 hash through the `Serialize` derive.

**Key changes:**
- New `AuthConfig::is_redirect_target_trusted` and `is_absolute_trusted_callback_url` helpers centralise all callback-URL validation with layered checks: control-char/quote stripping → authority-smuggling detection (protocol-relative, backslash variants, percent-encoded `%2f`/`%5c`) → non-http/https scheme rejection (even under `disable_origin_check`) → origin comparison against `base_url` + `trusted_origins`.
- Every handler that redirects or sends email now uses one of these helpers with the correct strictness: the looser `is_redirect_target_trusted` (allows relative paths) for server-issued `302` redirects; the stricter `is_absolute_trusted_callback_url` (requires absolute http/https) for email `href` values and OAuth `redirect_uri` forwarding.
- `Account.password` gains `#[serde(skip_serializing, default)]` — the hash no longer appears in any serialized response while DB deserialization continues to work.
- `advanced.disable_origin_check` is now actually honoured (it was previously defined but never read).
- 20+ new unit tests covering all the edge cases, plus two existing redirect tests updated to reflect the now-correct same-origin policy.

<h3>Confidence Score: 5/5</h3>

All previously raised P0/P1 security concerns have been addressed in the subsequent round-2 commits; the implementation is correct, well-tested, and safe to merge.

Every concern from the prior review threads was resolved: non-http/https schemes are now blocked even under `disable_origin_check`; relative callback URLs are rejected for email/OAuth contexts via `is_absolute_trusted_callback_url`; the bare backslash authority-smuggling bypass is caught; the duplicate dead guard in `change_email_core` was dropped. The two-layer trust model (`is_redirect_target_trusted` vs `is_absolute_trusted_callback_url`) is correctly applied at every call site, the WHATWG URL parser prevents userinfo/query-string authority spoofing, IDN normalization is handled, and 293 tests pass. No new issues were found in this review pass.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/core/src/config.rs | Adds `is_redirect_target_trusted`, `is_absolute_trusted_callback_url`, `extract_origin` (WHATWG URL parser), `extract_pattern_origin` (glob/IDN-aware), and `is_authority_smuggling` — the validation core for this PR; well-tested with 20+ unit cases including scheme blocks, backslash bypasses, percent-encoded bypasses, IDN normalization, and `disable_origin_check` interaction. |
| crates/core/src/types.rs | Adds `#[serde(skip_serializing, default)]` to `Account.password`; correct — `default` allows deserialization from DB rows that lack or include the column while the serialize skip prevents password hash exposure in API responses. |
| crates/api/src/plugins/email_verification/handlers.rs | POST send-verification-email validates with `is_absolute_trusted_callback_url` (email body requires absolute URL); GET verify-email uses the looser `is_redirect_target_trusted` with silent fallback — correct asymmetry since a GET is a user-clicked link where a hard 400 would be unfriendly. |
| crates/api/src/plugins/oauth/handlers.rs | `social_sign_in_core` and `link_social_core` both use `is_absolute_trusted_callback_url` — correctly stricter than the base redirect validator since OAuth providers require absolute `redirect_uri`; relative paths are rejected early before an orphaned OAuth state row is created. |
| crates/api/src/plugins/password_management/handlers.rs | `forget_password_core` uses `is_absolute_trusted_callback_url` with silent fallback (preserves email enumeration protection); `reset_password_token_core` uses the looser `is_redirect_target_trusted` with silent fallback (correct — it's a server-issued Location redirect); both handle untrusted values before any DB token creation. |
| crates/api/src/plugins/user_management/handlers.rs | `change_email_core` validates with `is_absolute_trusted_callback_url` before any DB work including the `update_without_verification` path — intentional API-contract stability even when the field isn't consumed; previous duplicate guard removed per thread reply. |
| crates/api/src/plugins/email_password.rs | `sign_up_core` and `sign_in_core` both validate `callbackURL` with `is_absolute_trusted_callback_url`; `sign_in_with_user_core` adds a redundant defence-in-depth check (well-documented comment) so callers invoked directly with a raw URL can't bypass the guard. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[callbackURL supplied] --> B{Control chars\nor double-quote?}
    B -->|yes| REJECT[Return false / 400]
    B -->|no| C{Authority\nsmuggling?\n// or backslash\nor %2f/%5c prefix}
    C -->|yes| REJECT
    C -->|no| D{disable_origin_check\n= true?}
    D -->|yes| E{Starts with /\nor extract_origin\nreturns Some?}
    E -->|no = non-http scheme| REJECT
    E -->|yes| PASS[Return true]
    D -->|no| F{Starts with /\nrelative path?}
    F -->|yes| G{is_absolute_trusted\n_callback_url mode?}
    G -->|strict - email/OAuth| REJECT
    G -->|loose - Location redirect| PASS
    F -->|no| H{extract_origin\nreturns Some?}
    H -->|no = non-http scheme| REJECT
    H -->|yes| I{is_origin_trusted?\nmatches base_url\nor trusted_origins}
    I -->|no| REJECT
    I -->|yes| PASS

    style REJECT fill:#f66,color:#fff
    style PASS fill:#6a6,color:#fff
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/api/src/plugins/email_verification/handlers.rs`, line 54-61 ([link](https://github.com/better-auth-rs/better-auth-rs/blob/a98d50092c355804a6bf43d691519cb6f5d8142a/crates/api/src/plugins/email_verification/handlers.rs#L54-L61)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Double question-mark when callback URL already has query parameters**

   The URL is built by unconditionally appending a question-mark separator and then the token value to the callback URL. When the caller supplies a callback URL that already contains a query string, the resulting URL ends up with two question-mark characters. Standard URL parsers treat everything after the first question-mark as the query string, so the appended token parameter will not be individually extractable — silently breaking the verification flow for those users.

   The same construction pattern appears in `forget_password_core` (password_management/handlers.rs lines 63-68), `reset_password_token_core` (lines 199 and 207), and the `create_verification_token` helper in user_management/handlers.rs (line 37).

   The fix is to check whether the callback URL already contains a question-mark before choosing the separator: use ampersand if it does, question-mark if it does not.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["fix(security): require absolute callback..."](https://github.com/better-auth-rs/better-auth-rs/commit/9a47a9a5dbee3922b57db48792dc257e1505b0bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28126669)</sub>

<!-- /greptile_comment -->