### PR TITLE
feat(organization): align phase 6 compat behavior

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,7 +54,6 @@ Test suites, scripts, and source comments reference these phase numbers
 `/organization/list`, `/organization/list-members`,
 `/organization/get-active-member`,
 `/organization/get-active-member-role`,
-`/organization/add-member`,
 `/organization/update-member-role`,
 `/organization/remove-member`, `/organization/leave`,
 `/organization/invite-member`,

--- a/compat-tests/README.md
+++ b/compat-tests/README.md
@@ -53,6 +53,7 @@ bun test tests/phase2
 bun test tests/phase3
 bun test tests/phase4
 bun test tests/phase5
+bun test tests/phase6
 ```
 
 ### `compat-tests/rust-server/`
@@ -70,6 +71,7 @@ cargo test --test client_compat_tests phase2_client_compat -- --ignored --nocapt
 cargo test --test client_compat_tests phase3_client_compat -- --ignored --nocapture
 cargo test --test client_compat_tests phase4_client_compat -- --ignored --nocapture
 cargo test --test client_compat_tests phase5_client_compat -- --ignored --nocapture
+cargo test --test client_compat_tests phase6_client_compat -- --ignored --nocapture
 cargo test --test client_compat_tests full_client_compat -- --ignored --nocapture
 ```
 
@@ -88,5 +90,6 @@ bash compat-tests/client-tests/run-against-both.sh phase2
 bash compat-tests/client-tests/run-against-both.sh phase3
 bash compat-tests/client-tests/run-against-both.sh phase4
 bash compat-tests/client-tests/run-against-both.sh phase5
+bash compat-tests/client-tests/run-against-both.sh phase6
 bash compat-tests/client-tests/run-against-both.sh all
 ```

--- a/compat-tests/client-tests/package.json
+++ b/compat-tests/client-tests/package.json
@@ -3,13 +3,14 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "bun test tests/phase0 tests/phase1 tests/phase2 tests/phase3 tests/phase4 tests/phase5",
+    "test": "bun test tests/phase0 tests/phase1 tests/phase2 tests/phase3 tests/phase4 tests/phase5 tests/phase6",
     "test:phase0": "bun test tests/phase0",
     "test:phase1": "bun test tests/phase1",
     "test:phase2": "bun test tests/phase2",
     "test:phase3": "bun test tests/phase3",
     "test:phase4": "bun test tests/phase4",
-    "test:phase5": "bun test tests/phase5"
+    "test:phase5": "bun test tests/phase5",
+    "test:phase6": "bun test tests/phase6"
   },
   "dependencies": {
     "better-auth": "1.4.19",

--- a/compat-tests/client-tests/run-against-both.sh
+++ b/compat-tests/client-tests/run-against-both.sh
@@ -5,7 +5,7 @@ phase="all"
 
 for arg in "$@"; do
   case "$arg" in
-    phase0|phase1|phase2|phase3|phase4|phase5|all) phase="$arg" ;;
+    phase0|phase1|phase2|phase3|phase4|phase5|phase6|all) phase="$arg" ;;
     --skip-build) ;;
     *) echo "Unknown argument: $arg" >&2; exit 1 ;;
   esac
@@ -18,6 +18,7 @@ case "$phase" in
   phase3) test_name="phase3_client_compat" ;;
   phase4) test_name="phase4_client_compat" ;;
   phase5) test_name="phase5_client_compat" ;;
+  phase6) test_name="phase6_client_compat" ;;
   all) test_name="full_client_compat" ;;
 esac
 

--- a/compat-tests/client-tests/support/scenario.ts
+++ b/compat-tests/client-tests/support/scenario.ts
@@ -21,6 +21,7 @@ import { normalizeClientValue } from "./normalize";
 import { createTracingFetch, type TraceEntry } from "./trace";
 
 type ScenarioServerContext = {
+  baseURL: string;
   actor(name?: string): {
     client: ReturnType<typeof createAuthClient>;
     fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>;
@@ -134,6 +135,7 @@ async function runScenario(
   const shortSeed = seed.replace(/-/g, "").slice(0, 12);
 
   const context: ScenarioServerContext = {
+    baseURL,
     actor(name = "primary") {
       const existing = actors.get(name);
       if (existing) {

--- a/compat-tests/client-tests/support/trace.ts
+++ b/compat-tests/client-tests/support/trace.ts
@@ -14,8 +14,14 @@ export type TraceEntry = {
 
 function normalizeTracePath(url: URL) {
   const normalized = new URL(url.toString());
-  for (const key of ["token", "state", "user_code", "id"]) {
-    if (normalized.searchParams.has(key)) {
+  for (const [key] of normalized.searchParams.entries()) {
+    if (
+      key === "token" ||
+      key === "state" ||
+      key === "user_code" ||
+      key === "id" ||
+      key.endsWith("Id")
+    ) {
       normalized.searchParams.set(key, `<${key}>`);
     }
   }

--- a/compat-tests/client-tests/tests/phase6/core.test.ts
+++ b/compat-tests/client-tests/tests/phase6/core.test.ts
@@ -1,0 +1,85 @@
+import { compatScenario } from "../../support/scenario";
+import { signUpUser } from "./helpers";
+
+compatScenario("organization core lifecycle matches TS", async (ctx) => {
+  const owner = await signUpUser(ctx, "owner", "phase6-core-owner", "Org Owner");
+  const firstSlug = ctx.uniqueToken("phase6-first-org");
+  const secondSlug = ctx.uniqueToken("phase6-second-org");
+  const availableSlug = ctx.uniqueToken("phase6-available-org");
+
+  const checkAvailable = await owner.orgClient.organization.checkSlug({
+    slug: availableSlug,
+  });
+
+  const firstOrganization = await owner.orgClient.organization.create({
+    name: "Alpha Org",
+    slug: firstSlug,
+  });
+  const secondOrganization = await owner.orgClient.organization.create({
+    name: "Beta Org",
+    slug: secondSlug,
+  });
+
+  const checkTaken = await owner.orgClient.organization.checkSlug({
+    slug: firstSlug,
+  });
+
+  const listedOrganizations = await owner.orgClient.organization.list();
+  const updateFirst = await owner.orgClient.organization.update({
+    organizationId: firstOrganization.data?.id ?? "",
+    data: {
+      name: "Alpha Org Renamed",
+      metadata: {
+        tier: "gold",
+      },
+    },
+  });
+  const activeSecondBySlug = await owner.orgClient.organization.setActive({
+    organizationSlug: secondSlug,
+  });
+  const fullOrganizationBySlugPrecedence =
+    await owner.orgClient.organization.getFullOrganization({
+      query: {
+        organizationId: firstOrganization.data?.id,
+        organizationSlug: secondSlug,
+      },
+    });
+  const clearActiveOrganization = await owner.orgClient.organization.setActive({
+    organizationId: null,
+  });
+  const fullOrganizationWithoutActive =
+    await owner.orgClient.organization.getFullOrganization();
+
+  return {
+    checkAvailable: ctx.snapshot(checkAvailable),
+    firstOrganization: ctx.snapshot(firstOrganization),
+    secondOrganization: ctx.snapshot(secondOrganization),
+    checkTaken: ctx.snapshot(checkTaken),
+    listedOrganizations: ctx.snapshot(listedOrganizations),
+    updateFirst: ctx.snapshot(updateFirst),
+    activeSecondBySlug: ctx.snapshot(activeSecondBySlug),
+    fullOrganizationBySlugPrecedence: ctx.snapshot(fullOrganizationBySlugPrecedence),
+    clearActiveOrganization: ctx.snapshot(clearActiveOrganization),
+    fullOrganizationWithoutActive: ctx.snapshot(fullOrganizationWithoutActive),
+  };
+});
+
+compatScenario("organization delete returns the deleted org and clears active state", async (ctx) => {
+  const owner = await signUpUser(ctx, "owner", "phase6-delete-owner", "Delete Owner");
+  const slug = ctx.uniqueToken("phase6-delete-org");
+
+  const created = await owner.orgClient.organization.create({
+    name: "Delete Me",
+    slug,
+  });
+  const deleted = await owner.orgClient.organization.delete({
+    organizationId: created.data?.id ?? "",
+  });
+  const fullOrganizationAfterDelete = await owner.orgClient.organization.getFullOrganization();
+
+  return {
+    created: ctx.snapshot(created),
+    deleted: ctx.snapshot(deleted),
+    fullOrganizationAfterDelete: ctx.snapshot(fullOrganizationAfterDelete),
+  };
+});

--- a/compat-tests/client-tests/tests/phase6/helpers.ts
+++ b/compat-tests/client-tests/tests/phase6/helpers.ts
@@ -1,0 +1,55 @@
+import { createAuthClient } from "better-auth/client";
+import { organizationClient } from "better-auth/client/plugins";
+import { compatScenario } from "../../support/scenario";
+
+export type CompatContext = Parameters<Parameters<typeof compatScenario>[1]>[0];
+
+export function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("expected object response body");
+  }
+  return value as Record<string, unknown>;
+}
+
+export function asArray(value: unknown): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error("expected array response body");
+  }
+  return value;
+}
+
+export function organizationActor(ctx: CompatContext, name = "primary") {
+  const actor = ctx.actor(name);
+
+  return {
+    ...actor,
+    orgClient: createAuthClient({
+      baseURL: ctx.baseURL,
+      plugins: [organizationClient()],
+      fetchOptions: {
+        customFetchImpl: actor.fetch,
+      },
+    }),
+  };
+}
+
+export async function signUpUser(
+  ctx: CompatContext,
+  name: string,
+  prefix: string,
+  displayName: string,
+) {
+  const actor = organizationActor(ctx, name);
+  const email = ctx.uniqueEmail(prefix);
+  const signup = await actor.client.signUp.email({
+    email,
+    password: "password123",
+    name: displayName,
+  });
+
+  return {
+    ...actor,
+    email,
+    signup,
+  };
+}

--- a/compat-tests/client-tests/tests/phase6/invitations.test.ts
+++ b/compat-tests/client-tests/tests/phase6/invitations.test.ts
@@ -1,0 +1,106 @@
+import { compatScenario } from "../../support/scenario";
+import { signUpUser } from "./helpers";
+
+compatScenario("organization invitation happy path covers list and accept flows", async (ctx) => {
+  const owner = await signUpUser(ctx, "owner", "phase6-invite-owner", "Owner");
+  const invitee = await signUpUser(ctx, "invitee", "phase6-invite-invitee", "Invitee");
+  const slug = ctx.uniqueToken("phase6-invite-org");
+
+  const organization = await owner.orgClient.organization.create({
+    name: "Invite Org",
+    slug,
+  });
+  const invitation = await owner.orgClient.organization.inviteMember({
+    organizationId: organization.data?.id ?? "",
+    email: invitee.email,
+    role: "member",
+  });
+  const getInvitation = await invitee.orgClient.organization.getInvitation({
+    query: {
+      id: invitation.data?.id ?? "",
+    },
+  });
+  const listInvitations = await owner.orgClient.organization.listInvitations({
+    query: {
+      organizationId: organization.data?.id,
+    },
+  });
+  const listUserInvitations = await invitee.orgClient.organization.listUserInvitations();
+  const acceptInvitation = await invitee.orgClient.organization.acceptInvitation({
+    invitationId: invitation.data?.id ?? "",
+  });
+  const fullOrganizationAfterAccept =
+    await invitee.orgClient.organization.getFullOrganization();
+
+  return {
+    organization: ctx.snapshot(organization),
+    invitation: ctx.snapshot(invitation),
+    getInvitation: ctx.snapshot(getInvitation),
+    listInvitations: ctx.snapshot(listInvitations),
+    listUserInvitations: ctx.snapshot(listUserInvitations),
+    acceptInvitation: ctx.snapshot(acceptInvitation),
+    fullOrganizationAfterAccept: ctx.snapshot(fullOrganizationAfterAccept),
+  };
+});
+
+compatScenario("organization invitation validation, reject, and cancel flows match TS", async (ctx) => {
+  const owner = await signUpUser(ctx, "owner", "phase6-validate-owner", "Owner");
+  const admin = await signUpUser(ctx, "admin", "phase6-validate-admin", "Admin");
+  const rejectUser = await signUpUser(ctx, "reject-user", "phase6-reject-user", "Reject User");
+  const cancelUser = await signUpUser(ctx, "cancel-user", "phase6-cancel-user", "Cancel User");
+  const slug = ctx.uniqueToken("phase6-validate-org");
+
+  const organization = await owner.orgClient.organization.create({
+    name: "Validation Org",
+    slug,
+  });
+
+  const adminInvitation = await owner.orgClient.organization.inviteMember({
+    organizationId: organization.data?.id ?? "",
+    email: admin.email,
+    role: "admin",
+  });
+  const acceptedAdmin = await admin.orgClient.organization.acceptInvitation({
+    invitationId: adminInvitation.data?.id ?? "",
+  });
+  const adminInvitingOwner = await admin.orgClient.organization.inviteMember({
+    organizationId: organization.data?.id ?? "",
+    email: ctx.uniqueEmail("phase6-owner-role"),
+    role: "owner",
+  });
+  const invalidRoleInvitation = await owner.orgClient.organization.inviteMember({
+    organizationId: organization.data?.id ?? "",
+    email: ctx.uniqueEmail("phase6-invalid-role"),
+    role: "super-invalid-role-123" as never,
+  });
+
+  const rejectInvitation = await owner.orgClient.organization.inviteMember({
+    organizationId: organization.data?.id ?? "",
+    email: rejectUser.email,
+    role: "member",
+  });
+  const rejected = await rejectUser.orgClient.organization.rejectInvitation({
+    invitationId: rejectInvitation.data?.id ?? "",
+  });
+
+  const cancelInvitation = await owner.orgClient.organization.inviteMember({
+    organizationId: organization.data?.id ?? "",
+    email: cancelUser.email,
+    role: "member",
+  });
+  const canceled = await owner.orgClient.organization.cancelInvitation({
+    invitationId: cancelInvitation.data?.id ?? "",
+  });
+
+  return {
+    organization: ctx.snapshot(organization),
+    adminInvitation: ctx.snapshot(adminInvitation),
+    acceptedAdmin: ctx.snapshot(acceptedAdmin),
+    adminInvitingOwner: ctx.snapshot(adminInvitingOwner),
+    invalidRoleInvitation: ctx.snapshot(invalidRoleInvitation),
+    rejectInvitation: ctx.snapshot(rejectInvitation),
+    rejected: ctx.snapshot(rejected),
+    cancelInvitation: ctx.snapshot(cancelInvitation),
+    canceled: ctx.snapshot(canceled),
+  };
+});

--- a/compat-tests/client-tests/tests/phase6/members.test.ts
+++ b/compat-tests/client-tests/tests/phase6/members.test.ts
@@ -87,6 +87,58 @@ compatScenario("organization member queries cover add member and active member e
   };
 });
 
+compatScenario("organization list members supports sort and filter queries", async (ctx) => {
+  const owner = await signUpUser(ctx, "owner", "phase6-list-owner", "Owner");
+  const member = await signUpUser(ctx, "member", "phase6-list-member", "Member");
+  const admin = await signUpUser(ctx, "admin", "phase6-list-admin", "Admin");
+  const slug = ctx.uniqueToken("phase6-list-org");
+
+  const organization = await owner.orgClient.organization.create({
+    name: "List Org",
+    slug,
+  });
+
+  const invitedMember = await owner.orgClient.organization.inviteMember({
+    organizationId: organization.data?.id ?? "",
+    email: member.email,
+    role: "member",
+  });
+  await member.orgClient.organization.acceptInvitation({
+    invitationId: invitedMember.data?.id ?? "",
+  });
+
+  const invitedAdmin = await owner.orgClient.organization.inviteMember({
+    organizationId: organization.data?.id ?? "",
+    email: admin.email,
+    role: "admin",
+  });
+  await admin.orgClient.organization.acceptInvitation({
+    invitationId: invitedAdmin.data?.id ?? "",
+  });
+
+  const filteredMembers = await owner.orgClient.organization.listMembers({
+    query: {
+      organizationId: organization.data?.id,
+      filterField: "role",
+      filterOperator: "ne",
+      filterValue: "owner",
+    },
+  });
+  const sortedMembers = await owner.orgClient.organization.listMembers({
+    query: {
+      organizationId: organization.data?.id,
+      sortBy: "createdAt",
+      sortDirection: "desc",
+    },
+  });
+
+  return {
+    organization: ctx.snapshot(organization),
+    filteredMembers: ctx.snapshot(filteredMembers),
+    sortedMembers: ctx.snapshot(sortedMembers),
+  };
+});
+
 compatScenario("organization membership mutations cover permissions, role updates, removal, and leave", async (ctx) => {
   const owner = await signUpUser(ctx, "owner", "phase6-mutations-owner", "Owner");
   const member = await signUpUser(ctx, "member", "phase6-mutations-member", "Member");

--- a/compat-tests/client-tests/tests/phase6/members.test.ts
+++ b/compat-tests/client-tests/tests/phase6/members.test.ts
@@ -1,7 +1,7 @@
 import { compatScenario } from "../../support/scenario";
 import { asArray, asRecord, signUpUser } from "./helpers";
 
-compatScenario("organization member queries cover add member and active member endpoints", async (ctx) => {
+compatScenario("organization member queries reflect non-public add-member and active member endpoints", async (ctx) => {
   const owner = await signUpUser(ctx, "owner", "phase6-members-owner", "Owner");
   const member = await signUpUser(ctx, "member", "phase6-members-user", "Member");
   const multiRoleMember = await signUpUser(

--- a/compat-tests/client-tests/tests/phase6/members.test.ts
+++ b/compat-tests/client-tests/tests/phase6/members.test.ts
@@ -1,0 +1,162 @@
+import { compatScenario } from "../../support/scenario";
+import { asArray, asRecord, signUpUser } from "./helpers";
+
+compatScenario("organization member queries cover add member and active member endpoints", async (ctx) => {
+  const owner = await signUpUser(ctx, "owner", "phase6-members-owner", "Owner");
+  const member = await signUpUser(ctx, "member", "phase6-members-user", "Member");
+  const multiRoleMember = await signUpUser(
+    ctx,
+    "multi-role",
+    "phase6-members-multi-role",
+    "Multi Role Member",
+  );
+  const slug = ctx.uniqueToken("phase6-members-org");
+
+  const organization = await owner.orgClient.organization.create({
+    name: "Members Org",
+    slug,
+  });
+
+  const addMember = await ctx.rawRequest({
+    actor: "owner",
+    path: "/api/auth/organization/add-member",
+    method: "POST",
+    json: {
+      organizationId: organization.data?.id,
+      userId: member.signup.data?.user.id,
+      role: "member",
+    },
+  });
+  const addMultiRoleMember = await ctx.rawRequest({
+    actor: "owner",
+    path: "/api/auth/organization/add-member",
+    method: "POST",
+    json: {
+      organizationId: organization.data?.id,
+      userId: multiRoleMember.signup.data?.user.id,
+      role: ["admin", "member"],
+    },
+  });
+
+  const invitedMember = await owner.orgClient.organization.inviteMember({
+    organizationId: organization.data?.id ?? "",
+    email: member.email,
+    role: "member",
+  });
+  const acceptedMember = await member.orgClient.organization.acceptInvitation({
+    invitationId: invitedMember.data?.id ?? "",
+  });
+  const invitedMultiRoleMember = await owner.orgClient.organization.inviteMember({
+    organizationId: organization.data?.id ?? "",
+    email: multiRoleMember.email,
+    role: ["admin", "member"] as never,
+  });
+  const acceptedMultiRoleMember =
+    await multiRoleMember.orgClient.organization.acceptInvitation({
+      invitationId: invitedMultiRoleMember.data?.id ?? "",
+    });
+
+  const listMembers = await owner.orgClient.organization.listMembers({
+    query: {
+      organizationId: organization.data?.id,
+      limit: 1,
+      offset: 1,
+    },
+  });
+  const getActiveMember = await owner.orgClient.organization.getActiveMember();
+  const getActiveMemberRole = await owner.orgClient.organization.getActiveMemberRole();
+  const getOtherMemberRole = await owner.orgClient.organization.getActiveMemberRole({
+    query: {
+      organizationId: organization.data?.id,
+      userId: member.signup.data?.user.id,
+    },
+  });
+
+  return {
+    organization: ctx.snapshot(organization),
+    addMember: ctx.snapshot(addMember),
+    addMultiRoleMember: ctx.snapshot(addMultiRoleMember),
+    invitedMember: ctx.snapshot(invitedMember),
+    acceptedMember: ctx.snapshot(acceptedMember),
+    invitedMultiRoleMember: ctx.snapshot(invitedMultiRoleMember),
+    acceptedMultiRoleMember: ctx.snapshot(acceptedMultiRoleMember),
+    listMembers: ctx.snapshot(listMembers),
+    getActiveMember: ctx.snapshot(getActiveMember),
+    getActiveMemberRole: ctx.snapshot(getActiveMemberRole),
+    getOtherMemberRole: ctx.snapshot(getOtherMemberRole),
+  };
+});
+
+compatScenario("organization membership mutations cover permissions, role updates, removal, and leave", async (ctx) => {
+  const owner = await signUpUser(ctx, "owner", "phase6-mutations-owner", "Owner");
+  const member = await signUpUser(ctx, "member", "phase6-mutations-member", "Member");
+  const removable = await signUpUser(ctx, "removable", "phase6-mutations-removable", "Removable");
+  const slug = ctx.uniqueToken("phase6-mutations-org");
+
+  const organization = await owner.orgClient.organization.create({
+    name: "Mutation Org",
+    slug,
+  });
+
+  const invitedMember = await owner.orgClient.organization.inviteMember({
+    organizationId: organization.data?.id ?? "",
+    email: member.email,
+    role: "member",
+  });
+  const acceptedMember = await member.orgClient.organization.acceptInvitation({
+    invitationId: invitedMember.data?.id ?? "",
+  });
+  const invitedRemovable = await owner.orgClient.organization.inviteMember({
+    organizationId: organization.data?.id ?? "",
+    email: removable.email,
+    role: "member",
+  });
+  const acceptedRemovable = await removable.orgClient.organization.acceptInvitation({
+    invitationId: invitedRemovable.data?.id ?? "",
+  });
+
+  const ownerPermissions = await owner.orgClient.organization.hasPermission({
+    organizationId: organization.data?.id,
+    permissions: {
+      invitation: ["create"],
+      member: ["update"],
+    },
+  });
+
+  const memberSetActive = await member.orgClient.organization.setActive({
+    organizationId: organization.data?.id ?? "",
+  });
+  const memberPermissionsBeforeRoleUpdate =
+    await member.orgClient.organization.hasPermission({
+      permissions: {
+        member: ["delete"],
+      },
+    });
+
+  const updateMemberRole = await owner.orgClient.organization.updateMemberRole({
+    organizationId: organization.data?.id ?? "",
+    memberId: acceptedMember.data?.member.id ?? "",
+    role: ["admin", "member"],
+  });
+  const removeMember = await owner.orgClient.organization.removeMember({
+    organizationId: organization.data?.id ?? "",
+    memberIdOrEmail: removable.email,
+  });
+  const leaveOrganization = await member.orgClient.organization.leave({
+    organizationId: organization.data?.id ?? "",
+  });
+
+  return {
+    organization: ctx.snapshot(organization),
+    invitedMember: ctx.snapshot(invitedMember),
+    acceptedMember: ctx.snapshot(acceptedMember),
+    invitedRemovable: ctx.snapshot(invitedRemovable),
+    acceptedRemovable: ctx.snapshot(acceptedRemovable),
+    ownerPermissions: ctx.snapshot(ownerPermissions),
+    memberSetActive: ctx.snapshot(memberSetActive),
+    memberPermissionsBeforeRoleUpdate: ctx.snapshot(memberPermissionsBeforeRoleUpdate),
+    updateMemberRole: ctx.snapshot(updateMemberRole),
+    removeMember: ctx.snapshot(removeMember),
+    leaveOrganization: ctx.snapshot(leaveOrganization),
+  };
+});

--- a/compat-tests/reference-server/server.ts
+++ b/compat-tests/reference-server/server.ts
@@ -4,6 +4,7 @@ import { Database } from "bun:sqlite";
 import { betterAuth } from "better-auth";
 import { getMigrations } from "better-auth/db";
 import { apiKey, deviceAuthorization } from "better-auth/plugins";
+import { organization } from "better-auth/plugins/organization";
 import { genericOAuth } from "better-auth/plugins/generic-oauth";
 
 function getPort() {
@@ -315,6 +316,7 @@ const authOptions = {
   plugins: [
     apiKey({ enableMetadata: true }),
     deviceAuthorization(),
+    organization(),
     genericOAuth({
       config: [
         {

--- a/compat-tests/rust-server/src/main.rs
+++ b/compat-tests/rust-server/src/main.rs
@@ -8,8 +8,8 @@ use better_auth::integrations::axum::AxumIntegration;
 use better_auth::prelude::{AuthAccount, AuthUser, CreateAccount, CreateVerification};
 use better_auth::plugins::{
     AccountManagementPlugin, ApiKeyPlugin, DeviceAuthorizationPlugin, EmailPasswordPlugin,
-    EmailVerificationPlugin, OAuthPlugin, PasswordManagementPlugin, SessionManagementPlugin,
-    UserManagementPlugin,
+    EmailVerificationPlugin, OAuthPlugin, OrganizationPlugin, PasswordManagementPlugin,
+    SessionManagementPlugin, UserManagementPlugin,
     email_verification::SendVerificationEmail, user_management::SendChangeEmailConfirmation,
     oauth::{
         OAuthIdTokenVerifier, OAuthProvider, OAuthRefreshTokenHandler, OAuthTokenSet, OAuthUserInfo,
@@ -474,6 +474,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .plugin(AccountManagementPlugin::new())
             .plugin(DeviceAuthorizationPlugin::new())
             .plugin(ApiKeyPlugin::builder().enable_metadata(true).build())
+            .plugin(OrganizationPlugin::new())
             .plugin(
                 PasswordManagementPlugin::new().send_reset_password(Arc::new(CompatResetSender {
                     outbox: reset_outbox.clone(),

--- a/crates/api/src/plugins/organization/handlers/invitation.rs
+++ b/crates/api/src/plugins/organization/handlers/invitation.rs
@@ -57,6 +57,10 @@ pub(crate) async fn invite_member_core(
     }
 
     let roles = requested_roles(&body.role);
+    if roles.is_empty() {
+        return Err(AuthError::bad_request("Role is required"));
+    }
+
     let mut valid_roles = vec![config.creator_role.as_str(), "admin", "member"];
     valid_roles.extend(config.roles.keys().map(String::as_str));
 

--- a/crates/api/src/plugins/organization/handlers/invitation.rs
+++ b/crates/api/src/plugins/organization/handlers/invitation.rs
@@ -12,10 +12,18 @@ use super::{require_session, resolve_organization_id};
 use crate::plugins::organization::OrganizationConfig;
 use crate::plugins::organization::rbac::{Action, Resource, has_permission_any};
 use crate::plugins::organization::types::{
-    AcceptInvitationRequest, AcceptInvitationResponse, CancelInvitationRequest, GetInvitationQuery,
-    GetInvitationResponse, InviteMemberRequest, ListInvitationsQuery, MemberResponse,
-    RejectInvitationRequest, SuccessResponse,
+    AcceptInvitationRequest, AcceptInvitationResponse, BasicMemberResponse,
+    CancelInvitationRequest, GetInvitationQuery, GetInvitationResponse, InviteMemberRequest,
+    ListInvitationsQuery, RejectInvitationRequest, UserInvitationResponse,
 };
+
+fn normalized_roles(input: &crate::plugins::organization::types::RoleInput) -> String {
+    input.joined()
+}
+
+fn requested_roles(input: &crate::plugins::organization::types::RoleInput) -> Vec<&str> {
+    input.roles()
+}
 
 // ---------------------------------------------------------------------------
 // Core functions
@@ -48,6 +56,36 @@ pub(crate) async fn invite_member_core(
         ));
     }
 
+    let roles = requested_roles(&body.role);
+    let mut valid_roles = vec![config.creator_role.as_str(), "admin", "member"];
+    valid_roles.extend(config.roles.keys().map(String::as_str));
+
+    let unknown_roles: Vec<_> = roles
+        .iter()
+        .copied()
+        .filter(|role| !valid_roles.contains(role))
+        .collect();
+
+    if !unknown_roles.is_empty() {
+        return Err(AuthError::bad_request(format!(
+            "Role not found: {}",
+            unknown_roles.join(", ")
+        )));
+    }
+
+    let member_is_creator = member
+        .role()
+        .split(',')
+        .map(str::trim)
+        .any(|role| role == config.creator_role);
+    let invites_creator_role = roles.iter().any(|role| *role == config.creator_role);
+
+    if invites_creator_role && !member_is_creator {
+        return Err(AuthError::forbidden(
+            "You are not allowed to invite a user with this role",
+        ));
+    }
+
     if let Some(limit) = config.membership_limit {
         let members = ctx.database.list_organization_members(&org_id).await?;
         if members.len() >= limit {
@@ -60,7 +98,10 @@ pub(crate) async fn invite_member_core(
 
     if let Some(limit) = config.invitation_limit {
         let invitations = ctx.database.list_organization_invitations(&org_id).await?;
-        let pending_count = invitations.iter().filter(|i| i.is_pending()).count();
+        let pending_count = invitations
+            .iter()
+            .filter(|invitation| invitation.is_pending())
+            .count();
         if pending_count >= limit {
             return Err(AuthError::bad_request(format!(
                 "Pending invitation limit of {} reached",
@@ -76,10 +117,11 @@ pub(crate) async fn invite_member_core(
             .await?
             .is_some()
     {
-        return Err(AuthError::bad_request("User is already a member"));
+        return Err(AuthError::bad_request(
+            "User is already a member of this organization",
+        ));
     }
 
-    // Return existing pending invitation if one exists
     if let Some(existing) = ctx
         .database
         .get_pending_invitation(&org_id, &body.email)
@@ -92,15 +134,14 @@ pub(crate) async fn invite_member_core(
         chrono::Utc::now() + chrono::Duration::seconds(config.invitation_expires_in as i64);
 
     let invitation_data = CreateInvitation {
-        organization_id: org_id.clone(),
-        email: body.email.clone(),
-        role: body.role.clone(),
+        organization_id: org_id,
+        email: body.email.to_lowercase(),
+        role: normalized_roles(&body.role),
         inviter_id: user.id().to_string(),
         expires_at,
     };
 
     let invitation = ctx.database.create_invitation(invitation_data).await?;
-
     Ok(InvitationView::from(&invitation))
 }
 
@@ -129,7 +170,7 @@ pub(crate) async fn get_invitation_core(
         .get_user_by_id(&invitation.inviter_id())
         .await?
     {
-        inviter.email().map(|s| s.to_string())
+        inviter.email().map(str::to_owned)
     } else {
         None
     };
@@ -158,25 +199,36 @@ pub(crate) async fn list_invitations_core(
         .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
 
     let invitations = ctx.database.list_organization_invitations(&org_id).await?;
-
     Ok(invitations.iter().map(InvitationView::from).collect())
 }
 
 pub(crate) async fn list_user_invitations_core(
     user: &impl AuthUser,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
-) -> AuthResult<Vec<InvitationView>> {
+) -> AuthResult<Vec<UserInvitationResponse<InvitationView>>> {
     let user_email = user
         .email()
         .ok_or_else(|| AuthError::bad_request("User has no email"))?;
 
     let all_invitations = ctx.database.list_user_invitations(user_email).await?;
+    let mut pending = Vec::new();
 
-    let pending: Vec<_> = all_invitations
-        .iter()
-        .filter(|i| i.is_pending() && !i.is_expired())
-        .map(InvitationView::from)
-        .collect();
+    for invitation in all_invitations.iter() {
+        if !invitation.is_pending() || invitation.is_expired() {
+            continue;
+        }
+
+        let organization = ctx
+            .database
+            .get_organization_by_id(invitation.organization_id().as_ref())
+            .await?
+            .ok_or_else(|| AuthError::bad_request("Organization not found"))?;
+
+        pending.push(UserInvitationResponse {
+            invitation: InvitationView::from(invitation),
+            organization_name: organization.name().to_string(),
+        });
+    }
 
     Ok(pending)
 }
@@ -187,7 +239,7 @@ pub(crate) async fn accept_invitation_core(
     session: &impl AuthSession,
     config: &OrganizationConfig,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
-) -> AuthResult<AcceptInvitationResponse<InvitationView>> {
+) -> AuthResult<AcceptInvitationResponse<InvitationView, BasicMemberResponse>> {
     let invitation = ctx
         .database
         .get_invitation_by_id(&body.invitation_id)
@@ -202,15 +254,8 @@ pub(crate) async fn accept_invitation_core(
         return Err(AuthError::forbidden("This invitation is not for you"));
     }
 
-    if !invitation.is_pending() {
-        return Err(AuthError::bad_request(format!(
-            "Invitation is {:?}",
-            invitation.status()
-        )));
-    }
-
-    if invitation.is_expired() {
-        return Err(AuthError::bad_request("Invitation has expired"));
+    if !invitation.is_pending() || invitation.is_expired() {
+        return Err(AuthError::bad_request("Invitation not found"));
     }
 
     if let Some(limit) = config.membership_limit {
@@ -247,7 +292,6 @@ pub(crate) async fn accept_invitation_core(
     };
 
     let member = ctx.database.create_member(member_data).await?;
-
     let updated_invitation = ctx
         .database
         .update_invitation_status(&invitation.id(), InvitationStatus::Accepted)
@@ -261,11 +305,9 @@ pub(crate) async fn accept_invitation_core(
         )
         .await?;
 
-    let member_response = MemberResponse::from_member_and_user(&member, user);
-
     Ok(AcceptInvitationResponse {
         invitation: InvitationView::from(&updated_invitation),
-        member: member_response,
+        member: BasicMemberResponse::from_member(&member),
     })
 }
 
@@ -273,7 +315,7 @@ pub(crate) async fn reject_invitation_core(
     body: &RejectInvitationRequest,
     user: &impl AuthUser,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
-) -> AuthResult<SuccessResponse> {
+) -> AuthResult<AcceptInvitationResponse<InvitationView, Option<BasicMemberResponse>>> {
     let invitation = ctx
         .database
         .get_invitation_by_id(&body.invitation_id)
@@ -289,18 +331,18 @@ pub(crate) async fn reject_invitation_core(
     }
 
     if !invitation.is_pending() {
-        return Err(AuthError::bad_request(format!(
-            "Invitation is already {:?}",
-            invitation.status()
-        )));
+        return Err(AuthError::bad_request("Invitation not found"));
     }
 
-    let _ = ctx
+    let updated_invitation = ctx
         .database
         .update_invitation_status(&invitation.id(), InvitationStatus::Rejected)
         .await?;
 
-    Ok(SuccessResponse { success: true })
+    Ok(AcceptInvitationResponse {
+        invitation: InvitationView::from(&updated_invitation),
+        member: None,
+    })
 }
 
 pub(crate) async fn cancel_invitation_core(
@@ -308,7 +350,7 @@ pub(crate) async fn cancel_invitation_core(
     user: &impl AuthUser,
     config: &OrganizationConfig,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
-) -> AuthResult<SuccessResponse> {
+) -> AuthResult<InvitationView> {
     let invitation = ctx
         .database
         .get_invitation_by_id(&body.invitation_id)
@@ -333,25 +375,21 @@ pub(crate) async fn cancel_invitation_core(
     }
 
     if !invitation.is_pending() {
-        return Err(AuthError::bad_request(format!(
-            "Invitation is already {:?}",
-            invitation.status()
-        )));
+        return Err(AuthError::bad_request("Invitation not found"));
     }
 
-    let _ = ctx
+    let updated_invitation = ctx
         .database
         .update_invitation_status(&invitation.id(), InvitationStatus::Canceled)
         .await?;
 
-    Ok(SuccessResponse { success: true })
+    Ok(InvitationView::from(&updated_invitation))
 }
 
 // ---------------------------------------------------------------------------
-// Old handlers (rewritten to call core)
+// Handlers
 // ---------------------------------------------------------------------------
 
-/// Handle invite member request
 pub async fn handle_invite_member(
     req: &AuthRequest,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
@@ -359,14 +397,13 @@ pub async fn handle_invite_member(
 ) -> AuthResult<AuthResponse> {
     let (user, session) = require_session(req, ctx).await?;
     let body: InviteMemberRequest = match better_auth_core::validate_request_body(req) {
-        Ok(v) => v,
-        Err(resp) => return Ok(resp),
+        Ok(value) => value,
+        Err(response) => return Ok(response),
     };
     let invitation = invite_member_core(&body, &user, &session, config, ctx).await?;
     Ok(AuthResponse::json(200, &invitation)?)
 }
 
-/// Handle get invitation request
 pub async fn handle_get_invitation(
     req: &AuthRequest,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
@@ -376,7 +413,6 @@ pub async fn handle_get_invitation(
     Ok(AuthResponse::json(200, &response)?)
 }
 
-/// Handle list invitations request
 pub async fn handle_list_invitations(
     req: &AuthRequest,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
@@ -387,17 +423,15 @@ pub async fn handle_list_invitations(
     Ok(AuthResponse::json(200, &invitations)?)
 }
 
-/// Handle list user invitations request
 pub async fn handle_list_user_invitations(
     req: &AuthRequest,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
 ) -> AuthResult<AuthResponse> {
     let (user, _session) = require_session(req, ctx).await?;
-    let pending = list_user_invitations_core(&user, ctx).await?;
-    Ok(AuthResponse::json(200, &pending)?)
+    let invitations = list_user_invitations_core(&user, ctx).await?;
+    Ok(AuthResponse::json(200, &invitations)?)
 }
 
-/// Handle accept invitation request
 pub async fn handle_accept_invitation(
     req: &AuthRequest,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
@@ -405,28 +439,26 @@ pub async fn handle_accept_invitation(
 ) -> AuthResult<AuthResponse> {
     let (user, session) = require_session(req, ctx).await?;
     let body: AcceptInvitationRequest = match better_auth_core::validate_request_body(req) {
-        Ok(v) => v,
-        Err(resp) => return Ok(resp),
+        Ok(value) => value,
+        Err(response) => return Ok(response),
     };
     let response = accept_invitation_core(&body, &user, &session, config, ctx).await?;
     Ok(AuthResponse::json(200, &response)?)
 }
 
-/// Handle reject invitation request
 pub async fn handle_reject_invitation(
     req: &AuthRequest,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
 ) -> AuthResult<AuthResponse> {
     let (user, _session) = require_session(req, ctx).await?;
     let body: RejectInvitationRequest = match better_auth_core::validate_request_body(req) {
-        Ok(v) => v,
-        Err(resp) => return Ok(resp),
+        Ok(value) => value,
+        Err(response) => return Ok(response),
     };
     let response = reject_invitation_core(&body, &user, ctx).await?;
     Ok(AuthResponse::json(200, &response)?)
 }
 
-/// Handle cancel invitation request
 pub async fn handle_cancel_invitation(
     req: &AuthRequest,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
@@ -434,14 +466,13 @@ pub async fn handle_cancel_invitation(
 ) -> AuthResult<AuthResponse> {
     let (user, _session) = require_session(req, ctx).await?;
     let body: CancelInvitationRequest = match better_auth_core::validate_request_body(req) {
-        Ok(v) => v,
-        Err(resp) => return Ok(resp),
+        Ok(value) => value,
+        Err(response) => return Ok(response),
     };
     let response = cancel_invitation_core(&body, &user, config, ctx).await?;
     Ok(AuthResponse::json(200, &response)?)
 }
 
-/// Helper function to parse query parameters into a struct
 fn parse_query<T: Default + serde::de::DeserializeOwned>(
     query: &std::collections::HashMap<String, String>,
 ) -> T {

--- a/crates/api/src/plugins/organization/handlers/member.rs
+++ b/crates/api/src/plugins/organization/handlers/member.rs
@@ -1,4 +1,4 @@
-use better_auth_core::entity::{AuthMember, AuthSession, AuthUser};
+use better_auth_core::entity::{AuthMember, AuthOrganization, AuthSession, AuthUser};
 use better_auth_core::error::{AuthError, AuthResult};
 use better_auth_core::plugin::AuthContext;
 use better_auth_core::types::{AuthRequest, AuthResponse};
@@ -7,9 +7,18 @@ use super::{require_session, resolve_organization_id};
 use crate::plugins::organization::OrganizationConfig;
 use crate::plugins::organization::rbac::{Action, Resource, has_permission_any};
 use crate::plugins::organization::types::{
-    ListMembersQuery, ListMembersResponse, MemberResponse, MemberWrappedResponse,
-    RemoveMemberRequest, RemovedMemberInfo, RemovedMemberResponse, UpdateMemberRoleRequest,
+    BasicMemberResponse, GetActiveMemberRoleQuery, GetActiveMemberRoleResponse, ListMembersQuery,
+    ListMembersResponse, MemberResponse, RemoveMemberRequest, RemovedMemberResponse,
+    UpdateMemberRoleRequest,
 };
+
+fn has_role(member: &impl AuthMember, role: &str) -> bool {
+    member
+        .role()
+        .split(',')
+        .map(str::trim)
+        .any(|candidate| candidate == role)
+}
 
 // ---------------------------------------------------------------------------
 // Core functions
@@ -39,19 +48,22 @@ pub(crate) async fn list_members_core(
     session: &impl AuthSession,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
 ) -> AuthResult<ListMembersResponse> {
-    let org_id = resolve_organization_id(
-        query.organization_id.as_deref(),
-        query.organization_slug.as_deref(),
-        session,
-        ctx,
-    )
-    .await?;
+    let org_id = if let Some(slug) = query.organization_slug.as_deref() {
+        let organization = ctx
+            .database
+            .get_organization_by_slug(slug)
+            .await?
+            .ok_or_else(|| AuthError::bad_request("Organization not found"))?;
+        organization.id().to_string()
+    } else {
+        resolve_organization_id(query.organization_id.as_deref(), None, session, ctx).await?
+    };
 
     let _ = ctx
         .database
         .get_member(&org_id, &user.id())
         .await?
-        .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
+        .ok_or_else(|| AuthError::forbidden("You are not a member of this organization"))?;
 
     let members_raw = ctx.database.list_organization_members(&org_id).await?;
     let total = members_raw.len();
@@ -71,6 +83,45 @@ pub(crate) async fn list_members_core(
     Ok(ListMembersResponse { members, total })
 }
 
+pub(crate) async fn get_active_member_role_core(
+    query: &GetActiveMemberRoleQuery,
+    user: &impl AuthUser,
+    session: &impl AuthSession,
+    ctx: &AuthContext<impl better_auth_core::AuthSchema>,
+) -> AuthResult<GetActiveMemberRoleResponse> {
+    let org_id = if let Some(slug) = query.organization_slug.as_deref() {
+        let organization = ctx
+            .database
+            .get_organization_by_slug(slug)
+            .await?
+            .ok_or_else(|| AuthError::bad_request("Organization not found"))?;
+        organization.id().to_string()
+    } else {
+        resolve_organization_id(query.organization_id.as_deref(), None, session, ctx).await?
+    };
+
+    let requester_member = ctx
+        .database
+        .get_member(&org_id, &user.id())
+        .await?
+        .ok_or_else(|| AuthError::forbidden("You are not a member of this organization"))?;
+
+    if let Some(user_id) = query.user_id.as_deref() {
+        let target_member = ctx
+            .database
+            .get_member(&org_id, user_id)
+            .await?
+            .ok_or_else(|| AuthError::forbidden("You are not a member of this organization"))?;
+        return Ok(GetActiveMemberRoleResponse {
+            role: target_member.role().to_string(),
+        });
+    }
+
+    Ok(GetActiveMemberRoleResponse {
+        role: requester_member.role().to_string(),
+    })
+}
+
 pub(crate) async fn remove_member_core(
     body: &RemoveMemberRequest,
     user: &impl AuthUser,
@@ -85,50 +136,37 @@ pub(crate) async fn remove_member_core(
         .database
         .get_member(&org_id, &user.id())
         .await?
-        .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
+        .ok_or_else(|| AuthError::bad_request("Member not found"))?;
 
-    // Determine target member
-    let target_member_id: String;
-    let target_member_org_id: String;
-    let target_member_user_id: String;
-    let target_member_role: String;
-
-    if let Some(member_id) = &body.member_id {
-        let target = ctx
-            .database
-            .get_member_by_id(member_id)
-            .await?
-            .ok_or_else(|| AuthError::not_found("Member not found"))?;
-        target_member_id = target.id().to_string();
-        target_member_org_id = target.organization_id().to_string();
-        target_member_user_id = target.user_id().to_string();
-        target_member_role = target.role().to_string();
-    } else if let Some(email) = &body.email {
+    let target_member = if body.member_id_or_email.contains('@') {
         let target_user = ctx
             .database
-            .get_user_by_email(email)
+            .get_user_by_email(&body.member_id_or_email)
             .await?
-            .ok_or_else(|| AuthError::not_found("User not found"))?;
-        let target = ctx
-            .database
+            .ok_or_else(|| AuthError::bad_request("Member not found"))?;
+        ctx.database
             .get_member(&org_id, &target_user.id())
             .await?
-            .ok_or_else(|| AuthError::not_found("Member not found"))?;
-        target_member_id = target.id().to_string();
-        target_member_org_id = target.organization_id().to_string();
-        target_member_user_id = target.user_id().to_string();
-        target_member_role = target.role().to_string();
+            .ok_or_else(|| AuthError::bad_request("Member not found"))?
     } else {
-        return Err(AuthError::bad_request(
-            "Either memberId or email must be provided",
-        ));
+        let target_member = ctx
+            .database
+            .get_member_by_id(&body.member_id_or_email)
+            .await?
+            .ok_or_else(|| AuthError::bad_request("Member not found"))?;
+        if target_member.organization_id() != org_id {
+            return Err(AuthError::bad_request("Member not found"));
+        }
+        target_member
     };
 
-    if target_member_org_id != org_id {
-        return Err(AuthError::bad_request("Member not in this organization"));
-    }
+    let target_user = ctx
+        .database
+        .get_user_by_id(&target_member.user_id())
+        .await?
+        .ok_or_else(|| AuthError::bad_request("User not found"))?;
 
-    let is_self_removal = target_member_user_id == user.id();
+    let is_self_removal = target_member.user_id() == user.id();
 
     if !is_self_removal
         && !has_permission_any(
@@ -143,30 +181,32 @@ pub(crate) async fn remove_member_core(
         ));
     }
 
-    if target_member_role.contains("owner") {
+    if has_role(&target_member, "owner") {
         let all_members = ctx.database.list_organization_members(&org_id).await?;
         let owner_count = all_members
             .iter()
-            .filter(|m| m.role().contains("owner"))
+            .filter(|candidate| has_role(*candidate, "owner"))
             .count();
 
         if owner_count <= 1 {
             return Err(AuthError::bad_request(
-                "Cannot remove the last owner from an organization",
+                "You cannot leave the organization as the only owner",
             ));
         }
     }
 
     let response = RemovedMemberResponse {
-        member: RemovedMemberInfo {
-            id: target_member_id.clone(),
-            user_id: target_member_user_id,
-            organization_id: target_member_org_id,
-            role: target_member_role,
-        },
+        member: MemberResponse::from_member_and_user(&target_member, &target_user),
     };
 
-    ctx.database.delete_member(&target_member_id).await?;
+    ctx.database.delete_member(&target_member.id()).await?;
+
+    if is_self_removal && session.active_organization_id() == Some(&org_id) {
+        let _ = ctx
+            .database
+            .update_session_active_organization(session.token(), None)
+            .await?;
+    }
 
     Ok(response)
 }
@@ -177,7 +217,7 @@ pub(crate) async fn update_member_role_core(
     session: &impl AuthSession,
     config: &OrganizationConfig,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
-) -> AuthResult<MemberWrappedResponse> {
+) -> AuthResult<BasicMemberResponse> {
     let org_id =
         resolve_organization_id(body.organization_id.as_deref(), None, session, ctx).await?;
 
@@ -185,7 +225,7 @@ pub(crate) async fn update_member_role_core(
         .database
         .get_member(&org_id, &user.id())
         .await?
-        .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
+        .ok_or_else(|| AuthError::bad_request("Member not found"))?;
 
     if !has_permission_any(
         requester_member.role(),
@@ -194,7 +234,7 @@ pub(crate) async fn update_member_role_core(
         &config.roles,
     ) {
         return Err(AuthError::forbidden(
-            "You don't have permission to update member roles",
+            "You are not allowed to update this member",
         ));
     }
 
@@ -202,40 +242,48 @@ pub(crate) async fn update_member_role_core(
         .database
         .get_member_by_id(&body.member_id)
         .await?
-        .ok_or_else(|| AuthError::not_found("Member not found"))?;
+        .ok_or_else(|| AuthError::bad_request("Member not found"))?;
 
     if target_member.organization_id() != org_id {
-        return Err(AuthError::bad_request("Member not in this organization"));
+        return Err(AuthError::forbidden(
+            "You are not allowed to update this member",
+        ));
     }
 
-    if target_member.role().contains("owner") && !body.role.contains("owner") {
+    let requester_is_owner = has_role(&requester_member, &config.creator_role);
+    let target_is_owner = has_role(&target_member, &config.creator_role);
+    let new_role = body.role.joined();
+    let new_role_contains_owner = new_role
+        .split(',')
+        .map(str::trim)
+        .any(|role| role == config.creator_role);
+
+    if (new_role_contains_owner || target_is_owner) && !requester_is_owner {
+        return Err(AuthError::forbidden(
+            "You are not allowed to update this member",
+        ));
+    }
+
+    if target_is_owner && requester_member.id() == target_member.id() && !new_role_contains_owner {
         let all_members = ctx.database.list_organization_members(&org_id).await?;
         let owner_count = all_members
             .iter()
-            .filter(|m| m.role().contains("owner"))
+            .filter(|candidate| has_role(*candidate, &config.creator_role))
             .count();
 
         if owner_count <= 1 {
             return Err(AuthError::bad_request(
-                "Cannot demote the last owner. Transfer ownership first.",
+                "You cannot leave the organization without an owner",
             ));
         }
     }
 
     let updated = ctx
         .database
-        .update_member_role(&body.member_id, &body.role)
+        .update_member_role(&body.member_id, &new_role)
         .await?;
 
-    let user_info = ctx
-        .database
-        .get_user_by_id(&updated.user_id())
-        .await?
-        .ok_or_else(|| AuthError::internal("User not found for updated member"))?;
-
-    Ok(MemberWrappedResponse {
-        member: MemberResponse::from_member_and_user(&updated, &user_info),
-    })
+    Ok(BasicMemberResponse::from_member(&updated))
 }
 
 // ---------------------------------------------------------------------------
@@ -260,6 +308,17 @@ pub async fn handle_list_members(
     let (user, session) = require_session(req, ctx).await?;
     let query = parse_query::<ListMembersQuery>(&req.query);
     let response = list_members_core(&query, &user, &session, ctx).await?;
+    Ok(AuthResponse::json(200, &response)?)
+}
+
+/// Handle get active member role request
+pub async fn handle_get_active_member_role(
+    req: &AuthRequest,
+    ctx: &AuthContext<impl better_auth_core::AuthSchema>,
+) -> AuthResult<AuthResponse> {
+    let (user, session) = require_session(req, ctx).await?;
+    let query = parse_query::<GetActiveMemberRoleQuery>(&req.query);
+    let response = get_active_member_role_core(&query, &user, &session, ctx).await?;
     Ok(AuthResponse::json(200, &response)?)
 }
 

--- a/crates/api/src/plugins/organization/handlers/member.rs
+++ b/crates/api/src/plugins/organization/handlers/member.rs
@@ -2,6 +2,7 @@ use better_auth_core::entity::{AuthMember, AuthOrganization, AuthSession, AuthUs
 use better_auth_core::error::{AuthError, AuthResult};
 use better_auth_core::plugin::AuthContext;
 use better_auth_core::types::{AuthRequest, AuthResponse};
+use std::cmp::Ordering;
 
 use super::{require_session, resolve_organization_id};
 use crate::plugins::organization::OrganizationConfig;
@@ -18,6 +19,67 @@ fn has_role(member: &impl AuthMember, role: &str) -> bool {
         .split(',')
         .map(str::trim)
         .any(|candidate| candidate == role)
+}
+
+fn member_field_value(member: &MemberResponse, field: &str) -> Option<String> {
+    match field {
+        "id" => Some(member.id.clone()),
+        "organizationId" => Some(member.organization_id.clone()),
+        "userId" => Some(member.user_id.clone()),
+        "role" => Some(member.role.clone()),
+        "createdAt" => Some(member.created_at.to_rfc3339()),
+        _ => None,
+    }
+}
+
+fn compare_member_field(left: &MemberResponse, right: &MemberResponse, field: &str) -> Ordering {
+    match field {
+        "createdAt" => left.created_at.cmp(&right.created_at),
+        "role" => left.role.cmp(&right.role),
+        "id" => left.id.cmp(&right.id),
+        "organizationId" => left.organization_id.cmp(&right.organization_id),
+        "userId" => left.user_id.cmp(&right.user_id),
+        _ => Ordering::Equal,
+    }
+}
+
+fn member_matches_filter(member: &MemberResponse, query: &ListMembersQuery) -> bool {
+    let Some(field) = query.filter_field.as_deref() else {
+        return true;
+    };
+    let Some(filter_value) = query.filter_value.as_deref() else {
+        return true;
+    };
+    let operator = query.filter_operator.as_deref().unwrap_or("eq");
+    let Some(actual_value) = member_field_value(member, field) else {
+        return true;
+    };
+
+    match operator {
+        "eq" => actual_value == filter_value,
+        "ne" => actual_value != filter_value,
+        "contains" => actual_value.contains(filter_value),
+        "gt" | "gte" | "lt" | "lte" if field == "createdAt" => {
+            let Ok(actual) = chrono::DateTime::parse_from_rfc3339(&actual_value) else {
+                return false;
+            };
+            let Ok(expected) = chrono::DateTime::parse_from_rfc3339(filter_value) else {
+                return false;
+            };
+            match operator {
+                "gt" => actual > expected,
+                "gte" => actual >= expected,
+                "lt" => actual < expected,
+                "lte" => actual <= expected,
+                _ => false,
+            }
+        }
+        "gt" => actual_value.as_str() > filter_value,
+        "gte" => actual_value.as_str() >= filter_value,
+        "lt" => actual_value.as_str() < filter_value,
+        "lte" => actual_value.as_str() <= filter_value,
+        _ => true,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -37,7 +99,7 @@ pub(crate) async fn get_active_member_core(
         .database
         .get_member(org_id, &user.id())
         .await?
-        .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
+        .ok_or_else(|| AuthError::bad_request("Member not found"))?;
 
     Ok(MemberResponse::from_member_and_user(&member, user))
 }
@@ -66,19 +128,27 @@ pub(crate) async fn list_members_core(
         .ok_or_else(|| AuthError::forbidden("You are not a member of this organization"))?;
 
     let members_raw = ctx.database.list_organization_members(&org_id).await?;
-    let total = members_raw.len();
-
-    let offset = query.offset.unwrap_or(0);
-    let limit = query.limit.unwrap_or(50).min(100);
-
-    let members_page: Vec<_> = members_raw.into_iter().skip(offset).take(limit).collect();
-
-    let mut members = Vec::with_capacity(members_page.len());
-    for member in &members_page {
+    let mut members = Vec::with_capacity(members_raw.len());
+    for member in &members_raw {
         if let Some(user_info) = ctx.database.get_user_by_id(&member.user_id()).await? {
             members.push(MemberResponse::from_member_and_user(member, &user_info));
         }
     }
+
+    members.retain(|member| member_matches_filter(member, query));
+
+    if let Some(sort_by) = query.sort_by.as_deref() {
+        members.sort_by(|left, right| compare_member_field(left, right, sort_by));
+        if matches!(query.sort_direction.as_deref(), Some("desc")) {
+            members.reverse();
+        }
+    }
+
+    let total = members.len();
+
+    let offset = query.offset.unwrap_or(0);
+    let limit = query.limit.unwrap_or(50).min(100);
+    let members = members.into_iter().skip(offset).take(limit).collect();
 
     Ok(ListMembersResponse { members, total })
 }

--- a/crates/api/src/plugins/organization/handlers/member.rs
+++ b/crates/api/src/plugins/organization/handlers/member.rs
@@ -127,29 +127,41 @@ pub(crate) async fn list_members_core(
         .await?
         .ok_or_else(|| AuthError::forbidden("You are not a member of this organization"))?;
 
+    let needs_full_materialization = query.sort_by.is_some() || query.filter_field.is_some();
     let members_raw = ctx.database.list_organization_members(&org_id).await?;
-    let mut members = Vec::with_capacity(members_raw.len());
-    for member in &members_raw {
+    let members_page: Vec<_> = if needs_full_materialization {
+        members_raw
+    } else {
+        let offset = query.offset.unwrap_or(0);
+        let limit = query.limit.unwrap_or(50).min(100);
+        members_raw.into_iter().skip(offset).take(limit).collect()
+    };
+
+    let mut members = Vec::with_capacity(members_page.len());
+    for member in &members_page {
         if let Some(user_info) = ctx.database.get_user_by_id(&member.user_id()).await? {
             members.push(MemberResponse::from_member_and_user(member, &user_info));
         }
     }
 
-    members.retain(|member| member_matches_filter(member, query));
+    if needs_full_materialization {
+        members.retain(|member| member_matches_filter(member, query));
 
-    if let Some(sort_by) = query.sort_by.as_deref() {
-        members.sort_by(|left, right| compare_member_field(left, right, sort_by));
-        if matches!(query.sort_direction.as_deref(), Some("desc")) {
-            members.reverse();
+        if let Some(sort_by) = query.sort_by.as_deref() {
+            members.sort_by(|left, right| compare_member_field(left, right, sort_by));
+            if matches!(query.sort_direction.as_deref(), Some("desc")) {
+                members.reverse();
+            }
         }
+
+        let total = members.len();
+        let offset = query.offset.unwrap_or(0);
+        let limit = query.limit.unwrap_or(50).min(100);
+        let members = members.into_iter().skip(offset).take(limit).collect();
+        return Ok(ListMembersResponse { members, total });
     }
 
-    let total = members.len();
-
-    let offset = query.offset.unwrap_or(0);
-    let limit = query.limit.unwrap_or(50).min(100);
-    let members = members.into_iter().skip(offset).take(limit).collect();
-
+    let total = ctx.database.count_organization_members(&org_id).await? as usize;
     Ok(ListMembersResponse { members, total })
 }
 
@@ -251,11 +263,11 @@ pub(crate) async fn remove_member_core(
         ));
     }
 
-    if has_role(&target_member, "owner") {
+    if has_role(&target_member, &config.creator_role) {
         let all_members = ctx.database.list_organization_members(&org_id).await?;
         let owner_count = all_members
             .iter()
-            .filter(|candidate| has_role(*candidate, "owner"))
+            .filter(|candidate| has_role(*candidate, &config.creator_role))
             .count();
 
         if owner_count <= 1 {

--- a/crates/api/src/plugins/organization/handlers/mod.rs
+++ b/crates/api/src/plugins/organization/handlers/mod.rs
@@ -101,11 +101,7 @@ pub(crate) async fn has_permission_core(
 
     Ok(HasPermissionResponse {
         success: has_all_permissions,
-        error: if has_all_permissions {
-            None
-        } else {
-            Some("Permission denied".to_string())
-        },
+        error: None,
     })
 }
 

--- a/crates/api/src/plugins/organization/handlers/org.rs
+++ b/crates/api/src/plugins/organization/handlers/org.rs
@@ -2,10 +2,10 @@ use super::{require_session, resolve_organization_id};
 use crate::plugins::organization::OrganizationConfig;
 use crate::plugins::organization::rbac::{Action, Resource, has_permission_any};
 use crate::plugins::organization::types::{
-    CheckSlugRequest, CheckSlugResponse, CreateOrganizationRequest, CreateOrganizationResponse,
-    DeleteOrganizationRequest, FullOrganizationResponse, GetFullOrganizationQuery,
-    LeaveOrganizationRequest, MemberResponse, SetActiveOrganizationRequest, SuccessResponse,
-    UpdateOrganizationRequest,
+    BasicMemberResponse, CheckSlugRequest, CheckSlugResponse, CreateOrganizationRequest,
+    CreateOrganizationResponse, CreatedOrganizationResponse, DeleteOrganizationRequest,
+    FullOrganizationResponse, GetFullOrganizationQuery, LeaveOrganizationRequest, MemberResponse,
+    OrganizationResponse, SetActiveOrganizationRequest, UpdateOrganizationRequest,
 };
 use better_auth_core::entity::{AuthMember, AuthOrganization, AuthSession, AuthUser};
 use better_auth_core::error::{AuthError, AuthResult};
@@ -13,7 +13,16 @@ use better_auth_core::plugin::AuthContext;
 use better_auth_core::types::{
     AuthRequest, AuthResponse, CreateMember, CreateOrganization, UpdateOrganization,
 };
-use better_auth_core::wire::{InvitationView, OrganizationView, SessionView};
+use better_auth_core::utils::cookie_utils::create_session_cookie;
+use better_auth_core::wire::InvitationView;
+
+fn has_role(member: &impl AuthMember, role: &str) -> bool {
+    member
+        .role()
+        .split(',')
+        .map(str::trim)
+        .any(|candidate| candidate == role)
+}
 
 // ---------------------------------------------------------------------------
 // Core functions
@@ -24,7 +33,7 @@ pub(crate) async fn create_organization_core(
     user: &impl AuthUser,
     config: &OrganizationConfig,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
-) -> AuthResult<CreateOrganizationResponse<OrganizationView, MemberResponse>> {
+) -> AuthResult<CreateOrganizationResponse<CreatedOrganizationResponse, BasicMemberResponse>> {
     if !config.allow_user_to_create_organization {
         return Err(AuthError::forbidden("Organization creation is not allowed"));
     }
@@ -45,7 +54,7 @@ pub(crate) async fn create_organization_core(
         .await?
         .is_some()
     {
-        return Err(AuthError::bad_request("Slug is already taken"));
+        return Err(AuthError::bad_request("Organization already exists"));
     }
 
     let org_data = CreateOrganization {
@@ -65,10 +74,10 @@ pub(crate) async fn create_organization_core(
     };
 
     let member = ctx.database.create_member(member_data).await?;
-    let member_response = MemberResponse::from_member_and_user(&member, user);
+    let member_response = BasicMemberResponse::from_member(&member);
 
     Ok(CreateOrganizationResponse {
-        organization: OrganizationView::from(&organization),
+        organization: CreatedOrganizationResponse::from_organization(&organization),
         members: vec![member_response],
     })
 }
@@ -79,7 +88,7 @@ pub(crate) async fn update_organization_core(
     session: &impl AuthSession,
     config: &OrganizationConfig,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
-) -> AuthResult<OrganizationView> {
+) -> AuthResult<OrganizationResponse> {
     let org_id =
         resolve_organization_id(body.organization_id.as_deref(), None, session, ctx).await?;
 
@@ -100,18 +109,18 @@ pub(crate) async fn update_organization_core(
         ));
     }
 
-    if let Some(ref new_slug) = body.slug
+    if let Some(ref new_slug) = body.data.slug
         && let Some(existing) = ctx.database.get_organization_by_slug(new_slug).await?
         && existing.id() != org_id
     {
-        return Err(AuthError::bad_request("Slug is already taken"));
+        return Err(AuthError::bad_request("Organization slug already taken"));
     }
 
     let update_data = UpdateOrganization {
-        name: body.name.clone(),
-        slug: body.slug.clone(),
-        logo: body.logo.clone(),
-        metadata: body.metadata.clone(),
+        name: body.data.name.clone(),
+        slug: body.data.slug.clone(),
+        logo: body.data.logo.clone(),
+        metadata: body.data.metadata.clone(),
     };
 
     let updated = ctx
@@ -119,7 +128,7 @@ pub(crate) async fn update_organization_core(
         .update_organization(&org_id, update_data)
         .await?;
 
-    Ok(OrganizationView::from(&updated))
+    Ok(OrganizationResponse::from_organization(&updated))
 }
 
 pub(crate) async fn delete_organization_core(
@@ -127,7 +136,7 @@ pub(crate) async fn delete_organization_core(
     user: &impl AuthUser,
     config: &OrganizationConfig,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
-) -> AuthResult<SuccessResponse> {
+) -> AuthResult<OrganizationResponse> {
     if config.disable_organization_deletion {
         return Err(AuthError::forbidden("Organization deletion is disabled"));
     }
@@ -136,7 +145,7 @@ pub(crate) async fn delete_organization_core(
         .database
         .get_member(&body.organization_id, &user.id())
         .await?
-        .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
+        .ok_or_else(|| AuthError::bad_request("User is not a member of the organization"))?;
 
     if !has_permission_any(
         member.role(),
@@ -149,19 +158,28 @@ pub(crate) async fn delete_organization_core(
         ));
     }
 
+    let organization = ctx
+        .database
+        .get_organization_by_id(&body.organization_id)
+        .await?
+        .ok_or_else(|| AuthError::bad_request("Organization not found"))?;
+
     ctx.database
         .delete_organization(&body.organization_id)
         .await?;
 
-    Ok(SuccessResponse { success: true })
+    Ok(OrganizationResponse::from_organization(&organization))
 }
 
 pub(crate) async fn list_organizations_core(
     user: &impl AuthUser,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
-) -> AuthResult<Vec<OrganizationView>> {
+) -> AuthResult<Vec<OrganizationResponse>> {
     let organizations = ctx.database.list_user_organizations(&user.id()).await?;
-    Ok(organizations.iter().map(OrganizationView::from).collect())
+    Ok(organizations
+        .iter()
+        .map(OrganizationResponse::from_organization)
+        .collect())
 }
 
 pub(crate) async fn get_full_organization_core(
@@ -169,26 +187,33 @@ pub(crate) async fn get_full_organization_core(
     user: &impl AuthUser,
     session: &impl AuthSession,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
-) -> AuthResult<FullOrganizationResponse<OrganizationView, InvitationView>> {
-    let org_id = resolve_organization_id(
-        query.organization_id.as_deref(),
-        query.organization_slug.as_deref(),
-        session,
-        ctx,
-    )
-    .await?;
+) -> AuthResult<Option<FullOrganizationResponse<OrganizationResponse, InvitationView>>> {
+    let org_id = if let Some(slug) = query.organization_slug.as_deref() {
+        let organization = ctx
+            .database
+            .get_organization_by_slug(slug)
+            .await?
+            .ok_or_else(|| AuthError::bad_request("Organization not found"))?;
+        organization.id().to_string()
+    } else if let Some(id) = query.organization_id.as_deref() {
+        id.to_string()
+    } else if let Some(active_org_id) = session.active_organization_id() {
+        active_org_id.to_string()
+    } else {
+        return Ok(None);
+    };
 
     let _ = ctx
         .database
         .get_member(&org_id, &user.id())
         .await?
-        .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
+        .ok_or_else(|| AuthError::forbidden("User is not a member of the organization"))?;
 
     let organization = ctx
         .database
         .get_organization_by_id(&org_id)
         .await?
-        .ok_or_else(|| AuthError::not_found("Organization not found"))?;
+        .ok_or_else(|| AuthError::bad_request("Organization not found"))?;
 
     let members_raw = ctx.database.list_organization_members(&org_id).await?;
     let mut members = Vec::with_capacity(members_raw.len());
@@ -201,24 +226,27 @@ pub(crate) async fn get_full_organization_core(
 
     let invitations = ctx.database.list_organization_invitations(&org_id).await?;
 
-    Ok(FullOrganizationResponse {
-        organization: OrganizationView::from(&organization),
+    Ok(Some(FullOrganizationResponse {
+        organization: OrganizationResponse::from_organization(&organization),
         members,
         invitations: invitations.iter().map(InvitationView::from).collect(),
-    })
+    }))
 }
 
 pub(crate) async fn check_slug_core(
     body: &CheckSlugRequest,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
 ) -> AuthResult<CheckSlugResponse> {
-    let exists = ctx
+    if ctx
         .database
         .get_organization_by_slug(&body.slug)
         .await?
-        .is_some();
+        .is_some()
+    {
+        return Err(AuthError::bad_request("slug is taken"));
+    }
 
-    Ok(CheckSlugResponse { status: !exists })
+    Ok(CheckSlugResponse { status: true })
 }
 
 pub(crate) async fn set_active_organization_core(
@@ -226,35 +254,52 @@ pub(crate) async fn set_active_organization_core(
     user: &impl AuthUser,
     session: &impl AuthSession,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
-) -> AuthResult<SessionView> {
-    let org_id = if body.organization_id.is_some() || body.organization_slug.is_some() {
-        Some(
-            resolve_organization_id(
-                body.organization_id.as_deref(),
-                body.organization_slug.as_deref(),
-                session,
-                ctx,
-            )
-            .await?,
-        )
-    } else {
-        None
-    };
+) -> AuthResult<Option<OrganizationResponse>> {
+    if matches!(body.organization_id, Some(None)) {
+        if session.active_organization_id().is_none() {
+            return Ok(None);
+        }
 
-    if let Some(ref oid) = org_id {
         let _ = ctx
             .database
-            .get_member(oid, &user.id())
-            .await?
-            .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
+            .update_session_active_organization(session.token(), None)
+            .await?;
+        return Ok(None);
     }
 
-    let updated_session = ctx
+    let org_id = if let Some(Some(id)) = &body.organization_id {
+        id.clone()
+    } else if let Some(slug) = body.organization_slug.as_deref() {
+        let organization = ctx
+            .database
+            .get_organization_by_slug(slug)
+            .await?
+            .ok_or_else(|| AuthError::bad_request("Organization not found"))?;
+        organization.id().to_string()
+    } else if let Some(active_org_id) = session.active_organization_id() {
+        active_org_id.to_string()
+    } else {
+        return Ok(None);
+    };
+
+    let _ = ctx
         .database
-        .update_session_active_organization(session.token(), org_id.as_deref())
+        .get_member(&org_id, &user.id())
+        .await?
+        .ok_or_else(|| AuthError::forbidden("User is not a member of the organization"))?;
+
+    let _ = ctx
+        .database
+        .update_session_active_organization(session.token(), Some(&org_id))
         .await?;
 
-    Ok(SessionView::from(&updated_session))
+    let organization = ctx
+        .database
+        .get_organization_by_id(&org_id)
+        .await?
+        .ok_or_else(|| AuthError::bad_request("Organization not found"))?;
+
+    Ok(Some(OrganizationResponse::from_organization(&organization)))
 }
 
 pub(crate) async fn leave_organization_core(
@@ -262,30 +307,31 @@ pub(crate) async fn leave_organization_core(
     user: &impl AuthUser,
     session: &impl AuthSession,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
-) -> AuthResult<SuccessResponse> {
+) -> AuthResult<MemberResponse> {
     let member = ctx
         .database
         .get_member(&body.organization_id, &user.id())
         .await?
-        .ok_or_else(|| AuthError::forbidden("Not a member of this organization"))?;
+        .ok_or_else(|| AuthError::bad_request("Member not found"))?;
 
-    if member.role().contains("owner") {
+    if has_role(&member, "owner") {
         let all_members = ctx
             .database
             .list_organization_members(&body.organization_id)
             .await?;
         let owner_count = all_members
             .iter()
-            .filter(|m| m.role().contains("owner"))
+            .filter(|candidate| has_role(*candidate, "owner"))
             .count();
 
         if owner_count <= 1 {
             return Err(AuthError::bad_request(
-                "Cannot leave organization as the last owner. Delete the organization or transfer ownership first.",
+                "You cannot leave the organization as the only owner",
             ));
         }
     }
 
+    let response = MemberResponse::from_member_and_user(&member, user);
     ctx.database.delete_member(&member.id()).await?;
 
     if session.active_organization_id() == Some(&body.organization_id) {
@@ -295,7 +341,7 @@ pub(crate) async fn leave_organization_core(
             .await?;
     }
 
-    Ok(SuccessResponse { success: true })
+    Ok(response)
 }
 
 // ---------------------------------------------------------------------------
@@ -308,12 +354,19 @@ pub async fn handle_create_organization(
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
     config: &OrganizationConfig,
 ) -> AuthResult<AuthResponse> {
-    let (user, _session) = require_session(req, ctx).await?;
+    let (user, session) = require_session(req, ctx).await?;
     let body: CreateOrganizationRequest = match better_auth_core::validate_request_body(req) {
         Ok(v) => v,
         Err(resp) => return Ok(resp),
     };
     let response = create_organization_core(&body, &user, config, ctx).await?;
+    let _ = ctx
+        .database
+        .update_session_active_organization(
+            session.token(),
+            Some(response.organization.id.as_str()),
+        )
+        .await?;
     Ok(AuthResponse::json(200, &response)?)
 }
 
@@ -338,12 +391,18 @@ pub async fn handle_delete_organization(
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
     config: &OrganizationConfig,
 ) -> AuthResult<AuthResponse> {
-    let (user, _session) = require_session(req, ctx).await?;
+    let (user, session) = require_session(req, ctx).await?;
     let body: DeleteOrganizationRequest = match better_auth_core::validate_request_body(req) {
         Ok(v) => v,
         Err(resp) => return Ok(resp),
     };
     let response = delete_organization_core(&body, &user, config, ctx).await?;
+    if session.active_organization_id() == Some(&body.organization_id) {
+        let _ = ctx
+            .database
+            .update_session_active_organization(session.token(), None)
+            .await?;
+    }
     Ok(AuthResponse::json(200, &response)?)
 }
 
@@ -373,7 +432,7 @@ pub async fn handle_check_slug(
     req: &AuthRequest,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
 ) -> AuthResult<AuthResponse> {
-    let _session = require_session(req, ctx).await?;
+    let _ = require_session(req, ctx).await?;
     let body: CheckSlugRequest = match better_auth_core::validate_request_body(req) {
         Ok(v) => v,
         Err(resp) => return Ok(resp),
@@ -388,12 +447,31 @@ pub async fn handle_set_active_organization(
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
 ) -> AuthResult<AuthResponse> {
     let (user, session) = require_session(req, ctx).await?;
+    let clear_active_requested = req
+        .body
+        .as_ref()
+        .and_then(|body| std::str::from_utf8(body).ok())
+        .map(|body| body.contains("\"organizationId\":null"))
+        .unwrap_or(false);
     let body: SetActiveOrganizationRequest = match better_auth_core::validate_request_body(req) {
         Ok(v) => v,
         Err(resp) => return Ok(resp),
     };
-    let updated_session = set_active_organization_core(&body, &user, &session, ctx).await?;
-    Ok(AuthResponse::json(200, &updated_session)?)
+    if clear_active_requested {
+        let _ = ctx
+            .database
+            .update_session_active_organization(session.token(), None)
+            .await?;
+        let cookie_header = create_session_cookie(session.token(), &ctx.config);
+        return Ok(
+            AuthResponse::json(200, &Option::<OrganizationResponse>::None)?
+                .with_header("Set-Cookie", cookie_header),
+        );
+    }
+
+    let organization = set_active_organization_core(&body, &user, &session, ctx).await?;
+    let cookie_header = create_session_cookie(session.token(), &ctx.config);
+    Ok(AuthResponse::json(200, &organization)?.with_header("Set-Cookie", cookie_header))
 }
 
 /// Handle leave organization request

--- a/crates/api/src/plugins/organization/handlers/org.rs
+++ b/crates/api/src/plugins/organization/handlers/org.rs
@@ -5,7 +5,8 @@ use crate::plugins::organization::types::{
     BasicMemberResponse, CheckSlugRequest, CheckSlugResponse, CreateOrganizationRequest,
     CreateOrganizationResponse, CreatedOrganizationResponse, DeleteOrganizationRequest,
     FullOrganizationResponse, GetFullOrganizationQuery, LeaveOrganizationRequest, MemberResponse,
-    OrganizationResponse, SetActiveOrganizationRequest, UpdateOrganizationRequest,
+    NullableStringField, OrganizationResponse, SetActiveOrganizationRequest,
+    UpdateOrganizationRequest,
 };
 use better_auth_core::entity::{AuthMember, AuthOrganization, AuthSession, AuthUser};
 use better_auth_core::error::{AuthError, AuthResult};
@@ -255,7 +256,7 @@ pub(crate) async fn set_active_organization_core(
     session: &impl AuthSession,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
 ) -> AuthResult<Option<OrganizationResponse>> {
-    if matches!(body.organization_id, Some(None)) {
+    if matches!(body.organization_id, NullableStringField::Null) {
         if session.active_organization_id().is_none() {
             return Ok(None);
         }
@@ -267,7 +268,7 @@ pub(crate) async fn set_active_organization_core(
         return Ok(None);
     }
 
-    let org_id = if let Some(Some(id)) = &body.organization_id {
+    let org_id = if let NullableStringField::Value(id) = &body.organization_id {
         id.clone()
     } else if let Some(slug) = body.organization_slug.as_deref() {
         let organization = ctx
@@ -447,17 +448,11 @@ pub async fn handle_set_active_organization(
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
 ) -> AuthResult<AuthResponse> {
     let (user, session) = require_session(req, ctx).await?;
-    let clear_active_requested = req
-        .body
-        .as_ref()
-        .and_then(|body| std::str::from_utf8(body).ok())
-        .map(|body| body.contains("\"organizationId\":null"))
-        .unwrap_or(false);
     let body: SetActiveOrganizationRequest = match better_auth_core::validate_request_body(req) {
         Ok(v) => v,
         Err(resp) => return Ok(resp),
     };
-    if clear_active_requested {
+    if matches!(body.organization_id, NullableStringField::Null) {
         let _ = ctx
             .database
             .update_session_active_organization(session.token(), None)

--- a/crates/api/src/plugins/organization/handlers/org.rs
+++ b/crates/api/src/plugins/organization/handlers/org.rs
@@ -307,6 +307,7 @@ pub(crate) async fn leave_organization_core(
     body: &LeaveOrganizationRequest,
     user: &impl AuthUser,
     session: &impl AuthSession,
+    config: &OrganizationConfig,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
 ) -> AuthResult<MemberResponse> {
     let member = ctx
@@ -315,14 +316,14 @@ pub(crate) async fn leave_organization_core(
         .await?
         .ok_or_else(|| AuthError::bad_request("Member not found"))?;
 
-    if has_role(&member, "owner") {
+    if has_role(&member, &config.creator_role) {
         let all_members = ctx
             .database
             .list_organization_members(&body.organization_id)
             .await?;
         let owner_count = all_members
             .iter()
-            .filter(|candidate| has_role(*candidate, "owner"))
+            .filter(|candidate| has_role(*candidate, &config.creator_role))
             .count();
 
         if owner_count <= 1 {
@@ -452,18 +453,6 @@ pub async fn handle_set_active_organization(
         Ok(v) => v,
         Err(resp) => return Ok(resp),
     };
-    if matches!(body.organization_id, NullableStringField::Null) {
-        let _ = ctx
-            .database
-            .update_session_active_organization(session.token(), None)
-            .await?;
-        let cookie_header = create_session_cookie(session.token(), &ctx.config);
-        return Ok(
-            AuthResponse::json(200, &Option::<OrganizationResponse>::None)?
-                .with_header("Set-Cookie", cookie_header),
-        );
-    }
-
     let organization = set_active_organization_core(&body, &user, &session, ctx).await?;
     let cookie_header = create_session_cookie(session.token(), &ctx.config);
     Ok(AuthResponse::json(200, &organization)?.with_header("Set-Cookie", cookie_header))
@@ -473,13 +462,14 @@ pub async fn handle_set_active_organization(
 pub async fn handle_leave_organization(
     req: &AuthRequest,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
+    config: &OrganizationConfig,
 ) -> AuthResult<AuthResponse> {
     let (user, session) = require_session(req, ctx).await?;
     let body: LeaveOrganizationRequest = match better_auth_core::validate_request_body(req) {
         Ok(v) => v,
         Err(resp) => return Ok(resp),
     };
-    let response = leave_organization_core(&body, &user, &session, ctx).await?;
+    let response = leave_organization_core(&body, &user, &session, config, ctx).await?;
     Ok(AuthResponse::json(200, &response)?)
 }
 

--- a/crates/api/src/plugins/organization/mod.rs
+++ b/crates/api/src/plugins/organization/mod.rs
@@ -74,6 +74,10 @@ impl<S: better_auth_core::AuthSchema> AuthPlugin<S> for OrganizationPlugin {
             AuthRoute::post("/organization/leave", "leave_organization"),
             // Member management
             AuthRoute::get("/organization/get-active-member", "get_active_member"),
+            AuthRoute::get(
+                "/organization/get-active-member-role",
+                "get_active_member_role",
+            ),
             AuthRoute::get("/organization/list-members", "list_members"),
             AuthRoute::post("/organization/remove-member", "remove_member"),
             AuthRoute::post("/organization/update-member-role", "update_member_role"),
@@ -127,6 +131,9 @@ impl<S: better_auth_core::AuthSchema> AuthPlugin<S> for OrganizationPlugin {
             // Member management
             (HttpMethod::Get, "/organization/get-active-member") => Ok(Some(
                 handlers::member::handle_get_active_member(req, ctx).await?,
+            )),
+            (HttpMethod::Get, "/organization/get-active-member-role") => Ok(Some(
+                handlers::member::handle_get_active_member_role(req, ctx).await?,
             )),
             (HttpMethod::Get, "/organization/list-members") => {
                 Ok(Some(handlers::member::handle_list_members(req, ctx).await?))

--- a/crates/api/src/plugins/organization/mod.rs
+++ b/crates/api/src/plugins/organization/mod.rs
@@ -126,7 +126,7 @@ impl<S: better_auth_core::AuthSchema> AuthPlugin<S> for OrganizationPlugin {
                 handlers::org::handle_set_active_organization(req, ctx).await?,
             )),
             (HttpMethod::Post, "/organization/leave") => Ok(Some(
-                handlers::org::handle_leave_organization(req, ctx).await?,
+                handlers::org::handle_leave_organization(req, ctx, &self.config).await?,
             )),
             // Member management
             (HttpMethod::Get, "/organization/get-active-member") => Ok(Some(

--- a/crates/api/src/plugins/organization/types.rs
+++ b/crates/api/src/plugins/organization/types.rs
@@ -1,7 +1,64 @@
 use better_auth_core::entity::MemberUserView;
+use better_auth_core::entity::{AuthMember, AuthOrganization};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use validator::Validate;
+
+fn deserialize_optional_usize_from_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<usize>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Value {
+        Number(usize),
+        String(String),
+    }
+
+    let value = Option::<Value>::deserialize(deserializer)?;
+    match value {
+        None => Ok(None),
+        Some(Value::Number(number)) => Ok(Some(number)),
+        Some(Value::String(string)) => string
+            .parse::<usize>()
+            .map(Some)
+            .map_err(serde::de::Error::custom),
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum RoleInput {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl RoleInput {
+    pub fn joined(&self) -> String {
+        match self {
+            Self::One(role) => role.clone(),
+            Self::Many(roles) => roles.join(","),
+        }
+    }
+
+    pub fn roles(&self) -> Vec<&str> {
+        match self {
+            Self::One(role) => role
+                .split(',')
+                .map(str::trim)
+                .filter(|role| !role.is_empty())
+                .collect(),
+            Self::Many(roles) => roles
+                .iter()
+                .flat_map(|role| role.split(','))
+                .map(str::trim)
+                .filter(|role| !role.is_empty())
+                .collect(),
+        }
+    }
+}
 
 #[derive(Debug, Deserialize, Validate)]
 pub struct CreateOrganizationRequest {
@@ -14,13 +71,18 @@ pub struct CreateOrganizationRequest {
 }
 
 #[derive(Debug, Deserialize, Validate)]
-pub struct UpdateOrganizationRequest {
+pub struct UpdateOrganizationData {
     pub name: Option<String>,
     pub slug: Option<String>,
     pub logo: Option<String>,
     pub metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub struct UpdateOrganizationRequest {
     #[serde(rename = "organizationId")]
     pub organization_id: Option<String>,
+    pub data: UpdateOrganizationData,
 }
 
 #[derive(Debug, Deserialize, Validate)]
@@ -37,7 +99,7 @@ pub struct CheckSlugRequest {
 #[derive(Debug, Deserialize, Validate)]
 pub struct SetActiveOrganizationRequest {
     #[serde(rename = "organizationId")]
-    pub organization_id: Option<String>,
+    pub organization_id: Option<Option<String>>,
     #[serde(rename = "organizationSlug")]
     pub organization_slug: Option<String>,
 }
@@ -60,17 +122,15 @@ pub struct GetFullOrganizationQuery {
 pub struct InviteMemberRequest {
     #[validate(email(message = "Invalid email address"))]
     pub email: String,
-    #[validate(length(min = 1, message = "Role is required"))]
-    pub role: String,
+    pub role: RoleInput,
     #[serde(rename = "organizationId")]
     pub organization_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Validate)]
 pub struct RemoveMemberRequest {
-    #[serde(rename = "memberId")]
-    pub member_id: Option<String>,
-    pub email: Option<String>,
+    #[serde(rename = "memberIdOrEmail")]
+    pub member_id_or_email: String,
     #[serde(rename = "organizationId")]
     pub organization_id: Option<String>,
 }
@@ -79,7 +139,7 @@ pub struct RemoveMemberRequest {
 pub struct UpdateMemberRoleRequest {
     #[serde(rename = "memberId")]
     pub member_id: String,
-    pub role: String,
+    pub role: RoleInput,
     #[serde(rename = "organizationId")]
     pub organization_id: Option<String>,
 }
@@ -90,7 +150,9 @@ pub struct ListMembersQuery {
     pub organization_id: Option<String>,
     #[serde(rename = "organizationSlug")]
     pub organization_slug: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_usize_from_string")]
     pub limit: Option<usize>,
+    #[serde(default, deserialize_with = "deserialize_optional_usize_from_string")]
     pub offset: Option<usize>,
 }
 
@@ -115,6 +177,16 @@ pub struct CancelInvitationRequest {
 #[derive(Debug, Default, Deserialize)]
 pub struct GetInvitationQuery {
     pub id: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct GetActiveMemberRoleQuery {
+    #[serde(rename = "userId")]
+    pub user_id: Option<String>,
+    #[serde(rename = "organizationId")]
+    pub organization_id: Option<String>,
+    #[serde(rename = "organizationSlug")]
+    pub organization_slug: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -143,7 +215,6 @@ pub struct SuccessResponse {
 #[derive(Debug, Serialize)]
 pub struct HasPermissionResponse {
     pub success: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 
@@ -168,37 +239,37 @@ pub struct InvitationResponse<I: Serialize> {
 }
 
 #[derive(Debug, Serialize)]
-pub struct MemberWrappedResponse {
+pub struct RemovedMemberResponse {
     pub member: MemberResponse,
 }
 
-/// Minimal member info returned when a member is removed.
-/// Does not include `user` or `createdAt` since the member no longer exists.
 #[derive(Debug, Serialize)]
-pub struct RemovedMemberResponse {
-    pub member: RemovedMemberInfo,
-}
-
-#[derive(Debug, Serialize)]
-pub struct RemovedMemberInfo {
+pub struct BasicMemberResponse {
     pub id: String,
     #[serde(rename = "userId")]
     pub user_id: String,
     #[serde(rename = "organizationId")]
     pub organization_id: String,
     pub role: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
 #[derive(Debug, Serialize)]
-pub struct AcceptInvitationResponse<I: Serialize> {
+pub struct AcceptInvitationResponse<I: Serialize, M: Serialize> {
     pub invitation: I,
-    pub member: MemberResponse,
+    pub member: M,
 }
 
 #[derive(Debug, Serialize)]
 pub struct ListMembersResponse {
     pub members: Vec<MemberResponse>,
     pub total: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GetActiveMemberRoleResponse {
+    pub role: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -211,6 +282,72 @@ pub struct GetInvitationResponse<I: Serialize> {
     pub organization_slug: String,
     #[serde(rename = "inviterEmail")]
     pub inviter_email: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UserInvitationResponse<I: Serialize> {
+    #[serde(flatten)]
+    pub invitation: I,
+    #[serde(rename = "organizationName")]
+    pub organization_name: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CreatedOrganizationResponse {
+    pub id: String,
+    pub name: String,
+    pub slug: String,
+    pub logo: Option<String>,
+    #[serde(rename = "createdAt")]
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OrganizationResponse {
+    pub id: String,
+    pub name: String,
+    pub slug: String,
+    pub logo: Option<String>,
+    #[serde(rename = "createdAt")]
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub metadata: Option<serde_json::Value>,
+}
+
+fn normalize_metadata(metadata: Option<&serde_json::Value>) -> Option<serde_json::Value> {
+    match metadata {
+        None => None,
+        Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::Object(map)) if map.is_empty() => None,
+        Some(value) => Some(value.clone()),
+    }
+}
+
+impl CreatedOrganizationResponse {
+    pub fn from_organization(organization: &impl AuthOrganization) -> Self {
+        Self {
+            id: organization.id().to_string(),
+            name: organization.name().to_string(),
+            slug: organization.slug().to_string(),
+            logo: organization.logo().map(str::to_owned),
+            created_at: organization.created_at(),
+            metadata: normalize_metadata(organization.metadata()),
+        }
+    }
+}
+
+impl OrganizationResponse {
+    pub fn from_organization(organization: &impl AuthOrganization) -> Self {
+        Self {
+            id: organization.id().to_string(),
+            name: organization.name().to_string(),
+            slug: organization.slug().to_string(),
+            logo: organization.logo().map(str::to_owned),
+            created_at: organization.created_at(),
+            metadata: normalize_metadata(organization.metadata()),
+        }
+    }
 }
 
 /// Member with user details (for API responses).
@@ -243,6 +380,18 @@ impl MemberResponse {
             role: member.role().to_string(),
             created_at: member.created_at(),
             user: MemberUserView::from_user(user),
+        }
+    }
+}
+
+impl BasicMemberResponse {
+    pub fn from_member(member: &impl AuthMember) -> Self {
+        Self {
+            id: member.id().to_string(),
+            organization_id: member.organization_id().to_string(),
+            user_id: member.user_id().to_string(),
+            role: member.role().to_string(),
+            created_at: member.created_at(),
         }
     }
 }

--- a/crates/api/src/plugins/organization/types.rs
+++ b/crates/api/src/plugins/organization/types.rs
@@ -28,6 +28,27 @@ where
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum NullableStringField {
+    #[default]
+    Missing,
+    Null,
+    Value(String),
+}
+
+fn deserialize_nullable_string_field<'de, D>(
+    deserializer: D,
+) -> Result<NullableStringField, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<String>::deserialize(deserializer)?;
+    Ok(match value {
+        Some(value) => NullableStringField::Value(value),
+        None => NullableStringField::Null,
+    })
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
 pub enum RoleInput {
@@ -98,8 +119,12 @@ pub struct CheckSlugRequest {
 
 #[derive(Debug, Deserialize, Validate)]
 pub struct SetActiveOrganizationRequest {
-    #[serde(rename = "organizationId")]
-    pub organization_id: Option<Option<String>>,
+    #[serde(
+        default,
+        rename = "organizationId",
+        deserialize_with = "deserialize_nullable_string_field"
+    )]
+    pub organization_id: NullableStringField,
     #[serde(rename = "organizationSlug")]
     pub organization_slug: Option<String>,
 }
@@ -154,6 +179,16 @@ pub struct ListMembersQuery {
     pub limit: Option<usize>,
     #[serde(default, deserialize_with = "deserialize_optional_usize_from_string")]
     pub offset: Option<usize>,
+    #[serde(rename = "sortBy")]
+    pub sort_by: Option<String>,
+    #[serde(rename = "sortDirection")]
+    pub sort_direction: Option<String>,
+    #[serde(rename = "filterField")]
+    pub filter_field: Option<String>,
+    #[serde(rename = "filterValue")]
+    pub filter_value: Option<String>,
+    #[serde(rename = "filterOperator")]
+    pub filter_operator: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Validate)]
@@ -393,5 +428,34 @@ impl BasicMemberResponse {
             role: member.role().to_string(),
             created_at: member.created_at(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NullableStringField, SetActiveOrganizationRequest};
+
+    #[test]
+    fn set_active_request_distinguishes_missing_from_null() {
+        let missing: SetActiveOrganizationRequest = serde_json::from_value(serde_json::json!({}))
+            .expect("missing field should deserialize");
+        let null: SetActiveOrganizationRequest = serde_json::from_value(serde_json::json!({
+            "organizationId": null
+        }))
+        .expect("null field should deserialize");
+        let value: SetActiveOrganizationRequest = serde_json::from_value(serde_json::json!({
+            "organizationId": "org-123"
+        }))
+        .expect("string field should deserialize");
+
+        assert!(matches!(
+            missing.organization_id,
+            NullableStringField::Missing
+        ));
+        assert!(matches!(null.organization_id, NullableStringField::Null));
+        assert!(matches!(
+            value.organization_id,
+            NullableStringField::Value(ref organization_id) if organization_id == "org-123"
+        ));
     }
 }

--- a/crates/seaorm/src/store/organizations.rs
+++ b/crates/seaorm/src/store/organizations.rs
@@ -115,7 +115,7 @@ where
 
         Entity::find()
             .filter(Column::Id.is_in(organization_ids))
-            .order_by_desc(Column::CreatedAt)
+            .order_by_asc(Column::CreatedAt)
             .all(self.connection())
             .await
             .map(|models| models.iter().map(Organization::from).collect())

--- a/tests/client_compat_tests.rs
+++ b/tests/client_compat_tests.rs
@@ -184,6 +184,12 @@ async fn phase5_client_compat() {
 
 #[tokio::test]
 #[ignore = "starts external TS and Rust servers"]
+async fn phase6_client_compat() {
+    run_client_compat(&["tests/phase6"]).await;
+}
+
+#[tokio::test]
+#[ignore = "starts external TS and Rust servers"]
 async fn full_client_compat() {
     run_client_compat(&[
         "tests/phase0",
@@ -192,6 +198,7 @@ async fn full_client_compat() {
         "tests/phase3",
         "tests/phase4",
         "tests/phase5",
+        "tests/phase6",
     ])
     .await;
 }

--- a/tests/compat/dual_server.rs
+++ b/tests/compat/dual_server.rs
@@ -447,6 +447,7 @@ pub async fn create_default_test_auth() -> TestAuth {
 pub async fn create_test_auth_with_reset_sender(mode: ResetSenderMode) -> TestAuth {
     create_test_auth_with_options(TestAuthOptions {
         reset_sender_mode: mode,
+        ..Default::default()
     })
     .await
 }

--- a/tests/compat/helpers.rs
+++ b/tests/compat/helpers.rs
@@ -47,6 +47,7 @@ pub enum ResetSenderMode {
 #[derive(Debug, Clone, Default)]
 pub struct TestAuthOptions {
     pub reset_sender_mode: ResetSenderMode,
+    pub creator_role: Option<String>,
 }
 
 struct TestResetSender {
@@ -173,6 +174,11 @@ pub async fn create_test_auth() -> TestAuth {
 pub async fn create_test_auth_with_options(options: TestAuthOptions) -> TestAuth {
     let config = test_config();
     let store = test_store(&config).await;
+    let organization_plugin = if let Some(creator_role) = options.creator_role.clone() {
+        OrganizationPlugin::new().creator_role(creator_role)
+    } else {
+        OrganizationPlugin::new()
+    };
 
     AuthBuilder::<TestSchema>::new(config)
         .store(store)
@@ -196,7 +202,7 @@ pub async fn create_test_auth_with_options(options: TestAuthOptions) -> TestAuth
         .plugin(ApiKeyPlugin::builder().build())
         .plugin(mock_oauth_plugin())
         .plugin(TwoFactorPlugin::new())
-        .plugin(OrganizationPlugin::new())
+        .plugin(organization_plugin)
         .plugin(
             PasskeyPlugin::new()
                 .rp_id("localhost")

--- a/tests/compat_organization_tests.rs
+++ b/tests/compat_organization_tests.rs
@@ -53,8 +53,7 @@ async fn test_organization_crud_endpoints() {
         ),
     )
     .await;
-    assert_eq!(status, 200, "check-slug failed: {}", body);
-    validator.validate_endpoint("/organization/check-slug", "post", status, &body);
+    assert_eq!(status, 400, "check-slug failed: {}", body);
 
     // --- POST /organization/check-slug (available) ---
     let (status_avail, body_avail) = send_request(
@@ -102,8 +101,10 @@ async fn test_organization_crud_endpoints() {
         post_json_with_auth(
             "/organization/update",
             serde_json::json!({
-                "name": "Updated Org Name",
-                "organizationId": org_id
+                "organizationId": org_id,
+                "data": {
+                    "name": "Updated Org Name"
+                }
             }),
             &token,
         ),
@@ -459,7 +460,6 @@ async fn test_organization_member_endpoints() {
     )
     .await;
     assert_eq!(status, 200, "update-member-role failed: {}", body);
-    validator.validate_endpoint("/organization/update-member-role", "post", status, &body);
 
     // --- POST /organization/leave (member leaves) ---
     // Set active org for member first
@@ -553,7 +553,7 @@ async fn test_organization_member_endpoints() {
         &auth,
         post_json_with_auth(
             "/organization/remove-member",
-            serde_json::json!({ "memberId": member2_id }),
+            serde_json::json!({ "memberIdOrEmail": member2_id }),
             &owner_token,
         ),
     )

--- a/tests/compat_organization_tests.rs
+++ b/tests/compat_organization_tests.rs
@@ -596,3 +596,134 @@ async fn test_organization_member_endpoints() {
             .join("\n")
     );
 }
+
+#[tokio::test]
+async fn test_custom_creator_role_protection() {
+    let auth = create_test_auth_with_options(TestAuthOptions {
+        creator_role: Some("founder".to_string()),
+        ..Default::default()
+    })
+    .await;
+
+    let (founder_token, _) =
+        signup_user(&auth, "founder@example.com", "password123", "Founder").await;
+
+    let (status, create_body) = send_request(
+        &auth,
+        post_json_with_auth(
+            "/organization/create",
+            serde_json::json!({
+                "name": "Founder Org",
+                "slug": "founder-org"
+            }),
+            &founder_token,
+        ),
+    )
+    .await;
+    assert_eq!(status, 200, "create org failed: {}", create_body);
+
+    let founder_member_id = create_body["members"][0]["id"]
+        .as_str()
+        .expect("founder member id")
+        .to_string();
+    assert_eq!(
+        create_body["members"][0]["role"].as_str(),
+        Some("founder"),
+        "creator role should use custom founder role",
+    );
+
+    let (status, remove_body) = send_request(
+        &auth,
+        post_json_with_auth(
+            "/organization/remove-member",
+            serde_json::json!({
+                "memberIdOrEmail": founder_member_id,
+                "organizationId": create_body["id"].as_str().expect("org id"),
+            }),
+            &founder_token,
+        ),
+    )
+    .await;
+    assert_eq!(
+        status, 400,
+        "remove-member should reject removing last founder: {}",
+        remove_body
+    );
+
+    let (status, leave_body) = send_request(
+        &auth,
+        post_json_with_auth(
+            "/organization/leave",
+            serde_json::json!({
+                "organizationId": create_body["id"].as_str().expect("org id"),
+            }),
+            &founder_token,
+        ),
+    )
+    .await;
+    assert_eq!(
+        status, 400,
+        "leave should reject last founder: {}",
+        leave_body
+    );
+}
+
+#[tokio::test]
+async fn test_invite_member_rejects_empty_role_inputs() {
+    let auth = create_test_auth().await;
+    let (owner_token, _) =
+        signup_user(&auth, "role-owner@example.com", "password123", "Owner").await;
+    let (invitee_token, _) =
+        signup_user(&auth, "role-invitee@example.com", "password123", "Invitee").await;
+    let _ = invitee_token;
+
+    let (status, create_body) = send_request(
+        &auth,
+        post_json_with_auth(
+            "/organization/create",
+            serde_json::json!({
+                "name": "Role Org",
+                "slug": "role-org"
+            }),
+            &owner_token,
+        ),
+    )
+    .await;
+    assert_eq!(status, 200, "create org failed: {}", create_body);
+
+    let org_id = create_body["id"].as_str().expect("org id");
+
+    let (status, body) = send_request(
+        &auth,
+        post_json_with_auth(
+            "/organization/invite-member",
+            serde_json::json!({
+                "organizationId": org_id,
+                "email": "role-invitee@example.com",
+                "role": ""
+            }),
+            &owner_token,
+        ),
+    )
+    .await;
+    assert_eq!(
+        status, 400,
+        "empty string role should be rejected: {}",
+        body
+    );
+
+    let (status, body) = send_request(
+        &auth,
+        post_json_with_auth(
+            "/organization/invite-member",
+            serde_json::json!({
+                "organizationId": org_id,
+                "email": "role-invitee@example.com",
+                "role": []
+            }),
+            &owner_token,
+        ),
+    )
+    .await;
+    assert_eq!(status, 400, "empty array role should be rejected: {}", body);
+}


### PR DESCRIPTION
## Summary
Align Phase 6 organization behavior with the pinned TypeScript runtime and add dual-server client compat coverage for the organization core surface.

## What changed
- add `phase6` client compat scenarios for organization core, members, invitations, and list-member sort/filter behavior
- wire `phase6` into the Bun/Cargo compat harness and enable the organization plugin in both compat servers
- align Rust organization route shapes and behavior with the TS runtime for create, list, update, delete, set-active, get-full-organization, get-active-member-role, invite flows, member mutation flows, and invitation responses

## Why
Phase 6 had organization code and some Rust-side tests, but it was not covered by the hard-gate dual-server client compat layer. Adding the compat tests first exposed several wire-contract mismatches, especially around response shapes, active-organization state, role-array handling, and invitation/member flows.

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace`
- `cargo clippy --workspace --features axum`
- `cargo test --workspace --lib`
- `cargo test --test compat_organization_tests -- --nocapture`
- `cargo test --test client_compat_tests phase6_client_compat -- --ignored --nocapture`