### PR TITLE
feat(core): introduce Cow-based ID accessors on AuthEntity traits

### DIFF
--- a/crates/api/src/plugins/account_management.rs
+++ b/crates/api/src/plugins/account_management.rs
@@ -56,7 +56,7 @@ pub(crate) async fn list_accounts_core<DB: DatabaseAdapter>(
     user: &DB::User,
     ctx: &AuthContext<DB>,
 ) -> AuthResult<Vec<AccountResponse>> {
-    let accounts = ctx.database.get_user_accounts(user.id()).await?;
+    let accounts = ctx.database.get_user_accounts(&user.id()).await?;
 
     let filtered: Vec<AccountResponse> = accounts
         .iter()
@@ -86,7 +86,7 @@ pub(crate) async fn unlink_account_core<DB: DatabaseAdapter>(
     provider_id: &str,
     ctx: &AuthContext<DB>,
 ) -> AuthResult<StatusResponse> {
-    let accounts = ctx.database.get_user_accounts(user.id()).await?;
+    let accounts = ctx.database.get_user_accounts(&user.id()).await?;
 
     let allow_unlinking_all = ctx.config.account.account_linking.allow_unlinking_all;
 
@@ -112,7 +112,7 @@ pub(crate) async fn unlink_account_core<DB: DatabaseAdapter>(
         .find(|acc| acc.provider_id() == provider_id)
         .ok_or_else(|| AuthError::not_found("No account found with this provider"))?;
 
-    ctx.database.delete_account(account_to_remove.id()).await?;
+    ctx.database.delete_account(&account_to_remove.id()).await?;
 
     Ok(StatusResponse { status: true })
 }

--- a/crates/api/src/plugins/admin/handlers.rs
+++ b/crates/api/src/plugins/admin/handlers.rs
@@ -332,7 +332,7 @@ pub(crate) async fn remove_user_core<DB: DatabaseAdapter>(
 
     let accounts = ctx.database.get_user_accounts(&body.user_id).await?;
     for account in &accounts {
-        ctx.database.delete_account(account.id()).await?;
+        ctx.database.delete_account(&account.id()).await?;
     }
 
     ctx.database.delete_user(&body.user_id).await?;
@@ -387,7 +387,7 @@ pub(crate) async fn set_user_password_core<DB: DatabaseAdapter>(
                     ..Default::default()
                 };
                 ctx.database
-                    .update_account(account.id(), account_update)
+                    .update_account(&account.id(), account_update)
                     .await?;
                 break;
             }

--- a/crates/api/src/plugins/admin/mod.rs
+++ b/crates/api/src/plugins/admin/mod.rs
@@ -173,7 +173,7 @@ impl AdminPlugin {
             Ok(v) => v,
             Err(resp) => return Ok(resp),
         };
-        let response = ban_user_core(&body, admin_user.id(), &self.config, ctx).await?;
+        let response = ban_user_core(&body, &admin_user.id(), &self.config, ctx).await?;
         AuthResponse::json(200, &response).map_err(AuthError::from)
     }
 
@@ -203,7 +203,7 @@ impl AdminPlugin {
         };
         let (response, token) = impersonate_user_core(
             &body,
-            admin_user.id(),
+            &admin_user.id(),
             req.headers.get("x-forwarded-for").map(|s| s.as_str()),
             req.headers.get("user-agent").map(|s| s.as_str()),
             ctx,
@@ -276,7 +276,7 @@ impl AdminPlugin {
             Ok(v) => v,
             Err(resp) => return Ok(resp),
         };
-        let response = remove_user_core(&body, admin_user.id(), ctx).await?;
+        let response = remove_user_core(&body, &admin_user.id(), ctx).await?;
         AuthResponse::json(200, &response).map_err(AuthError::from)
     }
 
@@ -331,7 +331,7 @@ mod axum_impl {
 
     async fn handle_set_role<DB: DatabaseAdapter>(
         State(state): State<AuthState<DB>>,
-        Extension(ps): Extension<Arc<PluginState>>,
+        Extension(_ps): Extension<Arc<PluginState>>,
         AdminSession { .. }: AdminSession<DB>,
         ValidatedJson(body): ValidatedJson<SetRoleRequest>,
     ) -> Result<Json<UserResponse<DB::User>>, AuthError> {
@@ -379,7 +379,7 @@ mod axum_impl {
         ValidatedJson(body): ValidatedJson<BanUserRequest>,
     ) -> Result<Json<UserResponse<DB::User>>, AuthError> {
         let ctx = state.to_context();
-        let response = ban_user_core(&body, user.id(), &ps.config, &ctx).await?;
+        let response = ban_user_core(&body, &user.id(), &ps.config, &ctx).await?;
         Ok(Json(response))
     }
 
@@ -405,7 +405,7 @@ mod axum_impl {
         AuthError,
     > {
         let ctx = state.to_context();
-        let (response, token) = impersonate_user_core(&body, user.id(), None, None, &ctx).await?;
+        let (response, token) = impersonate_user_core(&body, &user.id(), None, None, &ctx).await?;
         let cookie = state.session_cookie(&token);
         Ok(([(header::SET_COOKIE, cookie)], Json(response)))
     }
@@ -454,7 +454,7 @@ mod axum_impl {
         ValidatedJson(body): ValidatedJson<UserIdRequest>,
     ) -> Result<Json<SuccessResponse>, AuthError> {
         let ctx = state.to_context();
-        let response = remove_user_core(&body, user.id(), &ctx).await?;
+        let response = remove_user_core(&body, &user.id(), &ctx).await?;
         Ok(Json(response))
     }
 
@@ -469,7 +469,7 @@ mod axum_impl {
     }
 
     async fn handle_has_permission<DB: DatabaseAdapter>(
-        State(state): State<AuthState<DB>>,
+        State(_state): State<AuthState<DB>>,
         Extension(ps): Extension<Arc<PluginState>>,
         CurrentSession { user, .. }: CurrentSession<DB>,
         ValidatedJson(body): ValidatedJson<HasPermissionRequest>,

--- a/crates/api/src/plugins/api_key/mod.rs
+++ b/crates/api/src/plugins/api_key/mod.rs
@@ -486,7 +486,7 @@ impl ApiKeyPlugin {
             Ok(v) => v,
             Err(resp) => return Ok(resp),
         };
-        let response = create_key_core(&body, user.id(), self, ctx).await?;
+        let response = create_key_core(&body, &user.id(), self, ctx).await?;
         Ok(AuthResponse::json(200, &response)?)
     }
 
@@ -500,7 +500,7 @@ impl ApiKeyPlugin {
             .query
             .get("id")
             .ok_or_else(|| AuthError::bad_request("Query parameter 'id' is required"))?;
-        let response = get_key_core(id, user.id(), self, ctx).await?;
+        let response = get_key_core(id, &user.id(), self, ctx).await?;
         Ok(AuthResponse::json(200, &response)?)
     }
 
@@ -510,7 +510,7 @@ impl ApiKeyPlugin {
         ctx: &AuthContext<DB>,
     ) -> AuthResult<AuthResponse> {
         let (user, _session) = ctx.require_session(req).await?;
-        let response = list_keys_core(user.id(), self, ctx).await?;
+        let response = list_keys_core(&user.id(), self, ctx).await?;
         Ok(AuthResponse::json(200, &response)?)
     }
 
@@ -524,7 +524,7 @@ impl ApiKeyPlugin {
             Ok(v) => v,
             Err(resp) => return Ok(resp),
         };
-        let response = update_key_core(&body, user.id(), self, ctx).await?;
+        let response = update_key_core(&body, &user.id(), self, ctx).await?;
         Ok(AuthResponse::json(200, &response)?)
     }
 
@@ -538,7 +538,7 @@ impl ApiKeyPlugin {
             Ok(v) => v,
             Err(resp) => return Ok(resp),
         };
-        let response = delete_key_core(&body, user.id(), self, ctx).await?;
+        let response = delete_key_core(&body, &user.id(), self, ctx).await?;
         Ok(AuthResponse::json(200, &response)?)
     }
 
@@ -598,11 +598,11 @@ impl ApiKeyPlugin {
             && chrono::Utc::now() > expires_at
         {
             // Delete expired key and evict its cached rate limiter
-            let _ = ctx.database.delete_api_key(api_key.id()).await;
+            let _ = ctx.database.delete_api_key(&api_key.id()).await;
             self.rate_limiters
                 .lock()
                 .expect("rate_limiters mutex poisoned")
-                .remove(api_key.id());
+                .remove(api_key.id().as_ref());
             return Err(ApiKeyValidationError::new(ApiKeyErrorCode::KeyExpired));
         }
 
@@ -626,11 +626,11 @@ impl ApiKeyPlugin {
             && api_key.refill_amount().is_none()
         {
             // Usage exhausted, no refill configured -- delete key and evict cache
-            let _ = ctx.database.delete_api_key(api_key.id()).await;
+            let _ = ctx.database.delete_api_key(&api_key.id()).await;
             self.rate_limiters
                 .lock()
                 .expect("rate_limiters mutex poisoned")
-                .remove(api_key.id());
+                .remove(api_key.id().as_ref());
             return Err(ApiKeyValidationError::new(ApiKeyErrorCode::UsageExceeded));
         }
 
@@ -676,7 +676,7 @@ impl ApiKeyPlugin {
 
         let updated = ctx
             .database
-            .update_api_key(api_key.id(), update)
+            .update_api_key(&api_key.id(), update)
             .await
             .map_err(|_| ApiKeyValidationError::new(ApiKeyErrorCode::FailedToUpdateApiKey))?;
 
@@ -763,7 +763,7 @@ impl ApiKeyPlugin {
         ctx: &AuthContext<DB>,
     ) -> AuthResult<AuthResponse> {
         let (user, _session) = ctx.require_session(req).await?;
-        let response = delete_all_expired_core(user.id(), self, ctx).await?;
+        let response = delete_all_expired_core(&user.id(), self, ctx).await?;
         Ok(AuthResponse::json(200, &response)?)
     }
 }
@@ -876,7 +876,7 @@ mod axum_impl {
         ValidatedJson(body): ValidatedJson<CreateKeyRequest>,
     ) -> Result<Json<CreateKeyResponse>, AuthError> {
         let ctx = state.to_context();
-        let response = create_key_core(&body, user.id(), &plugin, &ctx).await?;
+        let response = create_key_core(&body, &user.id(), &plugin, &ctx).await?;
         Ok(Json(response))
     }
 
@@ -887,7 +887,7 @@ mod axum_impl {
         Query(query): Query<GetKeyQuery>,
     ) -> Result<Json<ApiKeyView>, AuthError> {
         let ctx = state.to_context();
-        let response = get_key_core(&query.id, user.id(), &plugin, &ctx).await?;
+        let response = get_key_core(&query.id, &user.id(), &plugin, &ctx).await?;
         Ok(Json(response))
     }
 
@@ -897,7 +897,7 @@ mod axum_impl {
         CurrentSession { user, .. }: CurrentSession<DB>,
     ) -> Result<Json<Vec<ApiKeyView>>, AuthError> {
         let ctx = state.to_context();
-        let response = list_keys_core(user.id(), &plugin, &ctx).await?;
+        let response = list_keys_core(&user.id(), &plugin, &ctx).await?;
         Ok(Json(response))
     }
 
@@ -908,7 +908,7 @@ mod axum_impl {
         ValidatedJson(body): ValidatedJson<UpdateKeyRequest>,
     ) -> Result<Json<ApiKeyView>, AuthError> {
         let ctx = state.to_context();
-        let response = update_key_core(&body, user.id(), &plugin, &ctx).await?;
+        let response = update_key_core(&body, &user.id(), &plugin, &ctx).await?;
         Ok(Json(response))
     }
 
@@ -919,7 +919,7 @@ mod axum_impl {
         ValidatedJson(body): ValidatedJson<DeleteKeyRequest>,
     ) -> Result<Json<serde_json::Value>, AuthError> {
         let ctx = state.to_context();
-        let response = delete_key_core(&body, user.id(), &plugin, &ctx).await?;
+        let response = delete_key_core(&body, &user.id(), &plugin, &ctx).await?;
         Ok(Json(response))
     }
 
@@ -939,7 +939,7 @@ mod axum_impl {
         CurrentSession { user, .. }: CurrentSession<DB>,
     ) -> Result<Json<serde_json::Value>, AuthError> {
         let ctx = state.to_context();
-        let response = delete_all_expired_core(user.id(), &plugin, &ctx).await?;
+        let response = delete_all_expired_core(&user.id(), &plugin, &ctx).await?;
         Ok(Json(response))
     }
 

--- a/crates/api/src/plugins/device_authorization.rs
+++ b/crates/api/src/plugins/device_authorization.rs
@@ -264,7 +264,7 @@ async fn approve_device_core<DB: DatabaseAdapter>(
         .await?
     {
         ctx.database
-            .delete_verification(device_verification.id())
+            .delete_verification(&device_verification.id())
             .await?;
     }
 
@@ -296,7 +296,7 @@ async fn deny_device_core<DB: DatabaseAdapter>(
         .await?
     {
         ctx.database
-            .delete_verification(device_verification.id())
+            .delete_verification(&device_verification.id())
             .await?;
     }
 

--- a/crates/api/src/plugins/email_verification/handlers.rs
+++ b/crates/api/src/plugins/email_verification/handlers.rs
@@ -135,10 +135,10 @@ pub(super) async fn verify_email_core<DB: DatabaseAdapter>(
         ..Default::default()
     };
 
-    let updated_user = ctx.database.update_user(user.id(), update_user).await?;
+    let updated_user = ctx.database.update_user(&user.id(), update_user).await?;
 
     // Delete the used verification token
-    ctx.database.delete_verification(verification.id()).await?;
+    ctx.database.delete_verification(&verification.id()).await?;
 
     // Run after_email_verification hook
     if let Some(ref hook) = config.after_email_verification {

--- a/crates/api/src/plugins/oauth/handlers.rs
+++ b/crates/api/src/plugins/oauth/handlers.rs
@@ -207,7 +207,7 @@ pub(crate) async fn link_social_core<DB: DatabaseAdapter>(
         provider_name,
         &callback_url,
         body.scopes.as_deref(),
-        Some(session.user_id()),
+        Some(&session.user_id()),
     )
     .await
 }
@@ -217,7 +217,7 @@ pub(crate) async fn get_access_token_core<DB: DatabaseAdapter>(
     session: &DB::Session,
     ctx: &AuthContext<DB>,
 ) -> AuthResult<AccessTokenResponse> {
-    let accounts = ctx.database.get_user_accounts(session.user_id()).await?;
+    let accounts = ctx.database.get_user_accounts(&session.user_id()).await?;
     let account = find_account_for_provider(&accounts, &body.provider_id)?;
 
     let encrypt = ctx.config.account.encrypt_oauth_tokens;
@@ -243,7 +243,7 @@ pub(crate) async fn refresh_token_core<DB: DatabaseAdapter>(
         .get(provider_name)
         .ok_or_else(|| AuthError::bad_request(format!("Unknown provider: {}", provider_name)))?;
 
-    let accounts = ctx.database.get_user_accounts(session.user_id()).await?;
+    let accounts = ctx.database.get_user_accounts(&session.user_id()).await?;
     let account = find_account_for_provider(&accounts, provider_name)?;
 
     let encrypt = ctx.config.account.encrypt_oauth_tokens;
@@ -300,7 +300,7 @@ pub(crate) async fn refresh_token_core<DB: DatabaseAdapter>(
     )?;
     ctx.database
         .update_account(
-            account.id(),
+            &account.id(),
             UpdateAccount {
                 access_token: tokens.access_token,
                 refresh_token: tokens.refresh_token,
@@ -430,7 +430,7 @@ pub(crate) async fn callback_core<DB: DatabaseAdapter>(
     let scopes = payload["scopes"].as_str().map(String::from);
 
     // Delete the verification now that we've used it
-    ctx.database.delete_verification(verification.id()).await?;
+    ctx.database.delete_verification(&verification.id()).await?;
 
     let provider = config
         .providers
@@ -566,7 +566,7 @@ pub(crate) async fn callback_core<DB: DatabaseAdapter>(
             )?;
             ctx.database
                 .update_account(
-                    existing_account.id(),
+                    &existing_account.id(),
                     UpdateAccount {
                         access_token: tokens.access_token,
                         refresh_token: tokens.refresh_token,
@@ -582,7 +582,7 @@ pub(crate) async fn callback_core<DB: DatabaseAdapter>(
         // Get the associated user
         let user = ctx
             .database
-            .get_user_by_id(existing_account.user_id())
+            .get_user_by_id(&existing_account.user_id())
             .await?
             .ok_or(AuthError::UserNotFound)?;
 
@@ -617,10 +617,12 @@ pub(crate) async fn callback_core<DB: DatabaseAdapter>(
                 if let Some(image) = &user_info.image {
                     update.image = Some(image.clone());
                 }
-                ctx.database.update_user(existing_user.id(), update).await?;
+                ctx.database
+                    .update_user(&existing_user.id(), update)
+                    .await?;
                 // Re-fetch the user to get updated fields
                 ctx.database
-                    .get_user_by_id(existing_user.id())
+                    .get_user_by_id(&existing_user.id())
                     .await?
                     .ok_or(AuthError::UserNotFound)?
             } else {

--- a/crates/api/src/plugins/organization/handlers/invitation.rs
+++ b/crates/api/src/plugins/organization/handlers/invitation.rs
@@ -33,7 +33,7 @@ pub(crate) async fn invite_member_core<DB: DatabaseAdapter>(
 
     let member = ctx
         .database
-        .get_member(&org_id, user.id())
+        .get_member(&org_id, &user.id())
         .await?
         .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
 
@@ -72,7 +72,7 @@ pub(crate) async fn invite_member_core<DB: DatabaseAdapter>(
     if let Some(existing_user) = ctx.database.get_user_by_email(&body.email).await?
         && ctx
             .database
-            .get_member(&org_id, existing_user.id())
+            .get_member(&org_id, &existing_user.id())
             .await?
             .is_some()
     {
@@ -120,16 +120,19 @@ pub(crate) async fn get_invitation_core<DB: DatabaseAdapter>(
 
     let organization = ctx
         .database
-        .get_organization_by_id(invitation.organization_id())
+        .get_organization_by_id(&invitation.organization_id())
         .await?
         .ok_or_else(|| AuthError::not_found("Organization not found"))?;
 
-    let inviter_email =
-        if let Some(inviter) = ctx.database.get_user_by_id(invitation.inviter_id()).await? {
-            inviter.email().map(|s| s.to_string())
-        } else {
-            None
-        };
+    let inviter_email = if let Some(inviter) = ctx
+        .database
+        .get_user_by_id(&invitation.inviter_id())
+        .await?
+    {
+        inviter.email().map(|s| s.to_string())
+    } else {
+        None
+    };
 
     Ok(GetInvitationResponse {
         invitation,
@@ -149,7 +152,7 @@ pub(crate) async fn list_invitations_core<DB: DatabaseAdapter>(
         resolve_organization_id(query.organization_id.as_deref(), None, session, ctx).await?;
 
     ctx.database
-        .get_member(&org_id, user.id())
+        .get_member(&org_id, &user.id())
         .await?
         .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
 
@@ -211,7 +214,7 @@ pub(crate) async fn accept_invitation_core<DB: DatabaseAdapter>(
     if let Some(limit) = config.membership_limit {
         let members = ctx
             .database
-            .list_organization_members(invitation.organization_id())
+            .list_organization_members(&invitation.organization_id())
             .await?;
         if members.len() >= limit {
             return Err(AuthError::bad_request(
@@ -222,12 +225,12 @@ pub(crate) async fn accept_invitation_core<DB: DatabaseAdapter>(
 
     if ctx
         .database
-        .get_member(invitation.organization_id(), user.id())
+        .get_member(&invitation.organization_id(), &user.id())
         .await?
         .is_some()
     {
         ctx.database
-            .update_invitation_status(invitation.id(), InvitationStatus::Accepted)
+            .update_invitation_status(&invitation.id(), InvitationStatus::Accepted)
             .await?;
         return Err(AuthError::bad_request(
             "Already a member of this organization",
@@ -244,11 +247,11 @@ pub(crate) async fn accept_invitation_core<DB: DatabaseAdapter>(
 
     let updated_invitation = ctx
         .database
-        .update_invitation_status(invitation.id(), InvitationStatus::Accepted)
+        .update_invitation_status(&invitation.id(), InvitationStatus::Accepted)
         .await?;
 
     ctx.database
-        .update_session_active_organization(session.token(), Some(invitation.organization_id()))
+        .update_session_active_organization(session.token(), Some(&invitation.organization_id()))
         .await?;
 
     let member_response = MemberResponse::from_member_and_user(&member, user);
@@ -286,7 +289,7 @@ pub(crate) async fn reject_invitation_core<DB: DatabaseAdapter>(
     }
 
     ctx.database
-        .update_invitation_status(invitation.id(), InvitationStatus::Rejected)
+        .update_invitation_status(&invitation.id(), InvitationStatus::Rejected)
         .await?;
 
     Ok(SuccessResponse { success: true })
@@ -306,7 +309,7 @@ pub(crate) async fn cancel_invitation_core<DB: DatabaseAdapter>(
 
     let member = ctx
         .database
-        .get_member(invitation.organization_id(), user.id())
+        .get_member(&invitation.organization_id(), &user.id())
         .await?
         .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
 
@@ -329,7 +332,7 @@ pub(crate) async fn cancel_invitation_core<DB: DatabaseAdapter>(
     }
 
     ctx.database
-        .update_invitation_status(invitation.id(), InvitationStatus::Canceled)
+        .update_invitation_status(&invitation.id(), InvitationStatus::Canceled)
         .await?;
 
     Ok(SuccessResponse { success: true })

--- a/crates/api/src/plugins/organization/handlers/member.rs
+++ b/crates/api/src/plugins/organization/handlers/member.rs
@@ -27,7 +27,7 @@ pub(crate) async fn get_active_member_core<DB: DatabaseAdapter>(
 
     let member = ctx
         .database
-        .get_member(org_id, user.id())
+        .get_member(org_id, &user.id())
         .await?
         .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
 
@@ -49,7 +49,7 @@ pub(crate) async fn list_members_core<DB: DatabaseAdapter>(
     .await?;
 
     ctx.database
-        .get_member(&org_id, user.id())
+        .get_member(&org_id, &user.id())
         .await?
         .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
 
@@ -63,7 +63,7 @@ pub(crate) async fn list_members_core<DB: DatabaseAdapter>(
 
     let mut members = Vec::with_capacity(members_page.len());
     for member in &members_page {
-        if let Some(user_info) = ctx.database.get_user_by_id(member.user_id()).await? {
+        if let Some(user_info) = ctx.database.get_user_by_id(&member.user_id()).await? {
             members.push(MemberResponse::from_member_and_user(member, &user_info));
         }
     }
@@ -83,7 +83,7 @@ pub(crate) async fn remove_member_core<DB: DatabaseAdapter>(
 
     let requester_member = ctx
         .database
-        .get_member(&org_id, user.id())
+        .get_member(&org_id, &user.id())
         .await?
         .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
 
@@ -111,7 +111,7 @@ pub(crate) async fn remove_member_core<DB: DatabaseAdapter>(
             .ok_or_else(|| AuthError::not_found("User not found"))?;
         let target = ctx
             .database
-            .get_member(&org_id, target_user.id())
+            .get_member(&org_id, &target_user.id())
             .await?
             .ok_or_else(|| AuthError::not_found("Member not found"))?;
         target_member_id = target.id().to_string();
@@ -183,7 +183,7 @@ pub(crate) async fn update_member_role_core<DB: DatabaseAdapter>(
 
     let requester_member = ctx
         .database
-        .get_member(&org_id, user.id())
+        .get_member(&org_id, &user.id())
         .await?
         .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
 
@@ -229,7 +229,7 @@ pub(crate) async fn update_member_role_core<DB: DatabaseAdapter>(
 
     let user_info = ctx
         .database
-        .get_user_by_id(updated.user_id())
+        .get_user_by_id(&updated.user_id())
         .await?
         .ok_or_else(|| AuthError::internal("User not found for updated member"))?;
 

--- a/crates/api/src/plugins/organization/handlers/mod.rs
+++ b/crates/api/src/plugins/organization/handlers/mod.rs
@@ -25,7 +25,7 @@ pub(crate) async fn require_session<DB: DatabaseAdapter>(
 
     if let Some(token) = session_manager.extract_session_token(req)
         && let Some(session) = session_manager.get_session(&token).await?
-        && let Some(user) = ctx.database.get_user_by_id(session.user_id()).await?
+        && let Some(user) = ctx.database.get_user_by_id(&session.user_id()).await?
     {
         return Ok((user, session));
     }
@@ -74,7 +74,7 @@ pub(crate) async fn has_permission_core<DB: DatabaseAdapter>(
 
     let member = ctx
         .database
-        .get_member(&org_id, user.id())
+        .get_member(&org_id, &user.id())
         .await?
         .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
 

--- a/crates/api/src/plugins/organization/handlers/org.rs
+++ b/crates/api/src/plugins/organization/handlers/org.rs
@@ -30,7 +30,7 @@ pub(crate) async fn create_organization_core<DB: DatabaseAdapter>(
     }
 
     if let Some(limit) = config.organization_limit {
-        let user_orgs = ctx.database.list_user_organizations(user.id()).await?;
+        let user_orgs = ctx.database.list_user_organizations(&user.id()).await?;
         if user_orgs.len() >= limit {
             return Err(AuthError::bad_request(format!(
                 "Organization limit of {} reached",
@@ -85,7 +85,7 @@ pub(crate) async fn update_organization_core<DB: DatabaseAdapter>(
 
     let member = ctx
         .database
-        .get_member(&org_id, user.id())
+        .get_member(&org_id, &user.id())
         .await?
         .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
 
@@ -134,7 +134,7 @@ pub(crate) async fn delete_organization_core<DB: DatabaseAdapter>(
 
     let member = ctx
         .database
-        .get_member(&body.organization_id, user.id())
+        .get_member(&body.organization_id, &user.id())
         .await?
         .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
 
@@ -160,7 +160,7 @@ pub(crate) async fn list_organizations_core<DB: DatabaseAdapter>(
     user: &DB::User,
     ctx: &AuthContext<DB>,
 ) -> AuthResult<Vec<DB::Organization>> {
-    let organizations = ctx.database.list_user_organizations(user.id()).await?;
+    let organizations = ctx.database.list_user_organizations(&user.id()).await?;
     Ok(organizations)
 }
 
@@ -179,7 +179,7 @@ pub(crate) async fn get_full_organization_core<DB: DatabaseAdapter>(
     .await?;
 
     ctx.database
-        .get_member(&org_id, user.id())
+        .get_member(&org_id, &user.id())
         .await?
         .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
 
@@ -193,7 +193,7 @@ pub(crate) async fn get_full_organization_core<DB: DatabaseAdapter>(
     let mut members = Vec::with_capacity(members_raw.len());
 
     for member in &members_raw {
-        if let Some(user_info) = ctx.database.get_user_by_id(member.user_id()).await? {
+        if let Some(user_info) = ctx.database.get_user_by_id(&member.user_id()).await? {
             members.push(MemberResponse::from_member_and_user(member, &user_info));
         }
     }
@@ -242,7 +242,7 @@ pub(crate) async fn set_active_organization_core<DB: DatabaseAdapter>(
 
     if let Some(ref oid) = org_id {
         ctx.database
-            .get_member(oid, user.id())
+            .get_member(oid, &user.id())
             .await?
             .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
     }
@@ -263,7 +263,7 @@ pub(crate) async fn leave_organization_core<DB: DatabaseAdapter>(
 ) -> AuthResult<SuccessResponse> {
     let member = ctx
         .database
-        .get_member(&body.organization_id, user.id())
+        .get_member(&body.organization_id, &user.id())
         .await?
         .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
 
@@ -284,7 +284,7 @@ pub(crate) async fn leave_organization_core<DB: DatabaseAdapter>(
         }
     }
 
-    ctx.database.delete_member(member.id()).await?;
+    ctx.database.delete_member(&member.id()).await?;
 
     if session.active_organization_id() == Some(&body.organization_id) {
         ctx.database

--- a/crates/api/src/plugins/passkey/handlers.rs
+++ b/crates/api/src/plugins/passkey/handlers.rs
@@ -123,7 +123,7 @@ pub(crate) async fn generate_register_options_core<DB: DatabaseAdapter>(
         .await?;
 
     // Build excludeCredentials from existing passkeys
-    let existing_passkeys = ctx.database.list_passkeys_by_user(user.id()).await?;
+    let existing_passkeys = ctx.database.list_passkeys_by_user(&user.id()).await?;
     let exclude_credentials: Vec<serde_json::Value> = existing_passkeys
         .iter()
         .map(|pk| {
@@ -277,7 +277,7 @@ pub(crate) async fn generate_authenticate_options_core<DB: DatabaseAdapter>(
 
     // If user is provided, build allowCredentials from their passkeys
     let allow_credentials: Vec<serde_json::Value> = if let Some(user) = maybe_user {
-        let passkeys = ctx.database.list_passkeys_by_user(user.id()).await?;
+        let passkeys = ctx.database.list_passkeys_by_user(&user.id()).await?;
         passkeys
             .iter()
             .map(|pk| {
@@ -357,7 +357,7 @@ pub(crate) async fn verify_authentication_core<DB: DatabaseAdapter>(
     // Look up the user
     let user = ctx
         .database
-        .get_user_by_id(passkey.user_id())
+        .get_user_by_id(&passkey.user_id())
         .await?
         .ok_or(AuthError::UserNotFound)?;
 
@@ -367,7 +367,7 @@ pub(crate) async fn verify_authentication_core<DB: DatabaseAdapter>(
         .checked_add(1)
         .ok_or_else(|| AuthError::internal("Passkey counter overflow"))?;
     ctx.database
-        .update_passkey_counter(passkey.id(), new_counter)
+        .update_passkey_counter(&passkey.id(), new_counter)
         .await?;
 
     // Create a session
@@ -385,7 +385,7 @@ pub(crate) async fn list_user_passkeys_core<DB: DatabaseAdapter>(
     user: &DB::User,
     ctx: &AuthContext<DB>,
 ) -> AuthResult<Vec<PasskeyView>> {
-    let passkeys = ctx.database.list_passkeys_by_user(user.id()).await?;
+    let passkeys = ctx.database.list_passkeys_by_user(&user.id()).await?;
     Ok(passkeys.iter().map(PasskeyView::from_entity).collect())
 }
 

--- a/crates/api/src/plugins/password_management/handlers.rs
+++ b/crates/api/src/plugins/password_management/handlers.rs
@@ -141,15 +141,15 @@ pub(crate) async fn reset_password_core<DB: DatabaseAdapter>(
     metadata[PASSWORD_HASH_KEY] = serde_json::Value::String(password_hash);
 
     ctx.database
-        .update_user(user.id(), password_utils::update_user_metadata(metadata))
+        .update_user(&user.id(), password_utils::update_user_metadata(metadata))
         .await?;
 
     // Delete the used verification token
-    ctx.database.delete_verification(verification.id()).await?;
+    ctx.database.delete_verification(&verification.id()).await?;
 
     // Revoke all existing sessions for security (when configured)
     if config.revoke_sessions_on_password_reset {
-        ctx.database.delete_user_sessions(user.id()).await?;
+        ctx.database.delete_user_sessions(&user.id()).await?;
     }
 
     // Call on_password_reset callback if configured.
@@ -257,13 +257,13 @@ pub(crate) async fn change_password_core<DB: DatabaseAdapter>(
 
     let updated_user = ctx
         .database
-        .update_user(user.id(), password_utils::update_user_metadata(metadata))
+        .update_user(&user.id(), password_utils::update_user_metadata(metadata))
         .await?;
 
     // Handle session revocation
     let new_token = if body.revoke_other_sessions == Some(true) {
         // Revoke all sessions except current one
-        ctx.database.delete_user_sessions(user.id()).await?;
+        ctx.database.delete_user_sessions(&user.id()).await?;
 
         // Create new session
         let session = ctx
@@ -312,7 +312,7 @@ pub(crate) async fn set_password_core<DB: DatabaseAdapter>(
     metadata[PASSWORD_HASH_KEY] = serde_json::Value::String(password_hash);
 
     ctx.database
-        .update_user(user.id(), password_utils::update_user_metadata(metadata))
+        .update_user(&user.id(), password_utils::update_user_metadata(metadata))
         .await?;
 
     Ok(StatusResponse { status: true })

--- a/crates/api/src/plugins/password_management/mod.rs
+++ b/crates/api/src/plugins/password_management/mod.rs
@@ -251,7 +251,7 @@ impl PasswordManagementPlugin {
         if let Some(token) = session_manager.extract_session_token(req)
             && let Some(session) = session_manager.get_session(&token).await?
         {
-            return ctx.database.get_user_by_id(session.user_id()).await;
+            return ctx.database.get_user_by_id(&session.user_id()).await;
         }
 
         Ok(None)

--- a/crates/api/src/plugins/session_management.rs
+++ b/crates/api/src/plugins/session_management.rs
@@ -181,7 +181,7 @@ impl SessionManagementPlugin {
         ctx: &AuthContext<DB>,
     ) -> AuthResult<AuthResponse> {
         let (user, _) = ctx.require_session(req).await?;
-        let sessions = list_sessions_core(user.id(), ctx).await?;
+        let sessions = list_sessions_core(&user.id(), ctx).await?;
         Ok(AuthResponse::json(200, &sessions)?)
     }
 
@@ -207,7 +207,7 @@ impl SessionManagementPlugin {
         ctx: &AuthContext<DB>,
     ) -> AuthResult<AuthResponse> {
         let (user, _) = ctx.require_session(req).await?;
-        let response = revoke_sessions_core(user.id(), ctx).await?;
+        let response = revoke_sessions_core(&user.id(), ctx).await?;
         Ok(AuthResponse::json(200, &response)?)
     }
 
@@ -217,7 +217,7 @@ impl SessionManagementPlugin {
         ctx: &AuthContext<DB>,
     ) -> AuthResult<AuthResponse> {
         let (user, current_session) = ctx.require_session(req).await?;
-        let response = revoke_other_sessions_core(user.id(), &current_session, ctx).await?;
+        let response = revoke_other_sessions_core(&user.id(), &current_session, ctx).await?;
         Ok(AuthResponse::json(200, &response)?)
     }
 }
@@ -263,7 +263,7 @@ mod axum_impl {
             return Err(AuthError::not_found("Not found"));
         }
         let ctx = state.to_context();
-        let sessions = list_sessions_core(user.id(), &ctx).await?;
+        let sessions = list_sessions_core(&user.id(), &ctx).await?;
         Ok(Json(sessions))
     }
 
@@ -290,7 +290,7 @@ mod axum_impl {
             return Err(AuthError::not_found("Not found"));
         }
         let ctx = state.to_context();
-        let response = revoke_sessions_core(user.id(), &ctx).await?;
+        let response = revoke_sessions_core(&user.id(), &ctx).await?;
         Ok(Json(response))
     }
 
@@ -303,7 +303,7 @@ mod axum_impl {
             return Err(AuthError::not_found("Not found"));
         }
         let ctx = state.to_context();
-        let response = revoke_other_sessions_core(user.id(), &session, &ctx).await?;
+        let response = revoke_other_sessions_core(&user.id(), &session, &ctx).await?;
         Ok(Json(response))
     }
 

--- a/crates/api/src/plugins/two_factor.rs
+++ b/crates/api/src/plugins/two_factor.rs
@@ -206,7 +206,7 @@ async fn enable_core<DB: DatabaseAdapter>(
     // Update user flag
     ctx.database
         .update_user(
-            user.id(),
+            &user.id(),
             UpdateUser {
                 two_factor_enabled: Some(true),
                 ..Default::default()
@@ -227,11 +227,11 @@ async fn disable_core<DB: DatabaseAdapter>(
 ) -> AuthResult<StatusResponse> {
     verify_user_password(user, &body.password).await?;
 
-    ctx.database.delete_two_factor(user.id()).await?;
+    ctx.database.delete_two_factor(&user.id()).await?;
 
     ctx.database
         .update_user(
-            user.id(),
+            &user.id(),
             UpdateUser {
                 two_factor_enabled: Some(false),
                 ..Default::default()
@@ -252,7 +252,7 @@ async fn get_totp_uri_core<DB: DatabaseAdapter>(
 
     let two_factor = ctx
         .database
-        .get_two_factor_by_user_id(user.id())
+        .get_two_factor_by_user_id(&user.id())
         .await?
         .ok_or_else(|| AuthError::not_found("Two-factor authentication not enabled"))?;
 
@@ -282,7 +282,7 @@ async fn generate_backup_codes_core<DB: DatabaseAdapter>(
     let hashed_codes = hash_backup_codes(&backup_codes).await?;
 
     ctx.database
-        .update_two_factor_backup_codes(user.id(), &hashed_codes)
+        .update_two_factor_backup_codes(&user.id(), &hashed_codes)
         .await?;
 
     Ok(BackupCodesResponse {
@@ -341,7 +341,7 @@ async fn verify_totp_core<DB: DatabaseAdapter>(
 ) -> AuthResult<(VerifyTotpResponse<DB::User>, String)> {
     let two_factor = ctx
         .database
-        .get_two_factor_by_user_id(user.id())
+        .get_two_factor_by_user_id(&user.id())
         .await?
         .ok_or_else(|| AuthError::not_found("Two-factor authentication not enabled"))?;
 
@@ -440,7 +440,7 @@ async fn verify_otp_core<DB: DatabaseAdapter>(
 
     // Clean up verifications
     ctx.database
-        .delete_verification(otp_verification.id())
+        .delete_verification(&otp_verification.id())
         .await?;
     ctx.database.delete_verification(verification_id).await?;
 
@@ -462,7 +462,7 @@ async fn verify_backup_code_core<DB: DatabaseAdapter>(
 ) -> AuthResult<(VerifyBackupCodeResponse<DB::User, DB::Session>, String)> {
     let two_factor = ctx
         .database
-        .get_two_factor_by_user_id(user.id())
+        .get_two_factor_by_user_id(&user.id())
         .await?
         .ok_or_else(|| AuthError::not_found("Two-factor authentication not enabled"))?;
 
@@ -496,7 +496,7 @@ async fn verify_backup_code_core<DB: DatabaseAdapter>(
         serde_json::to_string(&remaining_codes).map_err(|e| AuthError::internal(e.to_string()))?;
 
     ctx.database
-        .update_two_factor_backup_codes(user.id(), &updated_codes_json)
+        .update_two_factor_backup_codes(&user.id(), &updated_codes_json)
         .await?;
 
     // Create session

--- a/crates/api/src/plugins/user_management/handlers.rs
+++ b/crates/api/src/plugins/user_management/handlers.rs
@@ -125,7 +125,7 @@ pub(crate) async fn change_email_core<DB: DatabaseAdapter>(
             email_verified: Some(false),
             ..Default::default()
         };
-        ctx.database.update_user(user.id(), update_user).await?;
+        ctx.database.update_user(&user.id(), update_user).await?;
 
         return Ok(StatusMessageResponse {
             status: true,
@@ -186,7 +186,7 @@ pub(crate) async fn change_email_verify_core<DB: DatabaseAdapter>(
         .ok_or_else(|| AuthError::bad_request("Invalid or expired verification token"))?;
 
     if verification.expires_at() < Utc::now() {
-        ctx.database.delete_verification(verification.id()).await?;
+        ctx.database.delete_verification(&verification.id()).await?;
         return Err(AuthError::bad_request("Verification token has expired"));
     }
 
@@ -221,7 +221,7 @@ pub(crate) async fn change_email_verify_core<DB: DatabaseAdapter>(
         ..Default::default()
     };
 
-    ctx.database.update_user(user.id(), update_user).await?;
+    ctx.database.update_user(&user.id(), update_user).await?;
 
     // Consume the verification token
     ctx.database.delete_verification(&verification_id).await?;
@@ -296,7 +296,7 @@ pub(crate) async fn delete_user_verify_core<DB: DatabaseAdapter>(
         .ok_or_else(|| AuthError::bad_request("Invalid or expired verification token"))?;
 
     if verification.expires_at() < Utc::now() {
-        ctx.database.delete_verification(verification.id()).await?;
+        ctx.database.delete_verification(&verification.id()).await?;
         return Err(AuthError::bad_request("Verification token has expired"));
     }
 
@@ -342,17 +342,17 @@ async fn perform_user_deletion<DB: DatabaseAdapter>(
     }
 
     // Delete all sessions
-    ctx.database.delete_user_sessions(user.id()).await?;
+    ctx.database.delete_user_sessions(&user.id()).await?;
 
     // Delete all linked accounts
-    let accounts = ctx.database.get_user_accounts(user.id()).await?;
+    let accounts = ctx.database.get_user_accounts(&user.id()).await?;
     for account in &accounts {
         use better_auth_core::entity::AuthAccount;
-        ctx.database.delete_account(account.id()).await?;
+        ctx.database.delete_account(&account.id()).await?;
     }
 
     // Delete the user record
-    ctx.database.delete_user(user.id()).await?;
+    ctx.database.delete_user(&user.id()).await?;
 
     // after_delete hook (non-fatal)
     if let Some(ref hook) = config.delete_user.after_delete

--- a/crates/api/tests/account_oauth_tests.rs
+++ b/crates/api/tests/account_oauth_tests.rs
@@ -711,7 +711,7 @@ async fn test_callback_with_encryption_encrypts_tokens_for_new_user() {
                 .unwrap()
                 .expect("User should have been created");
 
-            let accounts = db.get_user_accounts(user.id()).await.unwrap();
+            let accounts = db.get_user_accounts(&user.id()).await.unwrap();
             assert_eq!(accounts.len(), 1);
 
             let stored_access = accounts[0].access_token().unwrap();

--- a/crates/core/src/entity.rs
+++ b/crates/core/src/entity.rs
@@ -22,6 +22,18 @@
 //! impl AuthUserMeta for MyUser {}   // uses default column names
 //! impl AuthSessionMeta for MySession {}
 //! ```
+//!
+//! ## Primary / foreign key returns
+//!
+//! Primary-key (`id()`) and foreign-key (e.g. `user_id()`, `organization_id()`,
+//! `inviter_id()`) accessors return [`Cow<'_, str>`](std::borrow::Cow). This
+//! allows implementors to either borrow an owned `String` field
+//! ([`Cow::Borrowed`]) or render a non-string identifier
+//! (e.g. [`uuid::Uuid`](https://docs.rs/uuid), `i64`) into an owned string
+//! ([`Cow::Owned`]) on the fly without changing the trait. All other fields
+//! continue to return plain `&str`.
+
+use std::borrow::Cow;
 
 use chrono::{DateTime, Utc};
 use serde::Serialize;
@@ -36,7 +48,7 @@ pub const PASSWORD_HASH_KEY: &str = "password_hash";
 /// The framework reads user fields through these getters. Custom types
 /// must provide all framework fields and may have additional fields.
 pub trait AuthUser: Clone + Send + Sync + Serialize + std::fmt::Debug + 'static {
-    fn id(&self) -> &str;
+    fn id(&self) -> Cow<'_, str>;
     fn email(&self) -> Option<&str>;
     fn name(&self) -> Option<&str>;
     fn email_verified(&self) -> bool;
@@ -62,14 +74,14 @@ pub trait AuthUser: Clone + Send + Sync + Serialize + std::fmt::Debug + 'static 
 
 /// Trait representing a session entity.
 pub trait AuthSession: Clone + Send + Sync + Serialize + std::fmt::Debug + 'static {
-    fn id(&self) -> &str;
+    fn id(&self) -> Cow<'_, str>;
     fn expires_at(&self) -> DateTime<Utc>;
     fn token(&self) -> &str;
     fn created_at(&self) -> DateTime<Utc>;
     fn updated_at(&self) -> DateTime<Utc>;
     fn ip_address(&self) -> Option<&str>;
     fn user_agent(&self) -> Option<&str>;
-    fn user_id(&self) -> &str;
+    fn user_id(&self) -> Cow<'_, str>;
     fn impersonated_by(&self) -> Option<&str>;
     fn active_organization_id(&self) -> Option<&str>;
     fn active(&self) -> bool;
@@ -77,10 +89,10 @@ pub trait AuthSession: Clone + Send + Sync + Serialize + std::fmt::Debug + 'stat
 
 /// Trait representing an account entity (OAuth provider linking).
 pub trait AuthAccount: Clone + Send + Sync + Serialize + std::fmt::Debug + 'static {
-    fn id(&self) -> &str;
+    fn id(&self) -> Cow<'_, str>;
     fn account_id(&self) -> &str;
     fn provider_id(&self) -> &str;
-    fn user_id(&self) -> &str;
+    fn user_id(&self) -> Cow<'_, str>;
     fn access_token(&self) -> Option<&str>;
     fn refresh_token(&self) -> Option<&str>;
     fn id_token(&self) -> Option<&str>;
@@ -94,7 +106,7 @@ pub trait AuthAccount: Clone + Send + Sync + Serialize + std::fmt::Debug + 'stat
 
 /// Trait representing an organization entity.
 pub trait AuthOrganization: Clone + Send + Sync + Serialize + std::fmt::Debug + 'static {
-    fn id(&self) -> &str;
+    fn id(&self) -> Cow<'_, str>;
     fn name(&self) -> &str;
     fn slug(&self) -> &str;
     fn logo(&self) -> Option<&str>;
@@ -105,21 +117,21 @@ pub trait AuthOrganization: Clone + Send + Sync + Serialize + std::fmt::Debug + 
 
 /// Trait representing an organization member entity.
 pub trait AuthMember: Clone + Send + Sync + Serialize + std::fmt::Debug + 'static {
-    fn id(&self) -> &str;
-    fn organization_id(&self) -> &str;
-    fn user_id(&self) -> &str;
+    fn id(&self) -> Cow<'_, str>;
+    fn organization_id(&self) -> Cow<'_, str>;
+    fn user_id(&self) -> Cow<'_, str>;
     fn role(&self) -> &str;
     fn created_at(&self) -> DateTime<Utc>;
 }
 
 /// Trait representing an invitation entity.
 pub trait AuthInvitation: Clone + Send + Sync + Serialize + std::fmt::Debug + 'static {
-    fn id(&self) -> &str;
-    fn organization_id(&self) -> &str;
+    fn id(&self) -> Cow<'_, str>;
+    fn organization_id(&self) -> Cow<'_, str>;
     fn email(&self) -> &str;
     fn role(&self) -> &str;
     fn status(&self) -> &InvitationStatus;
-    fn inviter_id(&self) -> &str;
+    fn inviter_id(&self) -> Cow<'_, str>;
     fn expires_at(&self) -> DateTime<Utc>;
     fn created_at(&self) -> DateTime<Utc>;
 
@@ -136,7 +148,7 @@ pub trait AuthInvitation: Clone + Send + Sync + Serialize + std::fmt::Debug + 's
 
 /// Trait representing a verification token entity.
 pub trait AuthVerification: Clone + Send + Sync + Serialize + std::fmt::Debug + 'static {
-    fn id(&self) -> &str;
+    fn id(&self) -> Cow<'_, str>;
     fn identifier(&self) -> &str;
     fn value(&self) -> &str;
     fn expires_at(&self) -> DateTime<Utc>;
@@ -146,22 +158,22 @@ pub trait AuthVerification: Clone + Send + Sync + Serialize + std::fmt::Debug + 
 
 /// Trait representing a two-factor authentication entity.
 pub trait AuthTwoFactor: Clone + Send + Sync + Serialize + std::fmt::Debug + 'static {
-    fn id(&self) -> &str;
+    fn id(&self) -> Cow<'_, str>;
     fn secret(&self) -> &str;
     fn backup_codes(&self) -> Option<&str>;
-    fn user_id(&self) -> &str;
+    fn user_id(&self) -> Cow<'_, str>;
     fn created_at(&self) -> DateTime<Utc>;
     fn updated_at(&self) -> DateTime<Utc>;
 }
 
 /// Trait representing an API key entity.
 pub trait AuthApiKey: Clone + Send + Sync + Serialize + std::fmt::Debug + 'static {
-    fn id(&self) -> &str;
+    fn id(&self) -> Cow<'_, str>;
     fn name(&self) -> Option<&str>;
     fn start(&self) -> Option<&str>;
     fn prefix(&self) -> Option<&str>;
     fn key_hash(&self) -> &str;
-    fn user_id(&self) -> &str;
+    fn user_id(&self) -> Cow<'_, str>;
     fn refill_interval(&self) -> Option<i64>;
     fn refill_amount(&self) -> Option<i64>;
     fn last_refill_at(&self) -> Option<&str>;
@@ -181,10 +193,10 @@ pub trait AuthApiKey: Clone + Send + Sync + Serialize + std::fmt::Debug + 'stati
 
 /// Trait representing a passkey entity.
 pub trait AuthPasskey: Clone + Send + Sync + Serialize + std::fmt::Debug + 'static {
-    fn id(&self) -> &str;
+    fn id(&self) -> Cow<'_, str>;
     fn name(&self) -> &str;
     fn public_key(&self) -> &str;
-    fn user_id(&self) -> &str;
+    fn user_id(&self) -> Cow<'_, str>;
     fn credential_id(&self) -> &str;
     fn counter(&self) -> u64;
     fn device_type(&self) -> &str;
@@ -629,3 +641,4 @@ impl MemberUserView {
 }
 
 use serde::Deserialize;
+

--- a/crates/core/src/entity.rs
+++ b/crates/core/src/entity.rs
@@ -642,3 +642,176 @@ impl MemberUserView {
 
 use serde::Deserialize;
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Session, User};
+    use crate::types_org::{InvitationStatus, Member, Organization};
+    use chrono::Utc;
+
+    fn sample_user() -> User {
+        User {
+            id: "user-123".into(),
+            name: Some("Alice".into()),
+            email: Some("alice@example.com".into()),
+            email_verified: true,
+            image: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            username: None,
+            display_username: None,
+            two_factor_enabled: false,
+            role: None,
+            banned: false,
+            ban_reason: None,
+            ban_expires: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    #[test]
+    fn bundled_user_id_is_borrowed() {
+        let user = sample_user();
+        let id = user.id();
+        // Bundled [`User`] stores its id as a `String`, so the `AuthUser::id()`
+        // accessor should hand out a zero-copy `Cow::Borrowed` slice.
+        match id {
+            Cow::Borrowed(s) => assert_eq!(s, "user-123"),
+            Cow::Owned(_) => panic!("bundled User.id() must return Cow::Borrowed"),
+        }
+    }
+
+    #[test]
+    fn bundled_session_implements_auth_session() {
+        let session = Session {
+            id: "sess-1".into(),
+            expires_at: Utc::now(),
+            token: "tok".into(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            ip_address: Some("127.0.0.1".into()),
+            user_agent: Some("ua".into()),
+            user_id: "user-123".into(),
+            impersonated_by: None,
+            active_organization_id: None,
+            active: true,
+        };
+
+        // Access every `AuthSession` method once to ensure the trait bounds
+        // are satisfied and the bundled impl compiles with the new `Cow`
+        // signatures.
+        assert_eq!(session.id(), Cow::Borrowed("sess-1"));
+        assert_eq!(session.user_id(), Cow::Borrowed("user-123"));
+        assert_eq!(session.token(), "tok");
+        assert_eq!(session.ip_address(), Some("127.0.0.1"));
+        assert_eq!(session.user_agent(), Some("ua"));
+        assert!(session.active());
+        assert!(session.impersonated_by().is_none());
+        assert!(session.active_organization_id().is_none());
+    }
+
+    #[test]
+    fn bundled_member_ids_are_all_cow() {
+        let member = Member {
+            id: "mem-1".into(),
+            organization_id: "org-1".into(),
+            user_id: "user-123".into(),
+            role: "owner".into(),
+            created_at: Utc::now(),
+        };
+
+        assert_eq!(member.id(), Cow::Borrowed("mem-1"));
+        assert_eq!(member.organization_id(), Cow::Borrowed("org-1"));
+        assert_eq!(member.user_id(), Cow::Borrowed("user-123"));
+        assert_eq!(member.role(), "owner");
+    }
+
+    #[test]
+    fn bundled_organization_metadata_respects_option() {
+        let org = Organization {
+            id: "org-1".into(),
+            name: "Acme".into(),
+            slug: "acme".into(),
+            logo: None,
+            metadata: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        assert_eq!(org.id(), Cow::Borrowed("org-1"));
+        assert!(org.metadata().is_none());
+    }
+
+    // ── Meta trait default names ──────────────────────────────────────────
+
+    #[test]
+    fn auth_user_meta_default_table_name() {
+        assert_eq!(<User as AuthUserMeta>::table(), "users");
+        assert_eq!(<User as AuthUserMeta>::col_id(), "id");
+        assert_eq!(<User as AuthUserMeta>::col_email(), "email");
+        assert_eq!(
+            <User as AuthUserMeta>::col_email_verified(),
+            "email_verified"
+        );
+    }
+
+    #[test]
+    fn auth_session_meta_default_names() {
+        assert_eq!(<Session as AuthSessionMeta>::table(), "sessions");
+        assert_eq!(<Session as AuthSessionMeta>::col_user_id(), "user_id");
+        assert_eq!(
+            <Session as AuthSessionMeta>::col_active_organization_id(),
+            "active_organization_id"
+        );
+    }
+
+    #[test]
+    fn auth_member_meta_default_names() {
+        assert_eq!(<Member as AuthMemberMeta>::table(), "member");
+        assert_eq!(
+            <Member as AuthMemberMeta>::col_organization_id(),
+            "organization_id"
+        );
+    }
+
+    // ── Invitation default helpers ────────────────────────────────────────
+
+    #[test]
+    fn invitation_is_pending_and_is_expired_defaults() {
+        use crate::types_org::Invitation;
+        let past = Utc::now() - chrono::Duration::days(1);
+        let future = Utc::now() + chrono::Duration::days(1);
+
+        let pending_valid = Invitation {
+            id: "inv-1".into(),
+            organization_id: "org-1".into(),
+            email: "b@example.com".into(),
+            role: "member".into(),
+            status: InvitationStatus::Pending,
+            inviter_id: "user-123".into(),
+            expires_at: future,
+            created_at: Utc::now(),
+        };
+        assert!(pending_valid.is_pending());
+        assert!(!pending_valid.is_expired());
+
+        let accepted = Invitation {
+            status: InvitationStatus::Accepted,
+            expires_at: past,
+            ..pending_valid.clone()
+        };
+        assert!(!accepted.is_pending());
+        assert!(accepted.is_expired());
+    }
+
+    // ── Member user view projection ───────────────────────────────────────
+
+    #[test]
+    fn member_user_view_projects_auth_user_fields() {
+        let user = sample_user();
+        let view = MemberUserView::from_user(&user);
+        assert_eq!(view.id, "user-123");
+        assert_eq!(view.email.as_deref(), Some("alice@example.com"));
+        assert_eq!(view.name.as_deref(), Some("Alice"));
+        assert_eq!(view.image, None);
+    }
+}

--- a/crates/core/src/extractors.rs
+++ b/crates/core/src/extractors.rs
@@ -106,7 +106,7 @@ mod axum_impl {
 
             let user = state
                 .database
-                .get_user_by_id(session.user_id())
+                .get_user_by_id(&session.user_id())
                 .await?
                 .ok_or(AuthError::UserNotFound)?;
 

--- a/crates/core/src/plugin.rs
+++ b/crates/core/src/plugin.rs
@@ -245,7 +245,7 @@ impl<DB: DatabaseAdapter> AuthContext<DB> {
 
         if let Some(token) = session_manager.extract_session_token(req)
             && let Some(session) = session_manager.get_session(&token).await?
-            && let Some(user) = self.database.get_user_by_id(session.user_id()).await?
+            && let Some(user) = self.database.get_user_by_id(&session.user_id()).await?
         {
             return Ok((user, session));
         }

--- a/crates/core/src/types_impls.rs
+++ b/crates/core/src/types_impls.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chrono::{DateTime, Utc};
 
 use crate::entity::{
@@ -16,7 +18,7 @@ use super::types_org::{Invitation, InvitationStatus, Member, Organization};
 impl<T: AuthUser> From<&T> for User {
     fn from(u: &T) -> Self {
         Self {
-            id: u.id().to_owned(),
+            id: u.id().into_owned(),
             name: u.name().map(str::to_owned),
             email: u.email().map(str::to_owned),
             email_verified: u.email_verified(),
@@ -36,8 +38,8 @@ impl<T: AuthUser> From<&T> for User {
 }
 
 impl AuthUser for User {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.id)
     }
     fn email(&self) -> Option<&str> {
         self.email.as_deref()
@@ -84,8 +86,8 @@ impl AuthUser for User {
 }
 
 impl AuthSession for Session {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.id)
     }
     fn expires_at(&self) -> DateTime<Utc> {
         self.expires_at
@@ -105,8 +107,8 @@ impl AuthSession for Session {
     fn user_agent(&self) -> Option<&str> {
         self.user_agent.as_deref()
     }
-    fn user_id(&self) -> &str {
-        &self.user_id
+    fn user_id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.user_id)
     }
     fn impersonated_by(&self) -> Option<&str> {
         self.impersonated_by.as_deref()
@@ -120,8 +122,8 @@ impl AuthSession for Session {
 }
 
 impl AuthAccount for Account {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.id)
     }
     fn account_id(&self) -> &str {
         &self.account_id
@@ -129,8 +131,8 @@ impl AuthAccount for Account {
     fn provider_id(&self) -> &str {
         &self.provider_id
     }
-    fn user_id(&self) -> &str {
-        &self.user_id
+    fn user_id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.user_id)
     }
     fn access_token(&self) -> Option<&str> {
         self.access_token.as_deref()
@@ -162,8 +164,8 @@ impl AuthAccount for Account {
 }
 
 impl AuthOrganization for Organization {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.id)
     }
     fn name(&self) -> &str {
         &self.name
@@ -186,14 +188,14 @@ impl AuthOrganization for Organization {
 }
 
 impl AuthMember for Member {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.id)
     }
-    fn organization_id(&self) -> &str {
-        &self.organization_id
+    fn organization_id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.organization_id)
     }
-    fn user_id(&self) -> &str {
-        &self.user_id
+    fn user_id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.user_id)
     }
     fn role(&self) -> &str {
         &self.role
@@ -204,11 +206,11 @@ impl AuthMember for Member {
 }
 
 impl AuthInvitation for Invitation {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.id)
     }
-    fn organization_id(&self) -> &str {
-        &self.organization_id
+    fn organization_id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.organization_id)
     }
     fn email(&self) -> &str {
         &self.email
@@ -219,8 +221,8 @@ impl AuthInvitation for Invitation {
     fn status(&self) -> &InvitationStatus {
         &self.status
     }
-    fn inviter_id(&self) -> &str {
-        &self.inviter_id
+    fn inviter_id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.inviter_id)
     }
     fn expires_at(&self) -> DateTime<Utc> {
         self.expires_at
@@ -231,8 +233,8 @@ impl AuthInvitation for Invitation {
 }
 
 impl AuthVerification for Verification {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.id)
     }
     fn identifier(&self) -> &str {
         &self.identifier
@@ -252,8 +254,8 @@ impl AuthVerification for Verification {
 }
 
 impl AuthTwoFactor for TwoFactor {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.id)
     }
     fn secret(&self) -> &str {
         &self.secret
@@ -261,8 +263,8 @@ impl AuthTwoFactor for TwoFactor {
     fn backup_codes(&self) -> Option<&str> {
         self.backup_codes.as_deref()
     }
-    fn user_id(&self) -> &str {
-        &self.user_id
+    fn user_id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.user_id)
     }
     fn created_at(&self) -> DateTime<Utc> {
         self.created_at
@@ -273,8 +275,8 @@ impl AuthTwoFactor for TwoFactor {
 }
 
 impl AuthApiKey for ApiKey {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.id)
     }
     fn name(&self) -> Option<&str> {
         self.name.as_deref()
@@ -288,8 +290,8 @@ impl AuthApiKey for ApiKey {
     fn key_hash(&self) -> &str {
         &self.key_hash
     }
-    fn user_id(&self) -> &str {
-        &self.user_id
+    fn user_id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.user_id)
     }
     fn refill_interval(&self) -> Option<i64> {
         self.refill_interval
@@ -352,8 +354,8 @@ impl AuthApiKeyMeta for ApiKey {}
 impl AuthPasskeyMeta for Passkey {}
 
 impl AuthPasskey for Passkey {
-    fn id(&self) -> &str {
-        &self.id
+    fn id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.id)
     }
     fn name(&self) -> &str {
         &self.name
@@ -361,8 +363,8 @@ impl AuthPasskey for Passkey {
     fn public_key(&self) -> &str {
         &self.public_key
     }
-    fn user_id(&self) -> &str {
-        &self.user_id
+    fn user_id(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.user_id)
     }
     fn credential_id(&self) -> &str {
         &self.credential_id

--- a/crates/derive/src/auth_derive.rs
+++ b/crates/derive/src/auth_derive.rs
@@ -140,7 +140,7 @@ pub(crate) fn derive_meta_trait(
 }
 
 pub(crate) const AUTH_USER_GETTERS: &[(&str, ReturnKind)] = &[
-    ("id", RefStr),
+    ("id", CowStr),
     ("email", OptionRefStr),
     ("name", OptionRefStr),
     ("email_verified", Bool),
@@ -158,24 +158,24 @@ pub(crate) const AUTH_USER_GETTERS: &[(&str, ReturnKind)] = &[
 ];
 
 pub(crate) const AUTH_SESSION_GETTERS: &[(&str, ReturnKind)] = &[
-    ("id", RefStr),
+    ("id", CowStr),
     ("expires_at", DateTime),
     ("token", RefStr),
     ("created_at", DateTime),
     ("updated_at", DateTime),
     ("ip_address", OptionRefStr),
     ("user_agent", OptionRefStr),
-    ("user_id", RefStr),
+    ("user_id", CowStr),
     ("impersonated_by", OptionRefStr),
     ("active_organization_id", OptionRefStr),
     ("active", Bool),
 ];
 
 pub(crate) const AUTH_ACCOUNT_GETTERS: &[(&str, ReturnKind)] = &[
-    ("id", RefStr),
+    ("id", CowStr),
     ("account_id", RefStr),
     ("provider_id", RefStr),
-    ("user_id", RefStr),
+    ("user_id", CowStr),
     ("access_token", OptionRefStr),
     ("refresh_token", OptionRefStr),
     ("id_token", OptionRefStr),
@@ -188,7 +188,7 @@ pub(crate) const AUTH_ACCOUNT_GETTERS: &[(&str, ReturnKind)] = &[
 ];
 
 pub(crate) const AUTH_ORGANIZATION_GETTERS: &[(&str, ReturnKind)] = &[
-    ("id", RefStr),
+    ("id", CowStr),
     ("name", RefStr),
     ("slug", RefStr),
     ("logo", OptionRefStr),
@@ -198,26 +198,26 @@ pub(crate) const AUTH_ORGANIZATION_GETTERS: &[(&str, ReturnKind)] = &[
 ];
 
 pub(crate) const AUTH_MEMBER_GETTERS: &[(&str, ReturnKind)] = &[
-    ("id", RefStr),
-    ("organization_id", RefStr),
-    ("user_id", RefStr),
+    ("id", CowStr),
+    ("organization_id", CowStr),
+    ("user_id", CowStr),
     ("role", RefStr),
     ("created_at", DateTime),
 ];
 
 pub(crate) const AUTH_INVITATION_GETTERS: &[(&str, ReturnKind)] = &[
-    ("id", RefStr),
-    ("organization_id", RefStr),
+    ("id", CowStr),
+    ("organization_id", CowStr),
     ("email", RefStr),
     ("role", RefStr),
     ("status", RefStatus),
-    ("inviter_id", RefStr),
+    ("inviter_id", CowStr),
     ("expires_at", DateTime),
     ("created_at", DateTime),
 ];
 
 pub(crate) const AUTH_VERIFICATION_GETTERS: &[(&str, ReturnKind)] = &[
-    ("id", RefStr),
+    ("id", CowStr),
     ("identifier", RefStr),
     ("value", RefStr),
     ("expires_at", DateTime),
@@ -226,19 +226,19 @@ pub(crate) const AUTH_VERIFICATION_GETTERS: &[(&str, ReturnKind)] = &[
 ];
 
 pub(crate) const AUTH_TWO_FACTOR_GETTERS: &[(&str, ReturnKind)] = &[
-    ("id", RefStr),
+    ("id", CowStr),
     ("secret", RefStr),
     ("backup_codes", OptionRefStr),
-    ("user_id", RefStr),
+    ("user_id", CowStr),
     ("created_at", DateTime),
     ("updated_at", DateTime),
 ];
 
 pub(crate) const AUTH_PASSKEY_GETTERS: &[(&str, ReturnKind)] = &[
-    ("id", RefStr),
+    ("id", CowStr),
     ("name", RefStr),
     ("public_key", RefStr),
-    ("user_id", RefStr),
+    ("user_id", CowStr),
     ("credential_id", RefStr),
     ("counter", U64),
     ("device_type", RefStr),

--- a/crates/derive/src/helpers.rs
+++ b/crates/derive/src/helpers.rs
@@ -8,6 +8,12 @@ use syn::DeriveInput;
 pub(crate) enum ReturnKind {
     /// `fn x(&self) -> &str` — field is `String`
     RefStr,
+    /// `fn x(&self) -> Cow<'_, str>` — field is `String`; returns `Cow::Borrowed`
+    ///
+    /// Used for primary-key (`id`) and foreign-key (`user_id`, `organization_id`,
+    /// `inviter_id`) getters so that app-owned entities with non-string IDs
+    /// (e.g. `Uuid`, `i64`) can override the getter to return `Cow::Owned`.
+    CowStr,
     /// `fn x(&self) -> Option<&str>` — field is `Option<String>`
     OptionRefStr,
     /// `fn x(&self) -> bool` — field is `bool`
@@ -200,6 +206,10 @@ pub(crate) fn gen_getter_tokens(
 ) -> (TokenStream2, TokenStream2) {
     match kind {
         RefStr => (quote! { &str }, quote! { &self.#field_ident }),
+        CowStr => (
+            quote! { ::std::borrow::Cow<'_, str> },
+            quote! { ::std::borrow::Cow::Borrowed(&self.#field_ident) },
+        ),
         OptionRefStr => (
             quote! { ::core::option::Option<&str> },
             quote! { self.#field_ident.as_deref() },

--- a/crates/derive/src/helpers.rs
+++ b/crates/derive/src/helpers.rs
@@ -13,6 +13,13 @@ pub(crate) enum ReturnKind {
     /// Used for primary-key (`id`) and foreign-key (`user_id`, `organization_id`,
     /// `inviter_id`) getters so that app-owned entities with non-string IDs
     /// (e.g. `Uuid`, `i64`) can override the getter to return `Cow::Owned`.
+    ///
+    /// **The derive only handles the `String`-backed default.** A custom
+    /// entity whose ID/FK field is anything other than `String` (or another
+    /// `Deref<Target = str>` type) cannot use `#[derive(AuthUser)]` on that
+    /// field — the generated body `Cow::Borrowed(&self.field)` will fail to
+    /// type-check. Implement `AuthUser` (etc.) manually for those entities,
+    /// returning `Cow::Owned(self.field.to_string())` or equivalent.
     CowStr,
     /// `fn x(&self) -> Option<&str>` — field is `Option<String>`
     OptionRefStr,

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -449,7 +449,7 @@ impl<DB: DatabaseAdapter> BetterAuth<DB> {
         };
 
         self.database
-            .update_user(current_user.id(), update_user)
+            .update_user(&current_user.id(), update_user)
             .await?;
 
         Ok(AuthResponse::json(
@@ -463,9 +463,9 @@ impl<DB: DatabaseAdapter> BetterAuth<DB> {
         let current_user = self.extract_current_user(req).await?;
 
         self.database
-            .delete_user_sessions(current_user.id())
+            .delete_user_sessions(&current_user.id())
             .await?;
-        self.database.delete_user(current_user.id()).await?;
+        self.database.delete_user(&current_user.id()).await?;
 
         let response = SuccessMessageResponse {
             success: true,
@@ -512,7 +512,7 @@ impl<DB: DatabaseAdapter> BetterAuth<DB> {
         };
 
         self.database
-            .update_user(current_user.id(), update_user)
+            .update_user(&current_user.id(), update_user)
             .await?;
 
         Ok(AuthResponse::json(
@@ -543,11 +543,13 @@ impl<DB: DatabaseAdapter> BetterAuth<DB> {
 
         let accounts = self.database.get_user_accounts(user_id).await?;
         for account in accounts {
-            self.database.delete_account(account.id()).await?;
+            self.database.delete_account(&account.id()).await?;
         }
 
         self.database.delete_user(user_id).await?;
-        self.database.delete_verification(verification.id()).await?;
+        self.database
+            .delete_verification(&verification.id())
+            .await?;
 
         let response = SuccessMessageResponse {
             success: true,
@@ -586,7 +588,7 @@ impl<DB: DatabaseAdapter> BetterAuth<DB> {
 
         let user = self
             .database
-            .get_user_by_id(session.user_id())
+            .get_user_by_id(&session.user_id())
             .await?
             .ok_or(AuthError::UserNotFound)?;
 

--- a/src/handlers/axum.rs
+++ b/src/handlers/axum.rs
@@ -404,7 +404,7 @@ impl<DB: DatabaseAdapter> FromRequestParts<Arc<BetterAuth<DB>>> for CurrentSessi
 
         let user = state
             .database()
-            .get_user_by_id(session.user_id())
+            .get_user_by_id(&session.user_id())
             .await
             .map_err(convert_auth_error)?
             .ok_or_else(|| convert_auth_error(AuthError::UserNotFound))?;

--- a/tests/compat_admin_tests.rs
+++ b/tests/compat_admin_tests.rs
@@ -36,7 +36,7 @@ async fn setup_admin(auth: &better_auth::BetterAuth<better_auth::MemoryDatabaseA
         ..Default::default()
     };
     auth.database()
-        .update_user(user.id(), update)
+        .update_user(&user.id(), update)
         .await
         .unwrap();
 


### PR DESCRIPTION
## Background

This PR is the first step of the B-track split of PR #56
(`refactor/app-owned-auth-schema`), labelled **PR-5: AuthEntity + `Auth*Meta`
Cow upgrade** in the split plan. It does one focused thing: let the
entity traits work with **application-owned, non-`String` primary and
foreign keys** (e.g. `Uuid`, `i64`, ULID) without changing any handler
signatures or bundled struct fields.

Today `entity.rs` already ships ten `Auth*` entity traits, ten
`Auth*Meta` SQL-metadata traits, and bundled implementations for
`User`, `Session`, `Account`, `Organization`, `Member`, `Invitation`,
`Verification`, `TwoFactor`, `ApiKey`, `Passkey`. The only change here
is the return type of ID-like accessors.

## What changes

**Trait signatures** (in `crates/core/src/entity.rs`) — primary-key
(`id()`) and foreign-key accessors now return `std::borrow::Cow<'_, str>`:

* `AuthUser`: `id`
* `AuthSession`: `id`, `user_id`
* `AuthAccount`: `id`, `user_id` (`account_id` / `provider_id` stay `&str`)
* `AuthOrganization`: `id`
* `AuthMember`: `id`, `organization_id`, `user_id`
* `AuthInvitation`: `id`, `organization_id`, `inviter_id`
* `AuthVerification`: `id`
* `AuthTwoFactor`: `id`, `user_id`
* `AuthApiKey`: `id`, `user_id`
* `AuthPasskey`: `id`, `user_id`

All other accessors keep returning plain `&str` (`name`, `email`,
`slug`, `token`, `secret`, `credential_id`, business columns, etc.).

**Bundled impls** — updated in `crates/core/src/types_impls.rs` to
return `Cow::Borrowed(&self.xxx)`. No struct fields are renamed or
retyped; the bundled types remain pure `String`-backed, so Cow
borrows are zero-copy.

**Derive macro** — `crates/derive/src/helpers.rs` gains a `CowStr`
`ReturnKind`, and the `AUTH_*_GETTERS` tables in
`crates/derive/src/auth_derive.rs` switch ID/FK rows to `CowStr`.
`#[derive(AuthUser)]` / `#[derive(AuthSession)]` / etc. therefore continue
to match the updated trait contract for the default `String` case.

**Call-site adaptation** — internal consumers that forwarded
`.id()` / `.user_id()` / `.organization_id()` / `.inviter_id()` into
database-adapter methods expecting `&str` now borrow the `Cow`
(`&session.user_id()`) or call `.as_ref()` where needed (one spot in
`api_key/mod.rs` where a `HashMap<String, _>` key was being removed).
Mechanical, behaviour-preserving.

## Why `Cow<'_, str>`?

For bundled `String`-backed IDs this is a zero-cost wrapper
(`Cow::Borrowed`). For app-owned entities whose primary key is e.g.
`Uuid` or `i64`, the trait contract now lets them return
`Cow::Owned(id.to_string())` on the fly without forcing them to store
a redundant `String` column just to satisfy the framework. This
unblocks the schema-native refactor planned in the B track of PR #56.

## Non-goals / what this PR does **not** do

* No public struct fields change. `User.id` is still `String`, etc.
* No handler `fn` signature changes, no new generic bounds on
  `DatabaseAdapter` methods.
* No runtime behaviour change.
* `examples/shared_sqlx_pool.rs` and other feature-gated examples
  continue to fail to compile on `master` — the failures here are
  identical to `master` baseline and are out of scope.

## Verification

* `cargo test --workspace --lib` — **335 passed**, 0 failed
  (9 new entity tests added; everything else unchanged).
* `cargo clippy --workspace --lib -- -D warnings` — clean.
* `cargo fmt --check` — clean.
* `cargo check --workspace --lib --features axum,sqlx-postgres,derive,redis-cache` — clean.

## Commits

1. `feat(core): switch AuthEntity ID accessors to Cow<'_, str>`
2. `test(core): cover bundled AuthEntity Cow<'_, str> accessors and meta defaults`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `Cow<'_, str>` return types for primary-key (`id()`) and foreign-key (`user_id()`, `organization_id()`, `inviter_id()`) accessors across all 10 `Auth*` entity traits in `crates/core/src/entity.rs`. The change is a focused first step toward allowing application-owned non-`String` identifiers (e.g. `Uuid`, `i64`) to satisfy the trait contract via `Cow::Owned(id.to_string())` without forcing a redundant `String` field.

Key changes:
- **Trait signatures** (`entity.rs`): 10 traits updated, ID/FK methods now return `Cow<'_, str>`; all other accessors remain `&str`
- **Bundled impls** (`types_impls.rs`): Each ID/FK getter now returns `Cow::Borrowed(&self.field)` — zero-copy for the existing `String`-backed structs; blanket `From<&T> for User` correctly uses `.into_owned()`
- **Derive macro** (`helpers.rs`, `auth_derive.rs`): New `CowStr` `ReturnKind` generates the correct signature and body for `String`-backed derived fields
- **Call-site adaptation** (17 API plugin files): All internal consumers updated using `&entity.id()` or `.as_ref()` where needed — mechanical and behaviour-preserving
- **Tests** (`entity.rs`): 9 new unit tests verify `Cow::Borrowed` is returned by bundled types and cover meta-trait defaults

This is a **semver-breaking change** (return type of public trait methods changed from `&str` to `Cow<'_, str>`). External code that manually implements these traits without the derive macros will need to update all ID/FK getter signatures. The project is pre-1.0 and all internal usages have been updated, but this should be called out in the CHANGELOG / release notes for the next version bump.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all internal consumers updated, tests pass, no runtime behaviour changes.

The change is mechanical, well-scoped, and thoroughly tested (335 existing + 9 new tests, clean clippy and fmt). Both the bundled impls and the derive macro correctly emit Cow::Borrowed for String-backed fields. All 17 affected call sites are adapted with the same consistent &entity.id() / .as_ref() pattern. The only findings are a pre-existing .to_string() vs .into_owned() inconsistency in MemberUserView::from_user (P2 micro-optimisation) and the expected-but-undocumented semver break for external manual implementors. Neither blocks merge.

No files require special attention; the derive macro's CowStr arm and the MemberUserView::from_user method are the only minor follow-up candidates.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/core/src/entity.rs | Core trait signatures updated; 9 new tests added covering Cow::Borrowed guarantee, meta-trait defaults, and invitation helpers — thorough and well-structured |
| crates/core/src/types_impls.rs | All bundled impls consistently updated to return Cow::Borrowed; blanket From<&T> for User correctly uses .into_owned() |
| crates/derive/src/helpers.rs | New CowStr ReturnKind correctly generates Cow::Borrowed(&self.field) for String-backed derived structs; well-documented variant |
| crates/derive/src/auth_derive.rs | All AUTH_*_GETTERS tables consistently updated to CowStr for id and FK columns, matching the trait signatures exactly |
| crates/api/src/plugins/api_key/mod.rs | Call sites correctly updated with &user.id() and .as_ref() for HashMap::remove; most impacted plugin file, all patterns correct |
| crates/api/src/plugins/organization/handlers/invitation.rs | All invitation handler call sites updated; Cow deref coercions into database adapter methods are correct |
| crates/api/src/plugins/organization/handlers/member.rs | Member handler call sites updated; existing .to_string() calls on Cow values are correct, if slightly sub-optimal for Cow::Owned case |
| crates/api/src/plugins/two_factor.rs | All two-factor handler call sites updated consistently with the &entity.id() pattern |
| crates/api/src/plugins/admin/mod.rs | Cow call-site updates plus two unrelated clippy fixes (unused Extension(_ps)/State(_state) bindings) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as API Handler
    participant Entity as AuthEntity (e.g. User/Session)
    participant DB as DatabaseAdapter

    Note over Entity: id() now returns Cow<'_, str>

    Caller->>Entity: .id() / .user_id() / .organization_id()
    alt Bundled String-backed type
        Entity-->>Caller: Cow::Borrowed(&self.field) [zero-copy]
    else Custom non-String type (Uuid, i64, etc.)
        Entity-->>Caller: Cow::Owned(id.to_string()) [on-the-fly]
    end

    Caller->>DB: db_method(&entity.id()) / db_method(entity.id().as_ref())
    Note over Caller,DB: &Cow<str> deref-coerces to &str at call site
    DB-->>Caller: Result
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/core/src/entity.rs`, line 635 ([link](https://github.com/better-auth-rs/better-auth-rs/blob/79be4937f8be95331f799e0d0a3be9152f71a1b1/crates/core/src/entity.rs#L635)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Prefer `.into_owned()` over `.to_string()` for `Cow<'_, str>`**

   `MemberUserView::from_user` was not updated alongside the rest of the PR, leaving a minor inefficiency. For the `Cow::Owned` variant — which is exactly the case this PR enables (e.g. `Uuid`/`i64` IDs rendered on the fly) — `.to_string()` goes through `Display::fmt` and allocates a brand-new `String`, whereas `.into_owned()` moves the already-allocated string out at zero cost.

   The rest of the PR (e.g. `From<&T> for User` in `types_impls.rs`) already uses `.into_owned()` consistently.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["test(core): cover bundled AuthEntity Cow..."](https://github.com/better-auth-rs/better-auth-rs/commit/79be4937f8be95331f799e0d0a3be9152f71a1b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28161986)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->