### PR TITLE
feat(device-authorization): implement phase 4 device flow

### DIFF
--- a/compat-tests/README.md
+++ b/compat-tests/README.md
@@ -50,6 +50,8 @@ cd compat-tests/client-tests
 bun test tests/phase0
 bun test tests/phase1
 bun test tests/phase2
+bun test tests/phase3
+bun test tests/phase4
 ```
 
 ### `compat-tests/rust-server/`
@@ -64,6 +66,8 @@ Cargo-native orchestration:
 cargo test --test client_compat_tests phase0_client_compat -- --ignored --nocapture
 cargo test --test client_compat_tests phase1_client_compat -- --ignored --nocapture
 cargo test --test client_compat_tests phase2_client_compat -- --ignored --nocapture
+cargo test --test client_compat_tests phase3_client_compat -- --ignored --nocapture
+cargo test --test client_compat_tests phase4_client_compat -- --ignored --nocapture
 cargo test --test client_compat_tests full_client_compat -- --ignored --nocapture
 ```
 
@@ -79,5 +83,7 @@ Convenience wrapper:
 bash compat-tests/client-tests/run-against-both.sh phase0
 bash compat-tests/client-tests/run-against-both.sh phase1
 bash compat-tests/client-tests/run-against-both.sh phase2
+bash compat-tests/client-tests/run-against-both.sh phase3
+bash compat-tests/client-tests/run-against-both.sh phase4
 bash compat-tests/client-tests/run-against-both.sh all
 ```

--- a/compat-tests/client-tests/package.json
+++ b/compat-tests/client-tests/package.json
@@ -3,11 +3,12 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "bun test tests/phase0 tests/phase1 tests/phase2 tests/phase3",
+    "test": "bun test tests/phase0 tests/phase1 tests/phase2 tests/phase3 tests/phase4",
     "test:phase0": "bun test tests/phase0",
     "test:phase1": "bun test tests/phase1",
     "test:phase2": "bun test tests/phase2",
-    "test:phase3": "bun test tests/phase3"
+    "test:phase3": "bun test tests/phase3",
+    "test:phase4": "bun test tests/phase4"
   },
   "dependencies": {
     "better-auth": "1.4.19",

--- a/compat-tests/client-tests/run-against-both.sh
+++ b/compat-tests/client-tests/run-against-both.sh
@@ -5,7 +5,7 @@ phase="all"
 
 for arg in "$@"; do
   case "$arg" in
-    phase0|phase1|phase2|phase3|all) phase="$arg" ;;
+    phase0|phase1|phase2|phase3|phase4|all) phase="$arg" ;;
     --skip-build) ;;
     *) echo "Unknown argument: $arg" >&2; exit 1 ;;
   esac
@@ -16,6 +16,7 @@ case "$phase" in
   phase1) test_name="phase1_client_compat" ;;
   phase2) test_name="phase2_client_compat" ;;
   phase3) test_name="phase3_client_compat" ;;
+  phase4) test_name="phase4_client_compat" ;;
   all) test_name="full_client_compat" ;;
 esac
 

--- a/compat-tests/client-tests/support/trace.ts
+++ b/compat-tests/client-tests/support/trace.ts
@@ -14,7 +14,7 @@ export type TraceEntry = {
 
 function normalizeTracePath(url: URL) {
   const normalized = new URL(url.toString());
-  for (const key of ["token", "state"]) {
+  for (const key of ["token", "state", "user_code"]) {
     if (normalized.searchParams.has(key)) {
       normalized.searchParams.set(key, `<${key}>`);
     }

--- a/compat-tests/client-tests/tests/phase4/device.test.ts
+++ b/compat-tests/client-tests/tests/phase4/device.test.ts
@@ -1,0 +1,280 @@
+import { compatScenario } from "../../support/scenario";
+
+const DEVICE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("expected object response body");
+  }
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, key: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`expected string for ${key}`);
+  }
+  return value;
+}
+
+compatScenario("device code request returns oauth device response fields", async (ctx) => {
+  const code = await ctx.rawRequest({
+    path: "/api/auth/device/code",
+    method: "POST",
+    json: {
+      client_id: "compat-device-client",
+      scope: "openid profile",
+    },
+  });
+  const body = asRecord(code.body);
+  const userCode = asString(body.user_code, "user_code");
+  const verificationUri = asString(body.verification_uri, "verification_uri");
+  const verificationUriComplete = asString(
+    body.verification_uri_complete,
+    "verification_uri_complete",
+  );
+
+  return {
+    code: {
+      status: code.status,
+      hasDeviceCode: typeof body.device_code === "string" && body.device_code.length >= 40,
+      userCodeFormat: /^[A-Z0-9]{8}$/.test(userCode),
+      expiresIn: body.expires_in,
+      interval: body.interval,
+      verificationUriHasDevicePath: verificationUri.includes("/device"),
+      verificationUriCompleteHasUserCode: verificationUriComplete.includes("user_code="),
+    },
+  };
+});
+
+compatScenario("device token returns authorization_pending while request is pending", async (ctx) => {
+  const code = await ctx.rawRequest({
+    path: "/api/auth/device/code",
+    method: "POST",
+    json: {
+      client_id: "compat-device-client",
+    },
+  });
+  const deviceCode = asString(asRecord(code.body).device_code, "device_code");
+
+  const token = await ctx.rawRequest({
+    path: "/api/auth/device/token",
+    method: "POST",
+    json: {
+      grant_type: DEVICE_GRANT_TYPE,
+      device_code: deviceCode,
+      client_id: "compat-device-client",
+    },
+  });
+
+  return {
+    token: ctx.snapshot(token),
+  };
+});
+
+compatScenario("device token returns invalid_grant for an unknown device code", async (ctx) => {
+  const token = await ctx.rawRequest({
+    path: "/api/auth/device/token",
+    method: "POST",
+    json: {
+      grant_type: DEVICE_GRANT_TYPE,
+      device_code: "unknown-device-code",
+      client_id: "compat-device-client",
+    },
+  });
+
+  return {
+    token: ctx.snapshot(token),
+  };
+});
+
+compatScenario("device verify accepts a hyphenated user code", async (ctx) => {
+  const code = await ctx.rawRequest({
+    path: "/api/auth/device/code",
+    method: "POST",
+    json: {
+      client_id: "compat-device-client",
+    },
+  });
+  const userCode = asString(asRecord(code.body).user_code, "user_code");
+  const formattedUserCode = `${userCode.slice(0, 4)}-${userCode.slice(4)}`;
+
+  const verify = await ctx.rawRequest({
+    path: `/api/auth/device?user_code=${encodeURIComponent(formattedUserCode)}`,
+  });
+  const verifyBody = asRecord(verify.body);
+
+  return {
+    verify: {
+      status: verify.status,
+      location: verify.location,
+      body: {
+        status: verifyBody.status,
+        echoedHyphenatedInput: verifyBody.user_code === formattedUserCode,
+      },
+    },
+  };
+});
+
+compatScenario("device approve flow returns a bearer token", async (ctx) => {
+  const primary = ctx.actor();
+  const email = ctx.uniqueEmail("phase4-device-approve");
+
+  const signup = await primary.client.signUp.email({
+    email,
+    password: "password123",
+    name: "Device Approve User",
+  });
+
+  const code = await ctx.rawRequest({
+    path: "/api/auth/device/code",
+    method: "POST",
+    json: {
+      client_id: "compat-device-client",
+      scope: "read write",
+    },
+  });
+  const codeBody = asRecord(code.body);
+  const deviceCode = asString(codeBody.device_code, "device_code");
+  const userCode = asString(codeBody.user_code, "user_code");
+
+  const approve = await ctx.rawRequest({
+    actor: "primary",
+    path: "/api/auth/device/approve",
+    method: "POST",
+    json: {
+      userCode,
+    },
+  });
+
+  const token = await ctx.rawRequest({
+    path: "/api/auth/device/token",
+    method: "POST",
+    json: {
+      grant_type: DEVICE_GRANT_TYPE,
+      device_code: deviceCode,
+      client_id: "compat-device-client",
+    },
+  });
+
+  return {
+    signup: ctx.snapshot(signup),
+    approve: ctx.snapshot(approve),
+    token: ctx.snapshot(token),
+  };
+});
+
+compatScenario("device deny flow returns access_denied", async (ctx) => {
+  const primary = ctx.actor();
+  const email = ctx.uniqueEmail("phase4-device-deny");
+
+  const signup = await primary.client.signUp.email({
+    email,
+    password: "password123",
+    name: "Device Deny User",
+  });
+
+  const code = await ctx.rawRequest({
+    path: "/api/auth/device/code",
+    method: "POST",
+    json: {
+      client_id: "compat-device-client",
+    },
+  });
+  const codeBody = asRecord(code.body);
+  const deviceCode = asString(codeBody.device_code, "device_code");
+  const userCode = asString(codeBody.user_code, "user_code");
+
+  const deny = await ctx.rawRequest({
+    actor: "primary",
+    path: "/api/auth/device/deny",
+    method: "POST",
+    json: {
+      userCode,
+    },
+  });
+
+  const token = await ctx.rawRequest({
+    path: "/api/auth/device/token",
+    method: "POST",
+    json: {
+      grant_type: DEVICE_GRANT_TYPE,
+      device_code: deviceCode,
+      client_id: "compat-device-client",
+    },
+  });
+
+  return {
+    signup: ctx.snapshot(signup),
+    deny: ctx.snapshot(deny),
+    token: ctx.snapshot(token),
+  };
+});
+
+compatScenario("device approve blocks already-processed codes", async (ctx) => {
+  const primary = ctx.actor();
+  const email = ctx.uniqueEmail("phase4-device-double-approve");
+
+  const signup = await primary.client.signUp.email({
+    email,
+    password: "password123",
+    name: "Device Double Approve User",
+  });
+
+  const code = await ctx.rawRequest({
+    path: "/api/auth/device/code",
+    method: "POST",
+    json: {
+      client_id: "compat-device-client",
+    },
+  });
+  const userCode = asString(asRecord(code.body).user_code, "user_code");
+
+  const firstApprove = await ctx.rawRequest({
+    actor: "primary",
+    path: "/api/auth/device/approve",
+    method: "POST",
+    json: {
+      userCode,
+    },
+  });
+
+  const secondApprove = await ctx.rawRequest({
+    actor: "primary",
+    path: "/api/auth/device/approve",
+    method: "POST",
+    json: {
+      userCode,
+    },
+  });
+
+  return {
+    signup: ctx.snapshot(signup),
+    firstApprove: ctx.snapshot(firstApprove),
+    secondApprove: ctx.snapshot(secondApprove),
+  };
+});
+
+compatScenario("device token rejects a mismatched client id", async (ctx) => {
+  const code = await ctx.rawRequest({
+    path: "/api/auth/device/code",
+    method: "POST",
+    json: {
+      client_id: "compat-device-client-a",
+    },
+  });
+  const deviceCode = asString(asRecord(code.body).device_code, "device_code");
+
+  const token = await ctx.rawRequest({
+    path: "/api/auth/device/token",
+    method: "POST",
+    json: {
+      grant_type: DEVICE_GRANT_TYPE,
+      device_code: deviceCode,
+      client_id: "compat-device-client-b",
+    },
+  });
+
+  return {
+    token: ctx.snapshot(token),
+  };
+});

--- a/compat-tests/reference-server/server.ts
+++ b/compat-tests/reference-server/server.ts
@@ -3,6 +3,7 @@
 import { Database } from "bun:sqlite";
 import { betterAuth } from "better-auth";
 import { getMigrations } from "better-auth/db";
+import { deviceAuthorization } from "better-auth/plugins";
 import { genericOAuth } from "better-auth/plugins/generic-oauth";
 
 function getPort() {
@@ -312,6 +313,7 @@ const authOptions = {
     },
   },
   plugins: [
+    deviceAuthorization(),
     genericOAuth({
       config: [
         {

--- a/compat-tests/rust-server/Cargo.lock
+++ b/compat-tests/rust-server/Cargo.lock
@@ -538,6 +538,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "better-auth-schema-registry"
+version = "0.10.0"
+
+[[package]]
 name = "better-auth-seaorm"
 version = "0.10.0"
 dependencies = [
@@ -558,6 +562,7 @@ dependencies = [
 name = "better-auth-seaorm-macros"
 version = "0.10.0"
 dependencies = [
+ "better-auth-schema-registry",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -869,16 +874,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1120,15 +1115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1413,25 +1399,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1589,7 +1556,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1600,22 +1566,6 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
 ]
 
 [[package]]
@@ -1652,11 +1602,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -2741,19 +2689,15 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -3123,7 +3067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3641,27 +3585,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3813,35 +3736,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
@@ -4399,17 +4299,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
 
 [[package]]
 name = "windows-result"

--- a/compat-tests/rust-server/src/main.rs
+++ b/compat-tests/rust-server/src/main.rs
@@ -7,8 +7,9 @@ use axum::{
 use better_auth::integrations::axum::AxumIntegration;
 use better_auth::prelude::{AuthAccount, AuthUser, CreateAccount, CreateVerification};
 use better_auth::plugins::{
-    AccountManagementPlugin, EmailPasswordPlugin, EmailVerificationPlugin, OAuthPlugin,
-    PasswordManagementPlugin, SessionManagementPlugin, UserManagementPlugin,
+    AccountManagementPlugin, DeviceAuthorizationPlugin, EmailPasswordPlugin,
+    EmailVerificationPlugin, OAuthPlugin, PasswordManagementPlugin, SessionManagementPlugin,
+    UserManagementPlugin,
     email_verification::SendVerificationEmail, user_management::SendChangeEmailConfirmation,
     oauth::{
         OAuthIdTokenVerifier, OAuthProvider, OAuthRefreshTokenHandler, OAuthTokenSet, OAuthUserInfo,
@@ -471,6 +472,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .plugin(EmailPasswordPlugin::new().enable_signup(true))
             .plugin(SessionManagementPlugin::new())
             .plugin(AccountManagementPlugin::new())
+            .plugin(DeviceAuthorizationPlugin::new())
             .plugin(
                 PasswordManagementPlugin::new().send_reset_password(Arc::new(CompatResetSender {
                     outbox: reset_outbox.clone(),

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -29,6 +29,7 @@ pub mod plugins;
 
 pub use plugins::account_management::AccountManagementPlugin;
 pub use plugins::api_key::{ApiKeyConfig, ApiKeyPlugin};
+pub use plugins::device_authorization::DeviceAuthorizationPlugin;
 pub use plugins::email_password::EmailPasswordPlugin;
 pub use plugins::email_verification::EmailVerificationPlugin;
 pub use plugins::oauth::OAuthPlugin;

--- a/crates/api/src/plugins/device_authorization/mod.rs
+++ b/crates/api/src/plugins/device_authorization/mod.rs
@@ -369,7 +369,13 @@ impl DeviceAuthorizationPlugin {
                 .await
             {
                 Ok(session) => session,
-                Err(_) => {
+                Err(error) => {
+                    tracing::error!(
+                        error = %error,
+                        device_code_id = %device_code.id,
+                        user_id,
+                        "failed to create session after device code redemption"
+                    );
                     return device_error_response(500, "server_error", FAILED_TO_CREATE_SESSION);
                 }
             };
@@ -491,10 +497,11 @@ impl DeviceAuthorizationPlugin {
                 .unwrap_or_else(|| current_user_id.clone()),
         };
 
-        let _ = ctx
+        let updated = ctx
             .database
-            .update_device_code(
+            .update_device_code_if_status(
                 &device_code.id,
+                DEVICE_STATUS_PENDING,
                 UpdateDeviceCode {
                     status: Some(decision.status().to_string()),
                     user_id: Some(Some(updated_user_id)),
@@ -502,6 +509,10 @@ impl DeviceAuthorizationPlugin {
                 },
             )
             .await?;
+
+        if !updated {
+            return device_error_response(400, "invalid_request", DEVICE_CODE_ALREADY_PROCESSED);
+        }
 
         AuthResponse::json(200, &DeviceActionResponse { success: true }).map_err(AuthError::from)
     }

--- a/crates/api/src/plugins/device_authorization/mod.rs
+++ b/crates/api/src/plugins/device_authorization/mod.rs
@@ -354,6 +354,14 @@ impl DeviceAuthorizationPlugin {
                 return device_error_response(500, "server_error", USER_NOT_FOUND);
             };
 
+            if !ctx
+                .database
+                .delete_device_code_if_status(&device_code.id, DEVICE_STATUS_APPROVED)
+                .await?
+            {
+                return device_error_response(400, "invalid_grant", INVALID_DEVICE_CODE);
+            }
+
             let meta = RequestMeta::from_request(req);
             let session = match ctx
                 .session_manager()
@@ -365,8 +373,6 @@ impl DeviceAuthorizationPlugin {
                     return device_error_response(500, "server_error", FAILED_TO_CREATE_SESSION);
                 }
             };
-
-            ctx.database.delete_device_code(&device_code.id).await?;
 
             return Ok(AuthResponse::json(
                 200,

--- a/crates/api/src/plugins/device_authorization/mod.rs
+++ b/crates/api/src/plugins/device_authorization/mod.rs
@@ -1,0 +1,595 @@
+use chrono::{Duration, Utc};
+use rand::RngCore;
+use rand::distributions::{Alphanumeric, DistString};
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use url::Url;
+
+use better_auth_core::entity::{AuthSession, AuthUser};
+use better_auth_core::{
+    AuthContext, AuthError, AuthRequest, AuthResponse, AuthResult, CreateDeviceCode, RequestMeta,
+    UpdateDeviceCode,
+};
+
+pub(super) mod types;
+
+#[cfg(test)]
+mod tests;
+
+use types::{
+    DeviceActionRequest, DeviceActionResponse, DeviceCodeRequest, DeviceCodeResponse,
+    DeviceErrorResponse, DeviceTokenRequest, DeviceTokenResponse, DeviceVerifyResponse,
+};
+
+const DEVICE_GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:device_code";
+const DEVICE_STATUS_PENDING: &str = "pending";
+const DEVICE_STATUS_APPROVED: &str = "approved";
+const DEVICE_STATUS_DENIED: &str = "denied";
+const DEFAULT_USER_CODE_CHARSET: &[u8] = b"ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+const INVALID_DEVICE_CODE: &str = "Invalid device code";
+const EXPIRED_DEVICE_CODE: &str = "Device code has expired";
+const EXPIRED_USER_CODE: &str = "User code has expired";
+const AUTHORIZATION_PENDING: &str = "Authorization pending";
+const ACCESS_DENIED: &str = "Access denied";
+const INVALID_USER_CODE: &str = "Invalid user code";
+const DEVICE_CODE_ALREADY_PROCESSED: &str = "Device code already processed";
+const POLLING_TOO_FREQUENTLY: &str = "Polling too frequently";
+const USER_NOT_FOUND: &str = "User not found";
+const FAILED_TO_CREATE_SESSION: &str = "Failed to create session";
+const INVALID_DEVICE_CODE_STATUS: &str = "Invalid device code status";
+const AUTHENTICATION_REQUIRED: &str = "Authentication required";
+const INVALID_CLIENT_ID: &str = "Invalid client ID";
+const CLIENT_ID_MISMATCH: &str = "Client ID mismatch";
+const INVALID_REQUEST: &str = "Invalid request";
+
+type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+type ValidateClientCallback = dyn Fn(String) -> BoxFuture<AuthResult<bool>> + Send + Sync;
+type DeviceAuthRequestCallback =
+    dyn Fn(String, Option<String>) -> BoxFuture<AuthResult<()>> + Send + Sync;
+type CodeGenerator = dyn Fn() -> String + Send + Sync;
+
+#[derive(Clone)]
+struct DeviceAuthorizationConfig {
+    expires_in: Duration,
+    interval: Duration,
+    device_code_length: usize,
+    user_code_length: usize,
+    generate_device_code: Option<Arc<CodeGenerator>>,
+    generate_user_code: Option<Arc<CodeGenerator>>,
+    validate_client: Option<Arc<ValidateClientCallback>>,
+    on_device_auth_request: Option<Arc<DeviceAuthRequestCallback>>,
+    verification_uri: Option<String>,
+}
+
+impl Default for DeviceAuthorizationConfig {
+    fn default() -> Self {
+        Self {
+            expires_in: Duration::minutes(30),
+            interval: Duration::seconds(5),
+            device_code_length: 40,
+            user_code_length: 8,
+            generate_device_code: None,
+            generate_user_code: None,
+            validate_client: None,
+            on_device_auth_request: None,
+            verification_uri: None,
+        }
+    }
+}
+
+impl fmt::Debug for DeviceAuthorizationConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DeviceAuthorizationConfig")
+            .field("expires_in", &self.expires_in)
+            .field("interval", &self.interval)
+            .field("device_code_length", &self.device_code_length)
+            .field("user_code_length", &self.user_code_length)
+            .field(
+                "generate_device_code",
+                &self.generate_device_code.as_ref().map(|_| "custom"),
+            )
+            .field(
+                "generate_user_code",
+                &self.generate_user_code.as_ref().map(|_| "custom"),
+            )
+            .field(
+                "validate_client",
+                &self.validate_client.as_ref().map(|_| "custom"),
+            )
+            .field(
+                "on_device_auth_request",
+                &self.on_device_auth_request.as_ref().map(|_| "custom"),
+            )
+            .field("verification_uri", &self.verification_uri)
+            .finish()
+    }
+}
+
+#[derive(Clone, Copy)]
+enum DeviceDecision {
+    Approve,
+    Deny,
+}
+
+impl DeviceDecision {
+    fn status(self) -> &'static str {
+        match self {
+            Self::Approve => DEVICE_STATUS_APPROVED,
+            Self::Deny => DEVICE_STATUS_DENIED,
+        }
+    }
+
+    fn forbidden_message(self) -> &'static str {
+        match self {
+            Self::Approve => "You are not authorized to approve this device authorization",
+            Self::Deny => "You are not authorized to deny this device authorization",
+        }
+    }
+}
+
+/// OAuth 2.0 device authorization grant plugin.
+pub struct DeviceAuthorizationPlugin {
+    config: DeviceAuthorizationConfig,
+}
+
+impl Default for DeviceAuthorizationPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeviceAuthorizationPlugin {
+    /// Create the plugin with TS-aligned defaults.
+    pub fn new() -> Self {
+        Self {
+            config: DeviceAuthorizationConfig::default(),
+        }
+    }
+
+    /// Override the device-code expiration window.
+    pub fn expires_in(mut self, duration: Duration) -> Self {
+        self.config.expires_in = duration;
+        self
+    }
+
+    /// Override the minimum polling interval enforced by `/device/token`.
+    pub fn interval(mut self, duration: Duration) -> Self {
+        self.config.interval = duration;
+        self
+    }
+
+    /// Override the generated device-code length.
+    pub fn device_code_length(mut self, length: usize) -> Self {
+        self.config.device_code_length = length;
+        self
+    }
+
+    /// Override the generated user-code length.
+    pub fn user_code_length(mut self, length: usize) -> Self {
+        self.config.user_code_length = length;
+        self
+    }
+
+    /// Override the verification page URI returned to devices.
+    pub fn verification_uri(mut self, uri: impl Into<String>) -> Self {
+        self.config.verification_uri = Some(uri.into());
+        self
+    }
+
+    /// Use a custom device-code generator.
+    pub fn generate_device_code_with<F>(mut self, generator: F) -> Self
+    where
+        F: Fn() -> String + Send + Sync + 'static,
+    {
+        self.config.generate_device_code = Some(Arc::new(generator));
+        self
+    }
+
+    /// Use a custom user-code generator.
+    pub fn generate_user_code_with<F>(mut self, generator: F) -> Self
+    where
+        F: Fn() -> String + Send + Sync + 'static,
+    {
+        self.config.generate_user_code = Some(Arc::new(generator));
+        self
+    }
+
+    /// Validate the OAuth client identifier before issuing or redeeming codes.
+    pub fn validate_client<F, Fut>(mut self, callback: F) -> Self
+    where
+        F: Fn(String) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = AuthResult<bool>> + Send + 'static,
+    {
+        self.config.validate_client =
+            Some(Arc::new(move |client_id| Box::pin(callback(client_id))));
+        self
+    }
+
+    /// Run a hook when a device authorization request is created.
+    pub fn on_device_auth_request<F, Fut>(mut self, callback: F) -> Self
+    where
+        F: Fn(String, Option<String>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = AuthResult<()>> + Send + 'static,
+    {
+        self.config.on_device_auth_request = Some(Arc::new(move |client_id, scope| {
+            Box::pin(callback(client_id, scope))
+        }));
+        self
+    }
+
+    async fn handle_device_code(
+        &self,
+        req: &AuthRequest,
+        ctx: &AuthContext<impl better_auth_core::AuthSchema>,
+    ) -> AuthResult<AuthResponse> {
+        let body: DeviceCodeRequest = match better_auth_core::validate_request_body(req) {
+            Ok(value) => value,
+            Err(response) => return Ok(response),
+        };
+
+        if !self.validate_client_id(&body.client_id).await? {
+            return device_error_response(400, "invalid_client", INVALID_CLIENT_ID);
+        }
+
+        if let Some(callback) = &self.config.on_device_auth_request {
+            callback(body.client_id.clone(), body.scope.clone()).await?;
+        }
+
+        let device_code = self.generate_device_code();
+        let user_code = self.generate_user_code();
+        let expires_at = Utc::now() + self.config.expires_in;
+        let polling_interval = self.config.interval.num_milliseconds();
+
+        let _ = ctx
+            .database
+            .create_device_code(CreateDeviceCode {
+                device_code: device_code.clone(),
+                user_code: user_code.clone(),
+                user_id: None,
+                expires_at,
+                status: DEVICE_STATUS_PENDING.to_string(),
+                last_polled_at: None,
+                polling_interval: Some(polling_interval),
+                client_id: Some(body.client_id.clone()),
+                scope: body.scope.clone(),
+            })
+            .await?;
+
+        let (verification_uri, verification_uri_complete) = build_verification_uris(
+            self.config.verification_uri.as_deref(),
+            &ctx.config.base_url,
+            &user_code,
+        )?;
+
+        Ok(AuthResponse::json(
+            200,
+            &DeviceCodeResponse {
+                device_code,
+                user_code,
+                verification_uri,
+                verification_uri_complete,
+                expires_in: self.config.expires_in.num_seconds(),
+                interval: self.config.interval.num_seconds(),
+            },
+        )?
+        .with_header("Cache-Control", "no-store"))
+    }
+
+    async fn handle_device_token(
+        &self,
+        req: &AuthRequest,
+        ctx: &AuthContext<impl better_auth_core::AuthSchema>,
+    ) -> AuthResult<AuthResponse> {
+        let body: DeviceTokenRequest = match better_auth_core::validate_request_body(req) {
+            Ok(value) => value,
+            Err(response) => return Ok(response),
+        };
+
+        if body.grant_type != DEVICE_GRANT_TYPE {
+            return device_error_response(400, "invalid_request", INVALID_REQUEST);
+        }
+
+        if !self.validate_client_id(&body.client_id).await? {
+            return device_error_response(400, "invalid_grant", INVALID_CLIENT_ID);
+        }
+
+        let Some(device_code) = ctx
+            .database
+            .get_device_code_by_device_code(&body.device_code)
+            .await?
+        else {
+            return device_error_response(400, "invalid_grant", INVALID_DEVICE_CODE);
+        };
+
+        if let Some(client_id) = device_code.client_id.as_deref()
+            && client_id != body.client_id
+        {
+            return device_error_response(400, "invalid_grant", CLIENT_ID_MISMATCH);
+        }
+
+        let now = Utc::now();
+        if let (Some(last_polled_at), Some(polling_interval)) =
+            (device_code.last_polled_at, device_code.polling_interval)
+        {
+            let elapsed = now.signed_duration_since(last_polled_at).num_milliseconds();
+            if elapsed < polling_interval {
+                return device_error_response(400, "slow_down", POLLING_TOO_FREQUENTLY);
+            }
+        }
+
+        let _ = ctx
+            .database
+            .update_device_code(
+                &device_code.id,
+                UpdateDeviceCode {
+                    last_polled_at: Some(Some(now)),
+                    ..Default::default()
+                },
+            )
+            .await?;
+
+        if device_code.expires_at < now {
+            ctx.database.delete_device_code(&device_code.id).await?;
+            return device_error_response(400, "expired_token", EXPIRED_DEVICE_CODE);
+        }
+
+        if device_code.status == DEVICE_STATUS_PENDING {
+            return device_error_response(400, "authorization_pending", AUTHORIZATION_PENDING);
+        }
+
+        if device_code.status == DEVICE_STATUS_DENIED {
+            ctx.database.delete_device_code(&device_code.id).await?;
+            return device_error_response(400, "access_denied", ACCESS_DENIED);
+        }
+
+        if device_code.status == DEVICE_STATUS_APPROVED {
+            let Some(user_id) = device_code.user_id.as_deref() else {
+                return device_error_response(500, "server_error", INVALID_DEVICE_CODE_STATUS);
+            };
+
+            let Some(user) = ctx.database.get_user_by_id(user_id).await? else {
+                return device_error_response(500, "server_error", USER_NOT_FOUND);
+            };
+
+            let meta = RequestMeta::from_request(req);
+            let session = match ctx
+                .session_manager()
+                .create_session(&user, meta.ip_address, meta.user_agent)
+                .await
+            {
+                Ok(session) => session,
+                Err(_) => {
+                    return device_error_response(500, "server_error", FAILED_TO_CREATE_SESSION);
+                }
+            };
+
+            ctx.database.delete_device_code(&device_code.id).await?;
+
+            return Ok(AuthResponse::json(
+                200,
+                &DeviceTokenResponse {
+                    access_token: session.token().to_string(),
+                    token_type: "Bearer",
+                    expires_in: ctx.config.session.expires_in.num_seconds(),
+                    scope: device_code.scope.unwrap_or_default(),
+                },
+            )?
+            .with_header("Cache-Control", "no-store")
+            .with_header("Pragma", "no-cache"));
+        }
+
+        device_error_response(500, "server_error", INVALID_DEVICE_CODE_STATUS)
+    }
+
+    async fn handle_device_verify(
+        &self,
+        req: &AuthRequest,
+        ctx: &AuthContext<impl better_auth_core::AuthSchema>,
+    ) -> AuthResult<AuthResponse> {
+        let Some(user_code) = req.query.get("user_code").cloned() else {
+            return device_error_response(400, "invalid_request", INVALID_REQUEST);
+        };
+
+        let clean_user_code = user_code.replace('-', "");
+        let Some(device_code) = ctx
+            .database
+            .get_device_code_by_user_code(&clean_user_code)
+            .await?
+        else {
+            return device_error_response(400, "invalid_request", INVALID_USER_CODE);
+        };
+
+        if device_code.expires_at < Utc::now() {
+            return device_error_response(400, "expired_token", EXPIRED_USER_CODE);
+        }
+
+        AuthResponse::json(
+            200,
+            &DeviceVerifyResponse {
+                user_code,
+                status: device_code.status,
+            },
+        )
+        .map_err(AuthError::from)
+    }
+
+    async fn handle_device_approve(
+        &self,
+        req: &AuthRequest,
+        ctx: &AuthContext<impl better_auth_core::AuthSchema>,
+    ) -> AuthResult<AuthResponse> {
+        self.handle_device_decision(req, ctx, DeviceDecision::Approve)
+            .await
+    }
+
+    async fn handle_device_deny(
+        &self,
+        req: &AuthRequest,
+        ctx: &AuthContext<impl better_auth_core::AuthSchema>,
+    ) -> AuthResult<AuthResponse> {
+        self.handle_device_decision(req, ctx, DeviceDecision::Deny)
+            .await
+    }
+
+    async fn handle_device_decision(
+        &self,
+        req: &AuthRequest,
+        ctx: &AuthContext<impl better_auth_core::AuthSchema>,
+        decision: DeviceDecision,
+    ) -> AuthResult<AuthResponse> {
+        let user = match ctx.require_session(req).await {
+            Ok((user, _session)) => user,
+            Err(AuthError::Unauthenticated) | Err(AuthError::SessionNotFound) => {
+                return device_error_response(401, "unauthorized", AUTHENTICATION_REQUIRED);
+            }
+            Err(error) => return Err(error),
+        };
+
+        let current_user_id = user.id().into_owned();
+        let body: DeviceActionRequest = match better_auth_core::validate_request_body(req) {
+            Ok(value) => value,
+            Err(response) => return Ok(response),
+        };
+
+        let clean_user_code = body.user_code.replace('-', "");
+        let Some(device_code) = ctx
+            .database
+            .get_device_code_by_user_code(&clean_user_code)
+            .await?
+        else {
+            return device_error_response(400, "invalid_request", INVALID_USER_CODE);
+        };
+
+        if device_code.expires_at < Utc::now() {
+            return device_error_response(400, "expired_token", EXPIRED_USER_CODE);
+        }
+
+        if device_code.status != DEVICE_STATUS_PENDING {
+            return device_error_response(400, "invalid_request", DEVICE_CODE_ALREADY_PROCESSED);
+        }
+
+        if let Some(user_id) = device_code.user_id.as_deref()
+            && user_id != current_user_id
+        {
+            return device_error_response(403, "access_denied", decision.forbidden_message());
+        }
+
+        let updated_user_id = match decision {
+            DeviceDecision::Approve => current_user_id.clone(),
+            DeviceDecision::Deny => device_code
+                .user_id
+                .clone()
+                .unwrap_or_else(|| current_user_id.clone()),
+        };
+
+        let _ = ctx
+            .database
+            .update_device_code(
+                &device_code.id,
+                UpdateDeviceCode {
+                    status: Some(decision.status().to_string()),
+                    user_id: Some(Some(updated_user_id)),
+                    ..Default::default()
+                },
+            )
+            .await?;
+
+        AuthResponse::json(200, &DeviceActionResponse { success: true }).map_err(AuthError::from)
+    }
+
+    async fn validate_client_id(&self, client_id: &str) -> AuthResult<bool> {
+        match &self.config.validate_client {
+            Some(callback) => callback(client_id.to_string()).await,
+            None => Ok(true),
+        }
+    }
+
+    fn generate_device_code(&self) -> String {
+        self.config
+            .generate_device_code
+            .as_ref()
+            .map(|generator| generator())
+            .unwrap_or_else(|| {
+                Alphanumeric.sample_string(&mut rand::rngs::OsRng, self.config.device_code_length)
+            })
+    }
+
+    fn generate_user_code(&self) -> String {
+        self.config
+            .generate_user_code
+            .as_ref()
+            .map(|generator| generator())
+            .unwrap_or_else(|| default_generate_user_code(self.config.user_code_length))
+    }
+}
+
+better_auth_core::impl_auth_plugin! {
+    DeviceAuthorizationPlugin, "device-authorization";
+    routes {
+        post "/device/code" => handle_device_code, "device_code";
+        post "/device/token" => handle_device_token, "device_token";
+        get "/device" => handle_device_verify, "device_verify";
+        post "/device/approve" => handle_device_approve, "device_approve";
+        post "/device/deny" => handle_device_deny, "device_deny";
+    }
+}
+
+fn build_verification_uris(
+    verification_uri: Option<&str>,
+    base_url: &str,
+    user_code: &str,
+) -> AuthResult<(String, String)> {
+    let uri = verification_uri.unwrap_or("/device");
+    let verification_url = match Url::parse(uri) {
+        Ok(url) => url,
+        Err(_) => Url::parse(base_url)
+            .map_err(|error| AuthError::config(format!("Invalid base URL: {error}")))?
+            .join(uri)
+            .map_err(|error| {
+                AuthError::bad_request(format!("Invalid verification URI: {error}"))
+            })?,
+    };
+
+    let mut verification_uri_complete = verification_url.clone();
+    let _ = verification_uri_complete
+        .query_pairs_mut()
+        .append_pair("user_code", user_code);
+
+    Ok((
+        verification_url.to_string(),
+        verification_uri_complete.to_string(),
+    ))
+}
+
+fn default_generate_user_code(length: usize) -> String {
+    let mut bytes = vec![0u8; length];
+    rand::rngs::OsRng.fill_bytes(&mut bytes);
+    bytes
+        .into_iter()
+        .map(|byte| {
+            let index = usize::from(byte) % DEFAULT_USER_CODE_CHARSET.len();
+            DEFAULT_USER_CODE_CHARSET
+                .get(index)
+                .copied()
+                .unwrap_or(b'A') as char
+        })
+        .collect()
+}
+
+fn device_error_response(
+    status: u16,
+    error: &str,
+    error_description: &str,
+) -> AuthResult<AuthResponse> {
+    AuthResponse::json(
+        status,
+        &DeviceErrorResponse {
+            error: error.to_string(),
+            error_description: error_description.to_string(),
+        },
+    )
+    .map_err(AuthError::from)
+}

--- a/crates/api/src/plugins/device_authorization/tests.rs
+++ b/crates/api/src/plugins/device_authorization/tests.rs
@@ -1,0 +1,584 @@
+use std::collections::HashMap;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use chrono::{Duration, Utc};
+use serde_json::Value;
+
+use better_auth_core::{AuthResponse, CreateDeviceCode, CreateUser, HttpMethod};
+
+use crate::plugins::test_helpers;
+
+use super::*;
+
+type TestSchema = better_auth_seaorm::store::__private_test_support::bundled_schema::BundledSchema;
+
+fn json_body(response: &AuthResponse) -> Value {
+    serde_json::from_slice(&response.body).unwrap()
+}
+
+fn device_token_request(device_code: &str, client_id: &str) -> better_auth_core::AuthRequest {
+    test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/token",
+        None,
+        Some(serde_json::json!({
+            "grant_type": DEVICE_GRANT_TYPE,
+            "device_code": device_code,
+            "client_id": client_id,
+        })),
+    )
+}
+
+fn device_verify_request(user_code: &str) -> better_auth_core::AuthRequest {
+    let mut query = HashMap::new();
+    let _ = query.insert("user_code".to_string(), user_code.to_string());
+    test_helpers::create_auth_request(HttpMethod::Get, "/device", None, None, query)
+}
+
+async fn create_context_with_user(
+    email: &str,
+) -> (
+    better_auth_core::AuthContext<TestSchema>,
+    better_auth_core::wire::UserView,
+    better_auth_core::wire::SessionView,
+) {
+    test_helpers::create_test_context_with_user(
+        CreateUser::new()
+            .with_email(email.to_string())
+            .with_name("Device Auth User"),
+        Duration::hours(1),
+    )
+    .await
+}
+
+// Upstream source: packages/better-auth/src/plugins/device-authorization/routes.ts and device-authorization.test.ts; adapted to the Rust plugin handlers.
+#[tokio::test]
+async fn test_device_code_response_shape_and_storage() {
+    let plugin = DeviceAuthorizationPlugin::new()
+        .expires_in(Duration::minutes(5))
+        .interval(Duration::seconds(2))
+        .verification_uri("/auth/device?lang=en");
+    let ctx = test_helpers::create_test_context().await;
+
+    let request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/code",
+        None,
+        Some(serde_json::json!({
+            "client_id": "test-client",
+            "scope": "openid profile",
+        })),
+    );
+
+    let response = plugin.handle_device_code(&request, &ctx).await.unwrap();
+    let body = json_body(&response);
+
+    assert_eq!(response.status, 200);
+    assert_eq!(
+        response.headers.get("Cache-Control"),
+        Some(&"no-store".to_string())
+    );
+    assert_eq!(body["expires_in"], 300);
+    assert_eq!(body["interval"], 2);
+    assert!(body["device_code"].as_str().unwrap().len() >= 40);
+    assert!(body["user_code"].as_str().unwrap().len() >= 8);
+    assert!(
+        body["user_code"]
+            .as_str()
+            .unwrap()
+            .chars()
+            .all(|char| { DEFAULT_USER_CODE_CHARSET.contains(&(char as u8)) })
+    );
+    assert!(
+        body["verification_uri"]
+            .as_str()
+            .unwrap()
+            .contains("/auth/device?lang=en")
+    );
+    assert!(
+        body["verification_uri_complete"]
+            .as_str()
+            .unwrap()
+            .contains("lang=en")
+    );
+    assert!(
+        body["verification_uri_complete"]
+            .as_str()
+            .unwrap()
+            .contains("user_code=")
+    );
+
+    let stored = ctx
+        .database
+        .get_device_code_by_device_code(body["device_code"].as_str().unwrap())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.polling_interval, Some(2000));
+    assert_eq!(stored.client_id.as_deref(), Some("test-client"));
+    assert_eq!(stored.scope.as_deref(), Some("openid profile"));
+}
+
+// Upstream source: packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts :: client validation scenarios; adapted to the Rust plugin builder API.
+#[tokio::test]
+async fn test_device_code_rejects_invalid_client() {
+    let plugin = DeviceAuthorizationPlugin::new()
+        .validate_client(|client_id| async move { Ok(client_id == "valid-client") });
+    let ctx = test_helpers::create_test_context().await;
+
+    let request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/code",
+        None,
+        Some(serde_json::json!({
+            "client_id": "invalid-client",
+        })),
+    );
+
+    let response = plugin.handle_device_code(&request, &ctx).await.unwrap();
+    let body = json_body(&response);
+
+    assert_eq!(response.status, 400);
+    assert_eq!(body["error"], "invalid_client");
+    assert_eq!(body["error_description"], INVALID_CLIENT_ID);
+}
+
+// Upstream source: packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts :: callback/generator coverage; adapted to the Rust plugin builder API.
+#[tokio::test]
+async fn test_device_code_uses_custom_generators_and_hook() {
+    let hook_calls = Arc::new(AtomicUsize::new(0));
+    let hook_calls_clone = hook_calls.clone();
+    let plugin = DeviceAuthorizationPlugin::new()
+        .generate_device_code_with(|| "custom-device-code".to_string())
+        .generate_user_code_with(|| "CUSTOM12".to_string())
+        .on_device_auth_request(move |client_id, scope| {
+            let hook_calls = hook_calls_clone.clone();
+            async move {
+                assert_eq!(client_id, "hook-client");
+                assert_eq!(scope.as_deref(), Some("openid"));
+                hook_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        })
+        .verification_uri("https://example.com/device");
+    let ctx = test_helpers::create_test_context().await;
+
+    let request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/code",
+        None,
+        Some(serde_json::json!({
+            "client_id": "hook-client",
+            "scope": "openid",
+        })),
+    );
+
+    let response = plugin.handle_device_code(&request, &ctx).await.unwrap();
+    let body = json_body(&response);
+
+    assert_eq!(body["device_code"], "custom-device-code");
+    assert_eq!(body["user_code"], "CUSTOM12");
+    assert_eq!(body["verification_uri"], "https://example.com/device");
+    assert_eq!(
+        body["verification_uri_complete"],
+        "https://example.com/device?user_code=CUSTOM12"
+    );
+    assert_eq!(hook_calls.load(Ordering::SeqCst), 1);
+}
+
+// Upstream source: packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts :: "should return authorization_pending when not approved".
+#[tokio::test]
+async fn test_device_token_pending_returns_authorization_pending() {
+    let plugin = DeviceAuthorizationPlugin::new();
+    let ctx = test_helpers::create_test_context().await;
+
+    let create_request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/code",
+        None,
+        Some(serde_json::json!({ "client_id": "test-client" })),
+    );
+    let create_response = plugin
+        .handle_device_code(&create_request, &ctx)
+        .await
+        .unwrap();
+    let create_body = json_body(&create_response);
+
+    let token_request =
+        device_token_request(create_body["device_code"].as_str().unwrap(), "test-client");
+    let token_response = plugin
+        .handle_device_token(&token_request, &ctx)
+        .await
+        .unwrap();
+    let token_body = json_body(&token_response);
+
+    assert_eq!(token_response.status, 400);
+    assert_eq!(token_body["error"], "authorization_pending");
+    assert_eq!(token_body["error_description"], AUTHORIZATION_PENDING);
+}
+
+// Upstream source: packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts :: "should return expired_token for expired device codes".
+#[tokio::test]
+async fn test_device_token_expired_returns_error_and_deletes_record() {
+    let plugin = DeviceAuthorizationPlugin::new();
+    let ctx = test_helpers::create_test_context().await;
+
+    let stored = ctx
+        .database
+        .create_device_code(CreateDeviceCode {
+            device_code: "expired-device-code".to_string(),
+            user_code: "EXPIRED12".to_string(),
+            user_id: None,
+            expires_at: Utc::now() - Duration::seconds(1),
+            status: DEVICE_STATUS_PENDING.to_string(),
+            last_polled_at: None,
+            polling_interval: Some(5000),
+            client_id: Some("test-client".to_string()),
+            scope: None,
+        })
+        .await
+        .unwrap();
+
+    let response = plugin
+        .handle_device_token(
+            &device_token_request(&stored.device_code, "test-client"),
+            &ctx,
+        )
+        .await
+        .unwrap();
+    let body = json_body(&response);
+
+    assert_eq!(response.status, 400);
+    assert_eq!(body["error"], "expired_token");
+    assert_eq!(body["error_description"], EXPIRED_DEVICE_CODE);
+    assert!(
+        ctx.database
+            .get_device_code_by_device_code(&stored.device_code)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+// Upstream source: packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts :: "should return error for invalid device code".
+#[tokio::test]
+async fn test_device_token_invalid_device_code_returns_invalid_grant() {
+    let plugin = DeviceAuthorizationPlugin::new();
+    let ctx = test_helpers::create_test_context().await;
+
+    let response = plugin
+        .handle_device_token(
+            &device_token_request("invalid-device-code", "test-client"),
+            &ctx,
+        )
+        .await
+        .unwrap();
+    let body = json_body(&response);
+
+    assert_eq!(response.status, 400);
+    assert_eq!(body["error"], "invalid_grant");
+    assert_eq!(body["error_description"], INVALID_DEVICE_CODE);
+}
+
+// Upstream source: packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts :: "should enforce rate limiting with slow_down error".
+#[tokio::test]
+async fn test_device_token_rate_limits_with_slow_down() {
+    let plugin = DeviceAuthorizationPlugin::new().interval(Duration::seconds(5));
+    let ctx = test_helpers::create_test_context().await;
+
+    let create_request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/code",
+        None,
+        Some(serde_json::json!({ "client_id": "test-client" })),
+    );
+    let create_response = plugin
+        .handle_device_code(&create_request, &ctx)
+        .await
+        .unwrap();
+    let create_body = json_body(&create_response);
+    let device_code = create_body["device_code"].as_str().unwrap();
+
+    let first = plugin
+        .handle_device_token(&device_token_request(device_code, "test-client"), &ctx)
+        .await
+        .unwrap();
+    assert_eq!(json_body(&first)["error"], "authorization_pending");
+
+    let second = plugin
+        .handle_device_token(&device_token_request(device_code, "test-client"), &ctx)
+        .await
+        .unwrap();
+    let second_body = json_body(&second);
+
+    assert_eq!(second.status, 400);
+    assert_eq!(second_body["error"], "slow_down");
+    assert_eq!(second_body["error_description"], POLLING_TOO_FREQUENTLY);
+}
+
+// Upstream source: packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts :: verification scenarios.
+#[tokio::test]
+async fn test_device_verify_strips_hyphens_and_preserves_input_shape() {
+    let plugin = DeviceAuthorizationPlugin::new();
+    let ctx = test_helpers::create_test_context().await;
+
+    ctx.database
+        .create_device_code(CreateDeviceCode {
+            device_code: "verify-device-code".to_string(),
+            user_code: "ABCD1234".to_string(),
+            user_id: None,
+            expires_at: Utc::now() + Duration::minutes(5),
+            status: DEVICE_STATUS_PENDING.to_string(),
+            last_polled_at: None,
+            polling_interval: Some(5000),
+            client_id: Some("test-client".to_string()),
+            scope: None,
+        })
+        .await
+        .unwrap();
+
+    let response = plugin
+        .handle_device_verify(&device_verify_request("ABCD-1234"), &ctx)
+        .await
+        .unwrap();
+    let body = json_body(&response);
+
+    assert_eq!(response.status, 200);
+    assert_eq!(body["user_code"], "ABCD-1234");
+    assert_eq!(body["status"], DEVICE_STATUS_PENDING);
+}
+
+// Upstream source: packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts :: invalid user code verification.
+#[tokio::test]
+async fn test_device_verify_invalid_user_code_returns_error() {
+    let plugin = DeviceAuthorizationPlugin::new();
+    let ctx = test_helpers::create_test_context().await;
+
+    let response = plugin
+        .handle_device_verify(&device_verify_request("INVALID"), &ctx)
+        .await
+        .unwrap();
+    let body = json_body(&response);
+
+    assert_eq!(response.status, 400);
+    assert_eq!(body["error"], "invalid_request");
+    assert_eq!(body["error_description"], INVALID_USER_CODE);
+}
+
+// Upstream source: packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts :: approval flow, scope preservation, and OAuth-compliant token response.
+#[tokio::test]
+async fn test_device_approve_flow_creates_session_and_returns_oauth_token_response() {
+    let plugin = DeviceAuthorizationPlugin::new();
+    let (ctx, _user, session) = create_context_with_user("approve@example.com").await;
+
+    let create_request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/code",
+        None,
+        Some(serde_json::json!({
+            "client_id": "test-client",
+            "scope": "read write profile",
+        })),
+    );
+    let create_response = plugin
+        .handle_device_code(&create_request, &ctx)
+        .await
+        .unwrap();
+    let create_body = json_body(&create_response);
+    let device_code = create_body["device_code"].as_str().unwrap().to_string();
+    let user_code = create_body["user_code"].as_str().unwrap().to_string();
+
+    let approve_request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/approve",
+        Some(&session.token),
+        Some(serde_json::json!({ "userCode": user_code })),
+    );
+    let approve_response = plugin
+        .handle_device_approve(&approve_request, &ctx)
+        .await
+        .unwrap();
+    assert_eq!(json_body(&approve_response)["success"], true);
+
+    let token_response = plugin
+        .handle_device_token(&device_token_request(&device_code, "test-client"), &ctx)
+        .await
+        .unwrap();
+    let token_body = json_body(&token_response);
+
+    assert_eq!(token_response.status, 200);
+    assert_eq!(
+        token_response.headers.get("Cache-Control"),
+        Some(&"no-store".to_string())
+    );
+    assert_eq!(
+        token_response.headers.get("Pragma"),
+        Some(&"no-cache".to_string())
+    );
+    assert_eq!(token_body["token_type"], "Bearer");
+    assert_eq!(token_body["scope"], "read write profile");
+    assert!(token_body["expires_in"].as_i64().unwrap() > 0);
+
+    let access_token = token_body["access_token"].as_str().unwrap();
+    assert!(
+        ctx.database
+            .get_session(access_token)
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        ctx.database
+            .get_device_code_by_device_code(&device_code)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+// Upstream source: packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts :: denial flow.
+#[tokio::test]
+async fn test_device_deny_flow_returns_access_denied_and_deletes_record() {
+    let plugin = DeviceAuthorizationPlugin::new();
+    let (ctx, _user, session) = create_context_with_user("deny@example.com").await;
+
+    let create_request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/code",
+        None,
+        Some(serde_json::json!({ "client_id": "test-client" })),
+    );
+    let create_response = plugin
+        .handle_device_code(&create_request, &ctx)
+        .await
+        .unwrap();
+    let create_body = json_body(&create_response);
+    let device_code = create_body["device_code"].as_str().unwrap().to_string();
+    let user_code = create_body["user_code"].as_str().unwrap().to_string();
+
+    let deny_request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/deny",
+        Some(&session.token),
+        Some(serde_json::json!({ "userCode": user_code })),
+    );
+    let deny_response = plugin
+        .handle_device_deny(&deny_request, &ctx)
+        .await
+        .unwrap();
+    assert_eq!(json_body(&deny_response)["success"], true);
+
+    let token_response = plugin
+        .handle_device_token(&device_token_request(&device_code, "test-client"), &ctx)
+        .await
+        .unwrap();
+    let token_body = json_body(&token_response);
+
+    assert_eq!(token_response.status, 400);
+    assert_eq!(token_body["error"], "access_denied");
+    assert_eq!(token_body["error_description"], ACCESS_DENIED);
+    assert!(
+        ctx.database
+            .get_device_code_by_device_code(&device_code)
+            .await
+            .unwrap()
+            .is_none()
+    );
+}
+
+// Upstream source: packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts :: auth-required and double-processing guard scenarios.
+#[tokio::test]
+async fn test_device_approve_requires_authentication_and_blocks_double_processing() {
+    let plugin = DeviceAuthorizationPlugin::new();
+    let (ctx, _user, session) = create_context_with_user("double@example.com").await;
+
+    let create_request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/code",
+        None,
+        Some(serde_json::json!({ "client_id": "test-client" })),
+    );
+    let create_response = plugin
+        .handle_device_code(&create_request, &ctx)
+        .await
+        .unwrap();
+    let create_body = json_body(&create_response);
+    let user_code = create_body["user_code"].as_str().unwrap().to_string();
+
+    let unauthenticated_request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/approve",
+        None,
+        Some(serde_json::json!({ "userCode": user_code.clone() })),
+    );
+    let unauthenticated_response = plugin
+        .handle_device_approve(&unauthenticated_request, &ctx)
+        .await
+        .unwrap();
+    let unauthenticated_body = json_body(&unauthenticated_response);
+    assert_eq!(unauthenticated_response.status, 401);
+    assert_eq!(unauthenticated_body["error"], "unauthorized");
+    assert_eq!(
+        unauthenticated_body["error_description"],
+        AUTHENTICATION_REQUIRED
+    );
+
+    let approve_request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/approve",
+        Some(&session.token),
+        Some(serde_json::json!({ "userCode": user_code.clone() })),
+    );
+    let first_response = plugin
+        .handle_device_approve(&approve_request, &ctx)
+        .await
+        .unwrap();
+    assert_eq!(json_body(&first_response)["success"], true);
+
+    let second_response = plugin
+        .handle_device_approve(&approve_request, &ctx)
+        .await
+        .unwrap();
+    let second_body = json_body(&second_response);
+    assert_eq!(second_response.status, 400);
+    assert_eq!(second_body["error"], "invalid_request");
+    assert_eq!(
+        second_body["error_description"],
+        DEVICE_CODE_ALREADY_PROCESSED
+    );
+}
+
+// Upstream source: packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts :: client mismatch scenario.
+#[tokio::test]
+async fn test_device_token_rejects_client_id_mismatch() {
+    let plugin = DeviceAuthorizationPlugin::new();
+    let ctx = test_helpers::create_test_context().await;
+
+    let create_request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/code",
+        None,
+        Some(serde_json::json!({ "client_id": "client-a" })),
+    );
+    let create_response = plugin
+        .handle_device_code(&create_request, &ctx)
+        .await
+        .unwrap();
+    let create_body = json_body(&create_response);
+
+    let response = plugin
+        .handle_device_token(
+            &device_token_request(create_body["device_code"].as_str().unwrap(), "client-b"),
+            &ctx,
+        )
+        .await
+        .unwrap();
+    let body = json_body(&response);
+
+    assert_eq!(response.status, 400);
+    assert_eq!(body["error"], "invalid_grant");
+    assert_eq!(body["error_description"], CLIENT_ID_MISMATCH);
+}

--- a/crates/api/src/plugins/device_authorization/tests.rs
+++ b/crates/api/src/plugins/device_authorization/tests.rs
@@ -582,3 +582,60 @@ async fn test_device_token_rejects_client_id_mismatch() {
     assert_eq!(body["error"], "invalid_grant");
     assert_eq!(body["error_description"], CLIENT_ID_MISMATCH);
 }
+
+// Deliberate hardening divergence from the current TS runtime: exactly one
+// poller may redeem an approved device code.
+#[tokio::test]
+async fn test_device_token_allows_only_one_concurrent_redemption() {
+    let plugin = DeviceAuthorizationPlugin::new();
+    let (ctx, _user, session) = create_context_with_user("concurrent@example.com").await;
+
+    let create_request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/code",
+        None,
+        Some(serde_json::json!({ "client_id": "test-client" })),
+    );
+    let create_response = plugin
+        .handle_device_code(&create_request, &ctx)
+        .await
+        .unwrap();
+    let create_body = json_body(&create_response);
+    let device_code = create_body["device_code"].as_str().unwrap().to_string();
+    let user_code = create_body["user_code"].as_str().unwrap().to_string();
+
+    let approve_request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/approve",
+        Some(&session.token),
+        Some(serde_json::json!({ "userCode": user_code })),
+    );
+    let approve_response = plugin
+        .handle_device_approve(&approve_request, &ctx)
+        .await
+        .unwrap();
+    assert_eq!(json_body(&approve_response)["success"], true);
+
+    let first_request = device_token_request(&device_code, "test-client");
+    let second_request = device_token_request(&device_code, "test-client");
+
+    let (first_response, second_response) = tokio::join!(
+        plugin.handle_device_token(&first_request, &ctx),
+        plugin.handle_device_token(&second_request, &ctx),
+    );
+
+    let first_response = first_response.unwrap();
+    let second_response = second_response.unwrap();
+
+    let success_count = [first_response.status, second_response.status]
+        .into_iter()
+        .filter(|status| *status == 200)
+        .count();
+    assert_eq!(success_count, 1);
+
+    let invalid_grant_count = [json_body(&first_response), json_body(&second_response)]
+        .into_iter()
+        .filter(|body| body["error"] == "invalid_grant")
+        .count();
+    assert_eq!(invalid_grant_count, 1);
+}

--- a/crates/api/src/plugins/device_authorization/tests.rs
+++ b/crates/api/src/plugins/device_authorization/tests.rs
@@ -551,6 +551,63 @@ async fn test_device_approve_requires_authentication_and_blocks_double_processin
     );
 }
 
+// Deliberate hardening divergence from the current TS runtime: exactly one
+// approval request may process a pending device code.
+#[tokio::test]
+async fn test_device_approve_allows_only_one_concurrent_decision() {
+    let plugin = DeviceAuthorizationPlugin::new();
+    let (ctx, _user, session) = create_context_with_user("decision-race@example.com").await;
+
+    let create_request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/code",
+        None,
+        Some(serde_json::json!({ "client_id": "test-client" })),
+    );
+    let create_response = plugin
+        .handle_device_code(&create_request, &ctx)
+        .await
+        .unwrap();
+    let create_body = json_body(&create_response);
+    let user_code = create_body["user_code"].as_str().unwrap().to_string();
+
+    let first_request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/approve",
+        Some(&session.token),
+        Some(serde_json::json!({ "userCode": user_code.clone() })),
+    );
+    let second_request = test_helpers::create_auth_json_request_no_query(
+        HttpMethod::Post,
+        "/device/approve",
+        Some(&session.token),
+        Some(serde_json::json!({ "userCode": user_code })),
+    );
+
+    let (first_response, second_response) = tokio::join!(
+        plugin.handle_device_approve(&first_request, &ctx),
+        plugin.handle_device_approve(&second_request, &ctx),
+    );
+
+    let first_response = first_response.unwrap();
+    let second_response = second_response.unwrap();
+
+    let success_count = [first_response.status, second_response.status]
+        .into_iter()
+        .filter(|status| *status == 200)
+        .count();
+    assert_eq!(success_count, 1);
+
+    let already_processed_count = [json_body(&first_response), json_body(&second_response)]
+        .into_iter()
+        .filter(|body| {
+            body["error"] == "invalid_request"
+                && body["error_description"] == DEVICE_CODE_ALREADY_PROCESSED
+        })
+        .count();
+    assert_eq!(already_processed_count, 1);
+}
+
 // Upstream source: packages/better-auth/src/plugins/device-authorization/device-authorization.test.ts :: client mismatch scenario.
 #[tokio::test]
 async fn test_device_token_rejects_client_id_mismatch() {

--- a/crates/api/src/plugins/device_authorization/types.rs
+++ b/crates/api/src/plugins/device_authorization/types.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+#[derive(Debug, Deserialize, Validate)]
+pub(super) struct DeviceCodeRequest {
+    pub client_id: String,
+    pub scope: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub(super) struct DeviceTokenRequest {
+    pub grant_type: String,
+    pub device_code: String,
+    pub client_id: String,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub(super) struct DeviceActionRequest {
+    #[serde(rename = "userCode")]
+    pub user_code: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct DeviceCodeResponse {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    pub verification_uri_complete: String,
+    pub expires_in: i64,
+    pub interval: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct DeviceTokenResponse {
+    pub access_token: String,
+    pub token_type: &'static str,
+    pub expires_in: i64,
+    pub scope: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct DeviceVerifyResponse {
+    pub user_code: String,
+    pub status: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct DeviceActionResponse {
+    pub success: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct DeviceErrorResponse {
+    pub error: String,
+    pub error_description: String,
+}

--- a/crates/api/src/plugins/mod.rs
+++ b/crates/api/src/plugins/mod.rs
@@ -1,6 +1,7 @@
 pub mod account_management;
 pub mod admin;
 pub mod api_key;
+pub mod device_authorization;
 pub mod email_password;
 pub mod email_verification;
 pub mod helpers;
@@ -169,6 +170,7 @@ pub use account_management::AccountManagementPlugin;
 pub use admin::{AdminConfig, AdminPlugin};
 pub use api_key::{ApiKeyConfig, ApiKeyPlugin};
 pub use better_auth_core::PasswordHasher;
+pub use device_authorization::DeviceAuthorizationPlugin;
 pub use email_password::{EmailPasswordConfig, EmailPasswordPlugin};
 pub use email_verification::{
     EmailVerificationConfig, EmailVerificationHook, EmailVerificationPlugin, SendVerificationEmail,

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -34,21 +34,345 @@ pub mod core_paths {
         } else {
             "UNKNOWN"
         };
-        format!(
-            r#"<!DOCTYPE html>
+        let ask_ai_query = format!("What%20does%20the%20error%20code%20{}%20mean%3F", safe_code);
+
+        r#"<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Error</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+        background: var(--background);
+        color: var(--foreground);
+        margin: 0;
+      }
+      :root,
+      :host {
+        --spacing: 0.25rem;
+        --container-md: 28rem;
+        --text-sm: 0.875rem;
+        --text-sm--line-height: calc(1.25 / 0.875);
+        --text-2xl: 1.5rem;
+        --text-2xl--line-height: calc(2 / 1.5);
+        --text-4xl: 2.25rem;
+        --text-4xl--line-height: calc(2.5 / 2.25);
+        --text-6xl: 3rem;
+        --text-6xl--line-height: 1;
+        --font-weight-medium: 500;
+        --font-weight-semibold: 600;
+        --font-weight-bold: 700;
+        --default-transition-duration: 150ms;
+        --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+        --radius: 0.625rem;
+        --default-mono-font-family: var(--font-geist-mono);
+        --primary: black;
+        --primary-foreground: white;
+        --background: white;
+        --foreground: oklch(0.271 0 0);
+        --border: oklch(0.89 0 0);
+        --destructive: oklch(0.55 0.15 25.723);
+        --muted-foreground: oklch(0.545 0 0);
+        --corner-border: #404040;
+      }
+
+      button, .btn {
+        cursor: pointer;
+        background: none;
+        border: none;
+        color: inherit;
+        font: inherit;
+        transition: all var(--default-transition-duration)
+          var(--default-transition-timing-function);
+      }
+      button:hover, .btn:hover {
+        opacity: 0.8;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root,
+        :host {
+          --primary: white;
+          --primary-foreground: black;
+          --background: oklch(0.15 0 0);
+          --foreground: oklch(0.98 0 0);
+          --border: oklch(0.27 0 0);
+          --destructive: oklch(0.65 0.15 25.723);
+          --muted-foreground: oklch(0.65 0 0);
+          --corner-border: #a0a0a0;
+        }
+      }
+      @media (max-width: 640px) {
+        :root, :host {
+          --text-6xl: 2.5rem;
+          --text-2xl: 1.25rem;
+          --text-sm: 0.8125rem;
+        }
+      }
+      @media (max-width: 480px) {
+        :root, :host {
+          --text-6xl: 2rem;
+          --text-2xl: 1.125rem;
+        }
+      }
+    </style>
   </head>
-  <body>
-    <h1>ERROR</h1>
-    <h2>Something went wrong</h2>
-    <p>CODE: {safe_code}</p>
+  <body style="width: 100vw; min-height: 100vh; overflow-x: hidden; overflow-y: auto;">
+    <div
+        style="
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 1.5rem;
+            position: relative;
+            width: 100%;
+            min-height: 100vh;
+            padding: 1rem;
+        "
+        >
+
+      <div
+        style="
+          position: absolute;
+          inset: 0;
+          background-image: linear-gradient(to right, var(--border) 1px, transparent 1px),
+            linear-gradient(to bottom, var(--border) 1px, transparent 1px);
+          background-size: 40px 40px;
+          opacity: 0.6;
+          pointer-events: none;
+          width: 100vw;
+          height: 100vh;
+        "
+      ></div>
+      <div
+        style="
+          position: absolute;
+          inset: 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          background: var(--background);
+          mask-image: radial-gradient(ellipse at center, transparent 20%, black);
+          -webkit-mask-image: radial-gradient(ellipse at center, transparent 20%, black);
+          pointer-events: none;
+        "
+      ></div>
+
+
+<div
+  style="
+    position: relative;
+    z-index: 10;
+    border: 2px solid var(--border);
+    background: var(--background);
+    padding: 1.5rem;
+    max-width: 42rem;
+    width: 100%;
+  "
+>
+    
+        <!-- Corner decorations -->
+        <div
+          style="
+            position: absolute;
+            top: -2px;
+            left: -2px;
+            width: 2rem;
+            height: 2rem;
+            border-top: 4px solid var(--corner-border);
+            border-left: 4px solid var(--corner-border);
+          "
+        ></div>
+        <div
+          style="
+            position: absolute;
+            top: -2px;
+            right: -2px;
+            width: 2rem;
+            height: 2rem;
+            border-top: 4px solid var(--corner-border);
+            border-right: 4px solid var(--corner-border);
+          "
+        ></div>
+  
+        <div
+          style="
+            position: absolute;
+            bottom: -2px;
+            left: -2px;
+            width: 2rem;
+            height: 2rem;
+            border-bottom: 4px solid var(--corner-border);
+            border-left: 4px solid var(--corner-border);
+          "
+        ></div>
+        <div
+          style="
+            position: absolute;
+            bottom: -2px;
+            right: -2px;
+            width: 2rem;
+            height: 2rem;
+            border-bottom: 4px solid var(--corner-border);
+            border-right: 4px solid var(--corner-border);
+          "
+        ></div>
+
+        <div style="text-align: center; margin-bottom: 1.5rem;">
+          <div style="margin-bottom: 1.5rem;">
+            <div
+              style="
+                display: inline-block;
+                border: 2px solid var(--destructive);
+                padding: 0.375rem 1rem;
+              "
+            >
+              <h1
+                style="
+                  font-size: var(--text-6xl);
+                  font-weight: var(--font-weight-semibold);
+                  color: var(--foreground);
+                  letter-spacing: -0.02em;
+                  margin: 0;
+                "
+              >
+                ERROR
+              </h1>
+            </div>
+            <div
+              style="
+                height: 2px;
+                background-color: var(--border);
+                width: calc(100% + 3rem);
+                margin-left: -1.5rem;
+                margin-top: 1.5rem;
+              "
+            ></div>
+          </div>
+
+          <h2
+            style="
+              font-size: var(--text-2xl);
+              font-weight: var(--font-weight-semibold);
+              color: var(--foreground);
+              margin: 0 0 1rem;
+            "
+          >
+            Something went wrong
+          </h2>
+
+          <div
+            style="
+                display: inline-flex;
+                align-items: center;
+                gap: 0.5rem;
+                border: 2px solid var(--border);
+                background-color: var(--muted);
+                padding: 0.375rem 0.75rem;
+                margin: 0 0 1rem;
+                flex-wrap: wrap;
+                justify-content: center;
+            "
+            >
+            <span
+                style="
+                font-size: 0.75rem;
+                color: var(--muted-foreground);
+                font-weight: var(--font-weight-semibold);
+                "
+            >
+                CODE:
+            </span>
+            <span
+                style="
+                font-size: var(--text-sm);
+                font-family: var(--default-mono-font-family, monospace);
+                color: var(--foreground);
+                word-break: break-all;
+                "
+            >
+                __CODE__
+            </span>
+            </div>
+
+          <p
+            style="
+              color: var(--muted-foreground);
+              max-width: 28rem;
+              margin: 0 auto;
+              font-size: var(--text-sm);
+              line-height: 1.5;
+              text-wrap: pretty;
+            "
+          >
+            We encountered an unexpected error. Please try again or return to the home page. If you're a developer, you can find more information about the error <a href='https://better-auth.com/docs/reference/errors/__CODE__' target='_blank' rel="noopener noreferrer" style='color: var(--foreground); text-decoration: underline;'>here</a>.
+          </p>
+        </div>
+
+        <div
+          style="
+            display: flex;
+            gap: 0.75rem;
+            margin-top: 1.5rem;
+            justify-content: center;
+            flex-wrap: wrap;
+          "
+        >
+          <a
+            href="/"
+            style="
+              text-decoration: none;
+            "
+          >
+            <div
+              style="
+                border: 2px solid var(--border);
+                background: var(--primary);
+                color: var(--primary-foreground);
+                padding: 0.5rem 1rem;
+                border-radius: 0;
+                white-space: nowrap;
+              "
+              class="btn"
+            >
+              Go Home
+            </div>
+          </a>
+          <a
+            href="https://better-auth.com/docs/reference/errors/__CODE__?askai=__ASK_AI__"
+            target="_blank"
+            rel="noopener noreferrer"
+            style="
+              text-decoration: none;
+            "
+          >
+            <div
+              style="
+                border: 2px solid var(--border);
+                background: transparent;
+                color: var(--foreground);
+                padding: 0.5rem 1rem;
+                border-radius: 0;
+                white-space: nowrap;
+              "
+              class="btn"
+            >
+              Ask AI
+            </div>
+          </a>
+        </div>
+      </div>
+    </div>
   </body>
 </html>"#
-        )
+            .replace("__CODE__", safe_code)
+            .replace("__ASK_AI__", &ask_ai_query)
     }
 }
 
@@ -1020,7 +1344,8 @@ mod tests {
     #[test]
     fn core_paths_error_page() {
         let html = core_paths::error_page_html("TEST_ERROR");
-        assert!(html.contains("CODE: TEST_ERROR"));
+        assert!(html.contains("TEST_ERROR"));
+        assert!(html.contains("Ask AI"));
         assert!(html.contains("<title>Error</title>"));
     }
 
@@ -1028,15 +1353,15 @@ mod tests {
     #[test]
     fn error_page_sanitizes_script_tag() {
         let html = core_paths::error_page_html("<script>alert(1)</script>");
-        assert!(html.contains("CODE: UNKNOWN"));
+        assert!(html.contains("UNKNOWN"));
         assert!(!html.contains("<script>"));
     }
 
     // Upstream reference: packages/better-auth/src/api/routes/error.ts :: sanitize function and /^[A-Za-z0-9_'-]+$/ whitelist.
     #[test]
     fn error_page_allows_valid_codes() {
-        assert!(core_paths::error_page_html("SOME_ERROR-CODE").contains("CODE: SOME_ERROR-CODE"));
-        assert!(core_paths::error_page_html("it's").contains("CODE: it's"));
+        assert!(core_paths::error_page_html("SOME_ERROR-CODE").contains("SOME_ERROR-CODE"));
+        assert!(core_paths::error_page_html("it's").contains("it's"));
     }
 
     // ── session builder methods ─────────────────────────────────────────

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -61,13 +61,14 @@ pub use session::SessionManager;
 pub use store::{AuthStore, AuthTransaction, CacheAdapter, MemoryCacheAdapter, transaction};
 pub use types::{
     ApiKey, AuthRequest, AuthResponse, CodeMessageResponse, CreateAccount, CreateApiKey,
-    CreateInvitation, CreateMember, CreateOrganization, CreatePasskey, CreateSession,
-    CreateTwoFactor, CreateUser, CreateVerification, ErrorCodeMessageResponse,
-    ErrorMessageResponse, Headers, HealthCheckResponse, HttpMethod, Invitation, InvitationStatus,
-    ListUsersParams, Member, OkResponse, Organization, Passkey, RateLimitErrorResponse,
-    RequestMeta, StatusMessageResponse, StatusResponse, SuccessMessageResponse, SuccessResponse,
-    TwoFactor, UpdateAccount, UpdateApiKey, UpdateOrganization, UpdatePasskey, UpdateUser,
-    UpdateUserRequest, UpdateUserResponse, ValidationErrorResponse,
+    CreateDeviceCode, CreateInvitation, CreateMember, CreateOrganization, CreatePasskey,
+    CreateSession, CreateTwoFactor, CreateUser, CreateVerification, DeviceCode,
+    ErrorCodeMessageResponse, ErrorMessageResponse, Headers, HealthCheckResponse, HttpMethod,
+    Invitation, InvitationStatus, ListUsersParams, Member, OkResponse, Organization, Passkey,
+    RateLimitErrorResponse, RequestMeta, StatusMessageResponse, StatusResponse,
+    SuccessMessageResponse, SuccessResponse, TwoFactor, UpdateAccount, UpdateApiKey,
+    UpdateDeviceCode, UpdateOrganization, UpdatePasskey, UpdateUser, UpdateUserRequest,
+    UpdateUserResponse, ValidationErrorResponse,
 };
 pub use utils::password::{PasswordHasher, hash_password, verify_password};
 #[doc(hidden)]

--- a/crates/core/src/store/mod.rs
+++ b/crates/core/src/store/mod.rs
@@ -205,6 +205,10 @@ pub trait DeviceCodeStore: Send + Sync {
     ) -> AuthResult<DeviceCode>;
     /// Delete a device code record.
     async fn delete_device_code(&self, id: &str) -> AuthResult<()>;
+    /// Delete a device code only when it still has the expected status.
+    ///
+    /// Returns `true` when a matching row was deleted and `false` otherwise.
+    async fn delete_device_code_if_status(&self, id: &str, status: &str) -> AuthResult<bool>;
 }
 
 #[async_trait]

--- a/crates/core/src/store/mod.rs
+++ b/crates/core/src/store/mod.rs
@@ -8,10 +8,11 @@ pub mod cache;
 use crate::error::{AuthError, AuthResult};
 use crate::schema::AuthSchema;
 use crate::types::{
-    ApiKey, CreateAccount, CreateApiKey, CreateInvitation, CreateMember, CreateOrganization,
-    CreatePasskey, CreateSession, CreateTwoFactor, CreateUser, CreateVerification, Invitation,
-    InvitationStatus, ListUsersParams, Member, Organization, Passkey, TwoFactor, UpdateAccount,
-    UpdateApiKey, UpdateOrganization, UpdateUser,
+    ApiKey, CreateAccount, CreateApiKey, CreateDeviceCode, CreateInvitation, CreateMember,
+    CreateOrganization, CreatePasskey, CreateSession, CreateTwoFactor, CreateUser,
+    CreateVerification, DeviceCode, Invitation, InvitationStatus, ListUsersParams, Member,
+    Organization, Passkey, TwoFactor, UpdateAccount, UpdateApiKey, UpdateDeviceCode,
+    UpdateOrganization, UpdateUser,
 };
 
 pub use cache::{CacheAdapter, MemoryCacheAdapter};
@@ -183,6 +184,29 @@ pub trait PasskeyStore: Send + Sync {
     async fn delete_passkey(&self, id: &str) -> AuthResult<()>;
 }
 
+/// Persistence for OAuth device authorization codes.
+#[async_trait]
+pub trait DeviceCodeStore: Send + Sync {
+    /// Persist a newly-issued device code.
+    async fn create_device_code(&self, input: CreateDeviceCode) -> AuthResult<DeviceCode>;
+    /// Fetch a device code by its opaque device-facing token.
+    async fn get_device_code_by_device_code(
+        &self,
+        device_code: &str,
+    ) -> AuthResult<Option<DeviceCode>>;
+    /// Fetch a device code by its user-facing verification code.
+    async fn get_device_code_by_user_code(&self, user_code: &str)
+    -> AuthResult<Option<DeviceCode>>;
+    /// Update mutable device-code state such as approval status or poll time.
+    async fn update_device_code(
+        &self,
+        id: &str,
+        update: UpdateDeviceCode,
+    ) -> AuthResult<DeviceCode>;
+    /// Delete a device code record.
+    async fn delete_device_code(&self, id: &str) -> AuthResult<()>;
+}
+
 #[async_trait]
 pub trait TransactionStore<S: AuthSchema>: Send + Sync {
     async fn transaction_boxed(
@@ -202,6 +226,7 @@ pub trait AuthStore<S: AuthSchema>:
     + TwoFactorStore
     + ApiKeyStore
     + PasskeyStore
+    + DeviceCodeStore
     + TransactionStore<S>
     + Send
     + Sync
@@ -221,6 +246,7 @@ where
         + TwoFactorStore
         + ApiKeyStore
         + PasskeyStore
+        + DeviceCodeStore
         + TransactionStore<S>
         + Send
         + Sync,

--- a/crates/core/src/store/mod.rs
+++ b/crates/core/src/store/mod.rs
@@ -203,6 +203,16 @@ pub trait DeviceCodeStore: Send + Sync {
         id: &str,
         update: UpdateDeviceCode,
     ) -> AuthResult<DeviceCode>;
+    /// Update a device code only when it still has the expected status.
+    ///
+    /// Returns `true` when the compare-and-swap succeeds, or `false` when the
+    /// row was already moved to a different state.
+    async fn update_device_code_if_status(
+        &self,
+        id: &str,
+        current_status: &str,
+        update: UpdateDeviceCode,
+    ) -> AuthResult<bool>;
     /// Delete a device code record.
     async fn delete_device_code(&self, id: &str) -> AuthResult<()>;
     /// Delete a device code only when it still has the expected status.

--- a/crates/core/src/test_store.rs
+++ b/crates/core/src/test_store.rs
@@ -681,6 +681,20 @@ impl DeviceCodeStore for MemoryStore {
         self.lock().device_codes.remove(id);
         Ok(())
     }
+
+    async fn delete_device_code_if_status(&self, id: &str, status: &str) -> AuthResult<bool> {
+        let mut state = self.lock();
+        let should_delete = state
+            .device_codes
+            .get(id)
+            .is_some_and(|device_code| device_code.status == status);
+
+        if should_delete {
+            state.device_codes.remove(id);
+        }
+
+        Ok(should_delete)
+    }
 }
 
 #[async_trait]

--- a/crates/core/src/test_store.rs
+++ b/crates/core/src/test_store.rs
@@ -677,6 +677,34 @@ impl DeviceCodeStore for MemoryStore {
         Ok(device_code.clone())
     }
 
+    async fn update_device_code_if_status(
+        &self,
+        id: &str,
+        current_status: &str,
+        update: UpdateDeviceCode,
+    ) -> AuthResult<bool> {
+        let mut state = self.lock();
+        let Some(device_code) = state.device_codes.get_mut(id) else {
+            return Ok(false);
+        };
+
+        if device_code.status != current_status {
+            return Ok(false);
+        }
+
+        if let Some(status) = update.status {
+            device_code.status = status;
+        }
+        if let Some(user_id) = update.user_id {
+            device_code.user_id = user_id;
+        }
+        if let Some(last_polled_at) = update.last_polled_at {
+            device_code.last_polled_at = last_polled_at;
+        }
+
+        Ok(true)
+    }
+
     async fn delete_device_code(&self, id: &str) -> AuthResult<()> {
         self.lock().device_codes.remove(id);
         Ok(())

--- a/crates/core/src/test_store.rs
+++ b/crates/core/src/test_store.rs
@@ -8,15 +8,16 @@ use crate::config::AuthConfig;
 use crate::error::{AuthError, AuthResult};
 use crate::schema::AuthSchema;
 use crate::store::{
-    AccountStore, ApiKeyStore, AuthStore, AuthTransaction, InvitationStore, MemberStore,
-    OrganizationStore, PasskeyStore, SessionStore, TransactionStore, TwoFactorStore, UserStore,
-    VerificationStore,
+    AccountStore, ApiKeyStore, AuthStore, AuthTransaction, DeviceCodeStore, InvitationStore,
+    MemberStore, OrganizationStore, PasskeyStore, SessionStore, TransactionStore, TwoFactorStore,
+    UserStore, VerificationStore,
 };
 use crate::types::{
-    ApiKey, CreateAccount, CreateApiKey, CreateInvitation, CreateMember, CreateOrganization,
-    CreatePasskey, CreateSession, CreateTwoFactor, CreateUser, CreateVerification, Invitation,
-    InvitationStatus, ListUsersParams, Member, Organization, Passkey, TwoFactor, UpdateAccount,
-    UpdateApiKey, UpdateOrganization, UpdateUser,
+    ApiKey, CreateAccount, CreateApiKey, CreateDeviceCode, CreateInvitation, CreateMember,
+    CreateOrganization, CreatePasskey, CreateSession, CreateTwoFactor, CreateUser,
+    CreateVerification, DeviceCode, Invitation, InvitationStatus, ListUsersParams, Member,
+    Organization, Passkey, TwoFactor, UpdateAccount, UpdateApiKey, UpdateDeviceCode,
+    UpdateOrganization, UpdateUser,
 };
 use crate::wire::{AccountView, SessionView, UserView, VerificationView};
 
@@ -35,6 +36,7 @@ struct State {
     sessions: HashMap<String, SessionView>,
     accounts: HashMap<String, AccountView>,
     verifications: HashMap<String, VerificationView>,
+    device_codes: HashMap<String, DeviceCode>,
 }
 
 #[derive(Default)]
@@ -602,6 +604,81 @@ impl PasskeyStore for MemoryStore {
         Err(AuthError::internal("unsupported test-store operation"))
     }
     async fn delete_passkey(&self, _id: &str) -> AuthResult<()> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl DeviceCodeStore for MemoryStore {
+    async fn create_device_code(&self, input: CreateDeviceCode) -> AuthResult<DeviceCode> {
+        let device_code = DeviceCode {
+            id: uuid::Uuid::new_v4().to_string(),
+            device_code: input.device_code,
+            user_code: input.user_code,
+            user_id: input.user_id,
+            expires_at: input.expires_at,
+            status: input.status,
+            last_polled_at: input.last_polled_at,
+            polling_interval: input.polling_interval,
+            client_id: input.client_id,
+            scope: input.scope,
+        };
+        self.lock()
+            .device_codes
+            .insert(device_code.id.clone(), device_code.clone());
+        Ok(device_code)
+    }
+
+    async fn get_device_code_by_device_code(
+        &self,
+        device_code: &str,
+    ) -> AuthResult<Option<DeviceCode>> {
+        Ok(self
+            .lock()
+            .device_codes
+            .values()
+            .find(|value| value.device_code == device_code)
+            .cloned())
+    }
+
+    async fn get_device_code_by_user_code(
+        &self,
+        user_code: &str,
+    ) -> AuthResult<Option<DeviceCode>> {
+        Ok(self
+            .lock()
+            .device_codes
+            .values()
+            .find(|value| value.user_code == user_code)
+            .cloned())
+    }
+
+    async fn update_device_code(
+        &self,
+        id: &str,
+        update: UpdateDeviceCode,
+    ) -> AuthResult<DeviceCode> {
+        let mut state = self.lock();
+        let device_code = state
+            .device_codes
+            .get_mut(id)
+            .ok_or_else(|| AuthError::not_found("Device code not found"))?;
+
+        if let Some(status) = update.status {
+            device_code.status = status;
+        }
+        if let Some(user_id) = update.user_id {
+            device_code.user_id = user_id;
+        }
+        if let Some(last_polled_at) = update.last_polled_at {
+            device_code.last_polled_at = last_polled_at;
+        }
+
+        Ok(device_code.clone())
+    }
+
+    async fn delete_device_code(&self, id: &str) -> AuthResult<()> {
+        self.lock().device_codes.remove(id);
         Ok(())
     }
 }

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -12,8 +12,8 @@ pub use super::types_org::{
     Organization, UpdateOrganization,
 };
 pub use super::types_plugin::{
-    ApiKey, CreateApiKey, CreatePasskey, CreateTwoFactor, Passkey, TwoFactor, UpdateApiKey,
-    UpdatePasskey,
+    ApiKey, CreateApiKey, CreateDeviceCode, CreatePasskey, CreateTwoFactor, DeviceCode, Passkey,
+    TwoFactor, UpdateApiKey, UpdateDeviceCode, UpdatePasskey,
 };
 
 /// HTTP method enumeration

--- a/crates/core/src/types_plugin.rs
+++ b/crates/core/src/types_plugin.rs
@@ -68,6 +68,56 @@ pub struct UpdatePasskey {
     pub name: Option<String>,
 }
 
+/// Device authorization code storage shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceCode {
+    pub id: String,
+    #[serde(rename = "deviceCode")]
+    pub device_code: String,
+    #[serde(rename = "userCode")]
+    pub user_code: String,
+    #[serde(rename = "userId", skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+    #[serde(rename = "expiresAt")]
+    pub expires_at: DateTime<Utc>,
+    pub status: String,
+    #[serde(rename = "lastPolledAt", skip_serializing_if = "Option::is_none")]
+    pub last_polled_at: Option<DateTime<Utc>>,
+    #[serde(rename = "pollingInterval", skip_serializing_if = "Option::is_none")]
+    pub polling_interval: Option<i64>,
+    #[serde(rename = "clientId", skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+}
+
+/// Input for creating a new device authorization code.
+#[derive(Debug, Clone)]
+pub struct CreateDeviceCode {
+    pub device_code: String,
+    pub user_code: String,
+    pub user_id: Option<String>,
+    pub expires_at: DateTime<Utc>,
+    pub status: String,
+    pub last_polled_at: Option<DateTime<Utc>>,
+    pub polling_interval: Option<i64>,
+    pub client_id: Option<String>,
+    pub scope: Option<String>,
+}
+
+/// Input for updating an existing device authorization code.
+#[derive(Debug, Clone, Default)]
+pub struct UpdateDeviceCode {
+    /// Update the status. `None` leaves it unchanged.
+    pub status: Option<String>,
+    /// Update the approving/denying user. `Some(None)` clears it, `None` leaves
+    /// it unchanged.
+    pub user_id: Option<Option<String>>,
+    /// Update the last poll timestamp. `Some(None)` clears it, `None` leaves it
+    /// unchanged.
+    pub last_polled_at: Option<Option<DateTime<Utc>>>,
+}
+
 /// API key response shape.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ApiKey {

--- a/crates/seaorm/src/conversions.rs
+++ b/crates/seaorm/src/conversions.rs
@@ -1,5 +1,5 @@
 use better_auth_core::{
-    ApiKey, Invitation, InvitationStatus, Member, Organization, Passkey, TwoFactor,
+    ApiKey, DeviceCode, Invitation, InvitationStatus, Member, Organization, Passkey, TwoFactor,
 };
 use chrono::{DateTime, Utc};
 
@@ -104,6 +104,23 @@ impl From<&entities::passkey::Model> for Passkey {
             backed_up: model.backed_up,
             transports: model.transports.clone(),
             created_at: model.created_at,
+        }
+    }
+}
+
+impl From<&entities::device_code::Model> for DeviceCode {
+    fn from(model: &entities::device_code::Model) -> Self {
+        Self {
+            id: model.id.clone(),
+            device_code: model.device_code.clone(),
+            user_code: model.user_code.clone(),
+            user_id: model.user_id.clone(),
+            expires_at: model.expires_at,
+            status: model.status.clone(),
+            last_polled_at: model.last_polled_at,
+            polling_interval: model.polling_interval,
+            client_id: model.client_id.clone(),
+            scope: model.scope.clone(),
         }
     }
 }

--- a/crates/seaorm/src/store/device_codes.rs
+++ b/crates/seaorm/src/store/device_codes.rs
@@ -97,4 +97,14 @@ where
             .map(|_| ())
             .map_err(map_db_err)
     }
+
+    async fn delete_device_code_if_status(&self, id: &str, status: &str) -> AuthResult<bool> {
+        Entity::delete_many()
+            .filter(Column::Id.eq(id))
+            .filter(Column::Status.eq(status))
+            .exec(self.connection())
+            .await
+            .map(|result| result.rows_affected == 1)
+            .map_err(map_db_err)
+    }
 }

--- a/crates/seaorm/src/store/device_codes.rs
+++ b/crates/seaorm/src/store/device_codes.rs
@@ -1,0 +1,100 @@
+use async_trait::async_trait;
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
+use uuid::Uuid;
+
+use better_auth_core::store::DeviceCodeStore;
+
+use crate::error::{AuthError, AuthResult};
+use crate::schema::AuthSchema;
+use crate::types::{CreateDeviceCode, DeviceCode, UpdateDeviceCode};
+
+use super::entities::device_code::{ActiveModel, Column, Entity};
+use super::{SeaOrmStore, map_db_err};
+
+#[async_trait]
+impl<S> DeviceCodeStore for SeaOrmStore<S>
+where
+    S: AuthSchema + Send + Sync,
+{
+    async fn create_device_code(&self, input: CreateDeviceCode) -> AuthResult<DeviceCode> {
+        ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            device_code: Set(input.device_code),
+            user_code: Set(input.user_code),
+            user_id: Set(input.user_id),
+            expires_at: Set(input.expires_at),
+            status: Set(input.status),
+            last_polled_at: Set(input.last_polled_at),
+            polling_interval: Set(input.polling_interval),
+            client_id: Set(input.client_id),
+            scope: Set(input.scope),
+        }
+        .insert(self.connection())
+        .await
+        .map(|model| DeviceCode::from(&model))
+        .map_err(map_db_err)
+    }
+
+    async fn get_device_code_by_device_code(
+        &self,
+        device_code: &str,
+    ) -> AuthResult<Option<DeviceCode>> {
+        Entity::find()
+            .filter(Column::DeviceCode.eq(device_code))
+            .one(self.connection())
+            .await
+            .map(|model| model.map(|model| DeviceCode::from(&model)))
+            .map_err(map_db_err)
+    }
+
+    async fn get_device_code_by_user_code(
+        &self,
+        user_code: &str,
+    ) -> AuthResult<Option<DeviceCode>> {
+        Entity::find()
+            .filter(Column::UserCode.eq(user_code))
+            .one(self.connection())
+            .await
+            .map(|model| model.map(|model| DeviceCode::from(&model)))
+            .map_err(map_db_err)
+    }
+
+    async fn update_device_code(
+        &self,
+        id: &str,
+        update: UpdateDeviceCode,
+    ) -> AuthResult<DeviceCode> {
+        let Some(model) = Entity::find_by_id(id.to_owned())
+            .one(self.connection())
+            .await
+            .map_err(map_db_err)?
+        else {
+            return Err(AuthError::not_found("Device code not found"));
+        };
+
+        let mut active = model.into_active_model();
+        if let Some(status) = update.status {
+            active.status = Set(status);
+        }
+        if let Some(user_id) = update.user_id {
+            active.user_id = Set(user_id);
+        }
+        if let Some(last_polled_at) = update.last_polled_at {
+            active.last_polled_at = Set(last_polled_at);
+        }
+
+        active
+            .update(self.connection())
+            .await
+            .map(|model| DeviceCode::from(&model))
+            .map_err(map_db_err)
+    }
+
+    async fn delete_device_code(&self, id: &str) -> AuthResult<()> {
+        Entity::delete_by_id(id.to_owned())
+            .exec(self.connection())
+            .await
+            .map(|_| ())
+            .map_err(map_db_err)
+    }
+}

--- a/crates/seaorm/src/store/device_codes.rs
+++ b/crates/seaorm/src/store/device_codes.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use sea_orm::sea_query::Expr;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
 use uuid::Uuid;
 
@@ -87,6 +88,32 @@ where
             .update(self.connection())
             .await
             .map(|model| DeviceCode::from(&model))
+            .map_err(map_db_err)
+    }
+
+    async fn update_device_code_if_status(
+        &self,
+        id: &str,
+        current_status: &str,
+        update: UpdateDeviceCode,
+    ) -> AuthResult<bool> {
+        let mut update_many = Entity::update_many();
+        if let Some(status) = update.status {
+            update_many = update_many.col_expr(Column::Status, Expr::value(status));
+        }
+        if let Some(user_id) = update.user_id {
+            update_many = update_many.col_expr(Column::UserId, Expr::value(user_id));
+        }
+        if let Some(last_polled_at) = update.last_polled_at {
+            update_many = update_many.col_expr(Column::LastPolledAt, Expr::value(last_polled_at));
+        }
+
+        update_many
+            .filter(Column::Id.eq(id))
+            .filter(Column::Status.eq(current_status))
+            .exec(self.connection())
+            .await
+            .map(|result| result.rows_affected == 1)
             .map_err(map_db_err)
     }
 

--- a/crates/seaorm/src/store/entities/device_code.rs
+++ b/crates/seaorm/src/store/entities/device_code.rs
@@ -1,0 +1,22 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "device_code")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub device_code: String,
+    pub user_code: String,
+    pub user_id: Option<String>,
+    pub expires_at: DateTimeUtc,
+    pub status: String,
+    pub last_polled_at: Option<DateTimeUtc>,
+    pub polling_interval: Option<i64>,
+    pub client_id: Option<String>,
+    pub scope: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/seaorm/src/store/entities/mod.rs
+++ b/crates/seaorm/src/store/entities/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod account;
 pub mod api_key;
+pub mod device_code;
 pub mod invitation;
 pub mod member;
 pub mod organization;

--- a/crates/seaorm/src/store/migrator.rs
+++ b/crates/seaorm/src/store/migrator.rs
@@ -5,8 +5,8 @@ use sea_orm::sea_query::IntoIden;
 use sea_orm_migration::prelude::*;
 
 use super::entities::{
-    account, api_key, invitation, member, organization, passkey, session, two_factor, user,
-    verification,
+    account, api_key, device_code, invitation, member, organization, passkey, session, two_factor,
+    user, verification,
 };
 
 pub struct AuthMigrator;
@@ -42,11 +42,13 @@ impl MigrationTrait for InitialAuthSchema {
         create_two_factor(manager).await?;
         create_api_keys(manager).await?;
         create_passkeys(manager).await?;
+        create_device_codes(manager).await?;
         Ok(())
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         for table in [
+            device_code::Entity.table_ref(),
             passkey::Entity.table_ref(),
             api_key::Entity.table_ref(),
             two_factor::Entity.table_ref(),
@@ -775,6 +777,79 @@ async fn create_passkeys(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
                 .to_owned(),
         )
         .await?;
+    Ok(())
+}
+
+async fn create_device_codes(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    manager
+        .create_table(
+            Table::create()
+                .table(device_code::Entity)
+                .if_not_exists()
+                .col(
+                    ColumnDef::new(device_code::Column::Id)
+                        .string()
+                        .not_null()
+                        .primary_key(),
+                )
+                .col(
+                    ColumnDef::new(device_code::Column::DeviceCode)
+                        .string()
+                        .not_null()
+                        .unique_key(),
+                )
+                .col(
+                    ColumnDef::new(device_code::Column::UserCode)
+                        .string()
+                        .not_null()
+                        .unique_key(),
+                )
+                .col(ColumnDef::new(device_code::Column::UserId).string())
+                .col(
+                    ColumnDef::new(device_code::Column::ExpiresAt)
+                        .timestamp_with_time_zone()
+                        .not_null(),
+                )
+                .col(
+                    ColumnDef::new(device_code::Column::Status)
+                        .string()
+                        .not_null(),
+                )
+                .col(ColumnDef::new(device_code::Column::LastPolledAt).timestamp_with_time_zone())
+                .col(ColumnDef::new(device_code::Column::PollingInterval).big_integer())
+                .col(ColumnDef::new(device_code::Column::ClientId).string())
+                .col(ColumnDef::new(device_code::Column::Scope).string())
+                .foreign_key(
+                    ForeignKey::create()
+                        .name("fk_device_code_user_id")
+                        .from(device_code::Entity, device_code::Column::UserId)
+                        .to(user::Entity, user::Column::Id)
+                        .on_delete(ForeignKeyAction::Cascade),
+                )
+                .to_owned(),
+        )
+        .await?;
+
+    for (name, column) in [
+        (
+            "idx_device_code_device_code",
+            device_code::Column::DeviceCode,
+        ),
+        ("idx_device_code_user_code", device_code::Column::UserCode),
+        ("idx_device_code_user_id", device_code::Column::UserId),
+        ("idx_device_code_expires_at", device_code::Column::ExpiresAt),
+    ] {
+        manager
+            .create_index(
+                Index::create()
+                    .name(name)
+                    .table(device_code::Entity)
+                    .col(column)
+                    .to_owned(),
+            )
+            .await?;
+    }
+
     Ok(())
 }
 

--- a/crates/seaorm/src/store/mod.rs
+++ b/crates/seaorm/src/store/mod.rs
@@ -3,6 +3,7 @@
 mod accounts;
 mod api_keys;
 mod bundled_schema;
+mod device_codes;
 pub mod entities;
 mod invitations;
 mod members;

--- a/crates/seaorm/src/types.rs
+++ b/crates/seaorm/src/types.rs
@@ -1,5 +1,5 @@
 pub(crate) use better_auth_core::{
-    ApiKey, CreateAccount, CreateApiKey, CreatePasskey, CreateSession, CreateTwoFactor, CreateUser,
-    CreateVerification, ListUsersParams, Passkey, TwoFactor, UpdateAccount, UpdateApiKey,
-    UpdateUser,
+    ApiKey, CreateAccount, CreateApiKey, CreateDeviceCode, CreatePasskey, CreateSession,
+    CreateTwoFactor, CreateUser, CreateVerification, DeviceCode, ListUsersParams, Passkey,
+    TwoFactor, UpdateAccount, UpdateApiKey, UpdateDeviceCode, UpdateUser,
 };

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -6,11 +6,11 @@ pub use better_auth_api::plugins::password_management::SendResetPassword;
 pub use better_auth_api::plugins::user_management::SendChangeEmailConfirmation;
 pub use better_auth_api::plugins::{
     AccountManagementPlugin, AdminConfig, AdminPlugin, ApiKeyConfig, ApiKeyPlugin,
-    ChangeEmailConfig, DeleteUserConfig, EmailPasswordConfig, EmailPasswordPlugin,
-    EmailVerificationConfig, EmailVerificationHook, EmailVerificationPlugin, OrganizationConfig,
-    OrganizationPlugin, PasskeyConfig, PasskeyPlugin, PasswordManagementConfig,
+    ChangeEmailConfig, DeleteUserConfig, DeviceAuthorizationPlugin, EmailPasswordConfig,
+    EmailPasswordPlugin, EmailVerificationConfig, EmailVerificationHook, EmailVerificationPlugin,
+    OrganizationConfig, OrganizationPlugin, PasskeyConfig, PasskeyPlugin, PasswordManagementConfig,
     PasswordManagementPlugin, SessionManagementPlugin, TwoFactorConfig, TwoFactorPlugin,
-    UserManagementConfig, UserManagementPlugin, account_management, admin, api_key, email_password,
-    email_verification, oauth, organization, passkey, password_management, session_management,
-    two_factor, user_management,
+    UserManagementConfig, UserManagementPlugin, account_management, admin, api_key,
+    device_authorization, email_password, email_verification, oauth, organization, passkey,
+    password_management, session_management, two_factor, user_management,
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,10 +6,11 @@ pub use better_auth_core::entity::{
     AuthSession, AuthTwoFactor, AuthUser, AuthVerification, MemberUserView,
 };
 pub use better_auth_core::types::{
-    ApiKey, AuthRequest, AuthResponse, CreateAccount, CreateApiKey, CreateInvitation, CreateMember,
-    CreateOrganization, CreatePasskey, CreateSession, CreateTwoFactor, CreateUser,
-    CreateVerification, Headers, HttpMethod, Invitation, InvitationStatus, ListUsersParams, Member,
-    Organization, Passkey, RequestMeta, TwoFactor, UpdateAccount, UpdateApiKey, UpdateOrganization,
-    UpdatePasskey, UpdateUser, UpdateUserRequest, UpdateUserResponse,
+    ApiKey, AuthRequest, AuthResponse, CreateAccount, CreateApiKey, CreateDeviceCode,
+    CreateInvitation, CreateMember, CreateOrganization, CreatePasskey, CreateSession,
+    CreateTwoFactor, CreateUser, CreateVerification, DeviceCode, Headers, HttpMethod, Invitation,
+    InvitationStatus, ListUsersParams, Member, Organization, Passkey, RequestMeta, TwoFactor,
+    UpdateAccount, UpdateApiKey, UpdateDeviceCode, UpdateOrganization, UpdatePasskey, UpdateUser,
+    UpdateUserRequest, UpdateUserResponse,
 };
 pub use better_auth_core::wire::{AccountView, SessionView, UserView, VerificationView};

--- a/tests/client_compat_tests.rs
+++ b/tests/client_compat_tests.rs
@@ -172,12 +172,19 @@ async fn phase3_client_compat() {
 
 #[tokio::test]
 #[ignore = "starts external TS and Rust servers"]
+async fn phase4_client_compat() {
+    run_client_compat(&["tests/phase4"]).await;
+}
+
+#[tokio::test]
+#[ignore = "starts external TS and Rust servers"]
 async fn full_client_compat() {
     run_client_compat(&[
         "tests/phase0",
         "tests/phase1",
         "tests/phase2",
         "tests/phase3",
+        "tests/phase4",
     ])
     .await;
 }


### PR DESCRIPTION
## Summary
- implement the Phase 4 device authorization flow with dedicated device-code storage, SeaORM persistence, and exported Rust plugin wiring
- add the TS-aligned endpoints `/device/code`, `/device/token`, `/device`, `/device/approve`, and `/device/deny`
- add phase4 dual-server compat coverage and wire the compat reference/rust servers to register the plugin
- harden approved-code redemption so only one concurrent poller can consume a device code while keeping client-visible behavior compatible
- fix default `/error` page parity surfaced by the full compat revalidation so phases 0-3 stay green

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace`
- `cargo clippy --workspace --features axum`
- `cargo test --workspace --lib`
- `cargo test -p better-auth-api device_authorization --lib`
- `cargo test --test client_compat_tests full_client_compat -- --ignored --nocapture`