### PR TITLE
docs: add CONTRIBUTING.md and ROADMAP.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Install the TypeScript reference server used by the compatibility
 harness:
 
 ```bash
-cd compat-tests/reference-server && bun install
+cd compat-tests/reference-server && npm install
 ```
 
 A local checkout of https://github.com/better-auth/better-auth is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing
+
+This project targets strict 1:1 wire-level compatibility with the
+canonical TypeScript Better Auth implementation. The TypeScript runtime
+is the spec.
+
+The primary compatibility contract is behavior exercised by the official
+`better-auth/client` SDK and the TypeScript reference server. Routes,
+payloads, headers, cookies, redirects, status codes, and error behavior
+must match upstream.
+
+Rust does not need to mirror the TypeScript embedding interface. Public
+Rust APIs should follow native Rust ecosystem conventions for the
+integrations we support (Axum, sqlx), but those integrations are not
+themselves the compatibility contract.
+
+## Source of Truth
+
+When sources disagree, trust them in this order:
+
+1. Runtime behavior of the TypeScript reference server in
+   `compat-tests/reference-server/`
+2. TypeScript source in a local checkout of
+   https://github.com/better-auth/better-auth, when available
+3. Generated upstream OpenAPI profiles from the pinned published package
+4. Better Auth documentation
+
+The pinned reference version is `better-auth@1.4.19` (see
+`compat-tests/reference-server/package.json`).
+
+## Non-Negotiables
+
+- No extra public route, wire behavior, or client-observable capability
+  beyond upstream TS
+- No missing upstream route or behavior
+- No legacy Rust-only migration shims or compatibility paths
+- Rust-native integration APIs are allowed when they preserve the same
+  client-observable contract
+- If TS looks buggy, match it anyway and document that choice in code
+
+## Before You Change Code
+
+Install the TypeScript reference server used by the compatibility
+harness:
+
+```bash
+cd compat-tests/reference-server && bun install
+```
+
+A local checkout of https://github.com/better-auth/better-auth is
+useful for inspecting upstream source and runtime behavior.
+
+## Workflow
+
+1. Read the relevant phase in [ROADMAP.md](ROADMAP.md)
+2. Compare Rust behavior against the TS reference server
+3. Implement the smallest self-contained fix that removes the diff
+4. Add or update tests in the same change
+5. Do not batch unrelated endpoint fixes into one commit
+
+## Testing Strategy
+
+1. Rust unit tests: `cargo test --workspace --lib`
+2. Integration and compatibility tests against the pinned TS reference
+   server: `cargo test --workspace --tests`. See
+   [compat-tests/README.md](compat-tests/README.md) for how the
+   dual-server harness is wired.
+
+Compatibility coverage against the TypeScript reference server is the
+hard gate — endpoint behavior must match upstream.
+
+## Required Checks
+
+Before committing, these must pass:
+
+```bash
+cargo fmt --check
+cargo clippy --workspace
+cargo clippy --workspace --features axum
+cargo test --workspace --lib
+```
+
+Then run the phase-appropriate compatibility checks for the behavior you
+changed.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,85 @@
+# Alignment Roadmap
+
+This project targets strict 1:1 behavioral alignment with the
+[TypeScript better-auth](https://github.com/better-auth/better-auth)
+implementation (`better-auth@1.4.19`). Work is organized into
+self-contained phases, each covering a group of related endpoints.
+
+Phases are ordered so that each one only depends on capabilities from
+earlier phases. A phase is complete when every endpoint in it has
+Rust-side tests and dual-server (TS-vs-Rust) comparison coverage.
+
+Test suites, scripts, and source comments reference these phase numbers
+(e.g. `phase0`, `phase1`).
+
+## Phases
+
+**Phase 0 — Core auth flow:**
+`/sign-up/email`, `/sign-in/email`, `/get-session`, `/sign-out`,
+`/ok`, `/error`
+
+**Phase 1 — Session and password management:**
+`/list-sessions`, `/revoke-session`, `/revoke-sessions`,
+`/revoke-other-sessions`, `/refresh-token`, `/get-access-token`,
+`/request-password-reset`, `/reset-password`, `/change-password`
+
+**Phase 2 — User self-service and verification:**
+`/update-user`, `/delete-user`, `/delete-user/callback`,
+`/change-email`, `/send-verification-email`, `/verify-email`
+
+**Phase 3 — Social-linked account surface:**
+`/sign-in/social`, `/callback`, `/link-social`, `/list-accounts`,
+`/unlink-account`
+
+**Phase 4 — Machine auth and API-key CRUD:**
+Bearer behavior, `/api-key/create`, `/api-key/list`, `/api-key/get`,
+`/api-key/update`, `/api-key/delete`, `/api-key/verify`
+
+**Phase 5 — Organization core:**
+`/organization/create`, `/organization/check-slug`,
+`/organization/update`, `/organization/delete`,
+`/organization/get-full-organization`, `/organization/set-active`,
+`/organization/list`, `/organization/list-members`,
+`/organization/get-active-member`,
+`/organization/get-active-member-role`,
+`/organization/update-member-role`,
+`/organization/remove-member`, `/organization/leave`,
+`/organization/invite-member`,
+`/organization/accept-invitation`,
+`/organization/reject-invitation`,
+`/organization/cancel-invitation`,
+`/organization/get-invitation`,
+`/organization/list-invitations`,
+`/organization/list-user-invitations`,
+`/organization/has-permission`
+
+**Phase 6 — Admin core:**
+`/admin/list-users`, `/admin/create-user`, `/admin/remove-user`,
+`/admin/set-user-password`, `/admin/set-role`,
+`/admin/has-permission`
+
+**Phase 7 — Passkey surface:**
+All `/passkey/*` endpoints.
+
+**Phase 8 — Organization advanced:**
+`/organization/create-team`, `/organization/remove-team`,
+`/organization/update-team`, `/organization/list-teams`,
+`/organization/set-active-team`, `/organization/list-user-teams`,
+`/organization/list-team-members`,
+`/organization/add-team-member`,
+`/organization/remove-team-member`,
+`/organization/create-role`, `/organization/delete-role`,
+`/organization/list-roles`, `/organization/get-role`,
+`/organization/update-role`
+
+**Phase 9 — Admin extended support flows:**
+`/admin/get-user`, `/admin/update-user`, `/admin/ban-user`,
+`/admin/unban-user`, `/admin/impersonate-user`,
+`/admin/stop-impersonating`, `/admin/list-user-sessions`,
+`/admin/revoke-user-session`, `/admin/revoke-user-sessions`
+
+**Phase 10 — Two-factor authentication:**
+All `/two-factor/*` endpoints.
+
+**Phase 11 — Cold account and token surfaces:**
+`/verify-password`, `/update-session`, `/account-info`, `/token`


### PR DESCRIPTION
## Summary

Publish two project-policy documents extracted from the larger schema-native branch so they can land immediately on master:

- **CONTRIBUTING.md** — states the compatibility contract (TypeScript \`better-auth@1.4.19\` is the spec), the source-of-truth priority order, non-negotiable behavior rules, the change workflow, and the required check list.
- **ROADMAP.md** — phase-based endpoint alignment plan (Phase 0–11). Existing test suites and source comments already reference these phase numbers.

Zero code change. Pure additions.

## What was trimmed vs. the source branch

The \`refactor/app-owned-auth-schema\` branch introduces these files alongside a large refactor. On master we prune references that wouldn't resolve:

- Dropped \`compat-tests/client-tests/\` — doesn't exist on master yet
- Dropped \`cargo test --test wire_compat_smoke_tests\` and \`cargo test --test client_compat_tests phase0_client_compat\` — those binaries only exist on the refactor branch
- Replaced two hard-coded \`/home/peron/dev/...\` paths with generic wording pointing at the public upstream repo
- Changed the "integration surface" line from Axum + SeaORM to Axum + sqlx, matching what master actually ships

ROADMAP.md is copied verbatim — it's a pure endpoint list and doesn't reference any Rust symbols.

## Test plan

- [x] \`cargo doc --workspace --no-deps\` — no new warnings (pre-existing 3 warnings in \`better-auth-api\` unrelated)
- [x] Every command in CONTRIBUTING.md resolves to a real path/binary on master
- [x] Every internal link in CONTRIBUTING.md (\`ROADMAP.md\`, \`compat-tests/README.md\`) exists on master

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new documentation files — `CONTRIBUTING.md` and `ROADMAP.md` — to the master branch, extracted and trimmed from the `refactor/app-owned-auth-schema` branch. There are zero code changes.

- **`CONTRIBUTING.md`** establishes the project's compatibility contract (TypeScript `better-auth@1.4.19` is the spec), the source-of-truth priority order, non-negotiable behavioral rules, the contribution workflow, and the minimum required pre-commit checks. All referenced paths and commands resolve correctly on master.
- **`ROADMAP.md`** defines the phase-by-phase (Phase 0–11) endpoint alignment plan, matching phase labels already used in existing test files and source comments.

**Key findings:**
- All internal links (`ROADMAP.md`, `compat-tests/README.md`) exist on master ✓
- Pinned version `better-auth@1.4.19` matches `compat-tests/reference-server/package.json` ✓
- Package manager is consistently `npm` (aligned with the checked-in `package-lock.json`) ✓
- Minor gap: the \"Before You Change Code\" section instructs `npm install` but does not tell contributors to also run `npm start` before executing integration tests — addressed in the inline comment above.

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure documentation additions with no code changes and all referenced paths verified on master.

Zero code changes; both files are well-structured and accurate. All internal links, commands, and the pinned version number were verified against the repo. The one open item (missing npm start note) is a non-blocking P2 suggestion that doesn't affect correctness.

No files require special attention. CONTRIBUTING.md has a minor documentation gap around the reference-server start step.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CONTRIBUTING.md | New contributor guide covering the compatibility contract, source-of-truth priority, workflow, and required checks. All referenced paths exist on master and the pinned version matches package.json. Minor gap: setup section omits the npm start step needed before running integration tests. |
| ROADMAP.md | Phase-based endpoint alignment plan (Phase 0–11), copied verbatim from the refactor branch. Contains no Rust symbols or relative path references; content is accurate and self-contained. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Start: Contributor picks a task]) --> B[Read relevant phase in ROADMAP.md]
    B --> C[cd compat-tests/reference-server\nnpm install && npm start]
    C --> D[Compare Rust behavior vs TS reference server]
    D --> E[Implement smallest self-contained fix]
    E --> F[Add / update tests in same change]
    F --> G{Required checks}
    G --> G1[cargo fmt --check]
    G --> G2[cargo clippy --workspace]
    G --> G3[cargo clippy --workspace --features axum]
    G --> G4[cargo test --workspace --lib]
    G1 & G2 & G3 & G4 --> H[Run phase-appropriate compat checks\ncargo test --workspace --tests]
    H --> I{All green?}
    I -- No --> E
    I -- Yes --> J([Open PR])
```

<sub>Reviews (2): Last reviewed commit: ["docs(contributing): use npm to match ref..."](https://github.com/better-auth-rs/better-auth-rs/commit/f448e6e9cdde71a1a5e740b599cda4cba229d940) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28126670)</sub>

<!-- /greptile_comment -->