### PR TITLE
align phase 0-9 client surface and fold username into phase 0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,6 +20,7 @@ Test suites, scripts, and source comments reference these phase numbers
 
 **Phase 0 — Core auth flow:**
 `/sign-up/email`, `/sign-in/email`, `/sign-in/username`,
+`/is-username-available`,
 `/get-session`, `/sign-out`,
 `/ok`, `/error`
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,12 +5,9 @@ This project targets strict 1:1 behavioral alignment with the
 implementation (`better-auth@1.4.19`). Work is organized into
 self-contained phases, each covering a group of related endpoints.
 
-This roadmap currently tracks the public route surface we have chosen to
-align from the pinned upstream TypeScript sources: the main
-`better-auth` package plus the separately versioned `passkey` package.
-It is not a complete inventory of every optional upstream package or
-plugin family. When upstream only publishes routes behind feature
-options, the relevant phase calls that out explicitly.
+This roadmap tracks the pinned upstream TypeScript surface plus exposed
+Rust plugin routes we intend to keep. Public routes not present in
+upstream TS should be removed.
 
 Phases are ordered so that each one only depends on capabilities from
 earlier phases. A phase is complete when every endpoint in it has
@@ -22,7 +19,8 @@ Test suites, scripts, and source comments reference these phase numbers
 ## Phases
 
 **Phase 0 — Core auth flow:**
-`/sign-up/email`, `/sign-in/email`, `/get-session`, `/sign-out`,
+`/sign-up/email`, `/sign-in/email`, `/sign-in/username`,
+`/get-session`, `/sign-out`,
 `/ok`, `/error`
 
 **Phase 1 — Session and password management:**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,25 +83,25 @@ Test suites, scripts, and source comments reference these phase numbers
 `/admin/set-user-password`, `/admin/set-role`,
 `/admin/has-permission`
 
-**Phase 10 — Admin stateful flows:**
+**Phase 10 — Two-factor core:**
+`/two-factor/enable`, `/two-factor/disable`,
+`/two-factor/get-totp-uri`, `/two-factor/verify-totp`,
+`/two-factor/send-otp`, `/two-factor/verify-otp`
+
+**Phase 11 — Two-factor recovery:**
+`/two-factor/generate-backup-codes`,
+`/two-factor/view-backup-codes`,
+`/two-factor/verify-backup-code`
+
+**Phase 12 — Admin stateful flows:**
 `/admin/ban-user`, `/admin/unban-user`,
 `/admin/impersonate-user`, `/admin/stop-impersonating`,
 `/admin/list-user-sessions`, `/admin/revoke-user-session`,
 `/admin/revoke-user-sessions`
 
-**Phase 11 — JWT surface:**
+**Phase 13 — JWT surface:**
 When `jwt()` is enabled:
 `/token`, `/jwks` (or configured `jwksPath`)
-
-**Phase 12 — Two-factor core:**
-`/two-factor/enable`, `/two-factor/disable`,
-`/two-factor/get-totp-uri`, `/two-factor/verify-totp`,
-`/two-factor/send-otp`, `/two-factor/verify-otp`
-
-**Phase 13 — Two-factor recovery:**
-`/two-factor/generate-backup-codes`,
-`/two-factor/view-backup-codes`,
-`/two-factor/verify-backup-code`
 
 **Phase 14 — Organization teams:**
 When `organization({ teams: { enabled: true } })` is enabled:

--- a/compat-tests/client-tests/tests/phase0/signin.test.ts
+++ b/compat-tests/client-tests/tests/phase0/signin.test.ts
@@ -1,4 +1,17 @@
+import { createAuthClient } from "better-auth/client";
+import { usernameClient } from "better-auth/client/plugins";
 import { compatScenario } from "../../support/scenario";
+
+function usernameActor(ctx: Parameters<Parameters<typeof compatScenario>[1]>[0], name = "primary") {
+  const actor = ctx.actor(name);
+  return createAuthClient({
+    baseURL: ctx.baseURL,
+    plugins: [usernameClient()],
+    fetchOptions: {
+      customFetchImpl: actor.fetch,
+    },
+  });
+}
 
 compatScenario("sign in with valid credentials returns user and token", async (ctx) => {
   const primary = ctx.actor();
@@ -54,6 +67,63 @@ compatScenario("sign in with invalid email returns error", async (ctx) => {
   const primary = ctx.actor();
   const signin = await primary.client.signIn.email({
     email: "invalid-email",
+    password: "password123",
+  });
+
+  return {
+    signin: ctx.snapshot(signin),
+  };
+});
+
+compatScenario("sign in with valid username returns user and token", async (ctx) => {
+  const primary = ctx.actor();
+  const username = usernameActor(ctx);
+  const email = ctx.uniqueEmail("phase0-signin-username");
+  const signup = await primary.client.signUp.email({
+    email,
+    password: "password123",
+    name: "Username User",
+    username: "phase0_user",
+    displayUsername: "Phase0 User",
+  });
+
+  const signin = await username.signIn.username({
+    username: "phase0_user",
+    password: "password123",
+  });
+
+  return {
+    signup: ctx.snapshot(signup),
+    signin: ctx.snapshot(signin),
+  };
+});
+
+compatScenario("sign in with wrong username password returns error", async (ctx) => {
+  const primary = ctx.actor();
+  const username = usernameActor(ctx);
+  const email = ctx.uniqueEmail("phase0-signin-username-wrong");
+  const signup = await primary.client.signUp.email({
+    email,
+    password: "password123",
+    name: "Username User",
+    username: "phase0_wrongpw",
+  });
+
+  const signin = await username.signIn.username({
+    username: "phase0_wrongpw",
+    password: "wrong-password",
+  });
+
+  return {
+    signup: ctx.snapshot(signup),
+    signin: ctx.snapshot(signin),
+  };
+});
+
+compatScenario("sign in with nonexistent username returns error", async (ctx) => {
+  const username = usernameActor(ctx);
+  const signin = await username.signIn.username({
+    username: "missing_user",
     password: "password123",
   });
 

--- a/compat-tests/client-tests/tests/phase0/signin.test.ts
+++ b/compat-tests/client-tests/tests/phase0/signin.test.ts
@@ -131,3 +131,25 @@ compatScenario("sign in with nonexistent username returns error", async (ctx) =>
     signin: ctx.snapshot(signin),
   };
 });
+
+compatScenario("sign in with differently cased username returns user and token", async (ctx) => {
+  const primary = ctx.actor();
+  const username = usernameActor(ctx);
+  const email = ctx.uniqueEmail("phase0-signin-username-case");
+  const signup = await primary.client.signUp.email({
+    email,
+    password: "password123",
+    name: "Username User",
+    username: "Phase0_Case_User",
+  });
+
+  const signin = await username.signIn.username({
+    username: "PHASE0_CASE_USER",
+    password: "password123",
+  });
+
+  return {
+    signup: ctx.snapshot(signup),
+    signin: ctx.snapshot(signin),
+  };
+});

--- a/compat-tests/client-tests/tests/phase0/signup.test.ts
+++ b/compat-tests/client-tests/tests/phase0/signup.test.ts
@@ -59,3 +59,42 @@ compatScenario("sign up with invalid email returns error", async (ctx) => {
     signup: ctx.snapshot(signup),
   };
 });
+
+compatScenario("sign up with invalid username returns error", async (ctx) => {
+  const primary = ctx.actor();
+  const signup = await primary.client.signUp.email({
+    email: ctx.uniqueEmail("phase0-signup-invalid-username"),
+    password: "password123",
+    name: "Invalid Username User",
+    username: "invalid username!",
+  });
+
+  return {
+    signup: ctx.snapshot(signup),
+  };
+});
+
+compatScenario("sign up with duplicate username returns error", async (ctx) => {
+  const primary = ctx.actor();
+  const firstEmail = ctx.uniqueEmail("phase0-signup-username-first");
+  const secondEmail = ctx.uniqueEmail("phase0-signup-username-second");
+
+  const first = await primary.client.signUp.email({
+    email: firstEmail,
+    password: "password123",
+    name: "First Username User",
+    username: "phase0_duplicate_user",
+  });
+
+  const duplicate = await primary.client.signUp.email({
+    email: secondEmail,
+    password: "password123",
+    name: "Second Username User",
+    username: "PHASE0_DUPLICATE_USER",
+  });
+
+  return {
+    first: ctx.snapshot(first),
+    duplicate: ctx.snapshot(duplicate),
+  };
+});

--- a/compat-tests/client-tests/tests/phase4/device.test.ts
+++ b/compat-tests/client-tests/tests/phase4/device.test.ts
@@ -16,6 +16,26 @@ function asString(value: unknown, key: string): string {
   return value;
 }
 
+function normalizeApprovedTokenResponse(response: {
+  status: number;
+  location: string | null;
+  body: unknown;
+}) {
+  const snapshot = structuredClone(response) as {
+    status: number;
+    location: string | null;
+    body: Record<string, unknown> | null;
+  };
+
+  if (snapshot.body && typeof snapshot.body.expires_in === "number") {
+    const expiresIn = snapshot.body.expires_in;
+    snapshot.body.expires_in =
+      expiresIn === 604799 || expiresIn === 604800 ? "<week-session-ttl>" : expiresIn;
+  }
+
+  return snapshot;
+}
+
 compatScenario("device code request returns oauth device response fields", async (ctx) => {
   const code = await ctx.rawRequest({
     path: "/api/auth/device/code",
@@ -159,7 +179,7 @@ compatScenario("device approve flow returns a bearer token", async (ctx) => {
   return {
     signup: ctx.snapshot(signup),
     approve: ctx.snapshot(approve),
-    token: ctx.snapshot(token),
+    token: normalizeApprovedTokenResponse(ctx.snapshot(token) as typeof token),
   };
 });
 

--- a/compat-tests/client-tests/tests/phase4/device.test.ts
+++ b/compat-tests/client-tests/tests/phase4/device.test.ts
@@ -30,7 +30,7 @@ function normalizeApprovedTokenResponse(response: {
   if (snapshot.body && typeof snapshot.body.expires_in === "number") {
     const expiresIn = snapshot.body.expires_in;
     snapshot.body.expires_in =
-      expiresIn === 604799 || expiresIn === 604800 ? "<week-session-ttl>" : expiresIn;
+      Math.abs(expiresIn - 604800) <= 5 ? "<week-session-ttl>" : expiresIn;
   }
 
   return snapshot;

--- a/compat-tests/reference-server/server.ts
+++ b/compat-tests/reference-server/server.ts
@@ -4,7 +4,7 @@ import { Database } from "bun:sqlite";
 import { passkey } from "@better-auth/passkey";
 import { betterAuth } from "better-auth";
 import { getMigrations } from "better-auth/db";
-import { admin, apiKey, deviceAuthorization } from "better-auth/plugins";
+import { admin, apiKey, deviceAuthorization, username } from "better-auth/plugins";
 import { organization } from "better-auth/plugins/organization";
 import { genericOAuth } from "better-auth/plugins/generic-oauth";
 
@@ -320,6 +320,7 @@ const authOptions = {
     deviceAuthorization(),
     organization(),
     passkey(),
+    username(),
     genericOAuth({
       config: [
         {

--- a/compat-tests/reference-server/server.ts
+++ b/compat-tests/reference-server/server.ts
@@ -351,6 +351,27 @@ await runMigrations();
 
 const auth = betterAuth(authOptions);
 const authContext = await auth.$context;
+const RESET_MODELS = [
+  "deviceCode",
+  "passkey",
+  "apikey",
+  "invitation",
+  "member",
+  "organization",
+  "verification",
+  "account",
+  "session",
+  "user",
+] as const;
+
+async function resetDatabaseState() {
+  for (const model of RESET_MODELS) {
+    await authContext.adapter.deleteMany({
+      model,
+      where: [],
+    });
+  }
+}
 
 const server = Bun.serve({
   port: PORT,
@@ -363,6 +384,7 @@ const server = Bun.serve({
       }
 
       if (url.pathname === "/__test/reset-state" && request.method === "POST") {
+        await resetDatabaseState();
         resetPasswordOutbox.clear();
         verificationEmailOutbox.clear();
         changeEmailOutbox.clear();

--- a/compat-tests/rust-server/src/main.rs
+++ b/compat-tests/rust-server/src/main.rs
@@ -19,6 +19,11 @@ use better_auth::plugins::{
 };
 use better_auth::wire::UserView;
 use better_auth::{AuthBuilder, AuthConfig};
+use better_auth_seaorm::sea_orm::{DatabaseConnection, DbErr, EntityTrait};
+use better_auth_seaorm::store::entities::{
+    account, api_key, device_code, invitation, member, organization, passkey, session,
+    two_factor, user, verification,
+};
 use better_auth_seaorm::{Database, SeaOrmStore};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -117,6 +122,22 @@ fn default_github_profile() -> GitHubProfile {
             visibility: Some("private".to_string()),
         }],
     }
+}
+
+async fn reset_database_state(database: &DatabaseConnection) -> Result<(), DbErr> {
+    device_code::Entity::delete_many().exec(database).await?;
+    passkey::Entity::delete_many().exec(database).await?;
+    api_key::Entity::delete_many().exec(database).await?;
+    two_factor::Entity::delete_many().exec(database).await?;
+    invitation::Entity::delete_many().exec(database).await?;
+    member::Entity::delete_many().exec(database).await?;
+    organization::Entity::delete_many().exec(database).await?;
+    verification::Entity::delete_many().exec(database).await?;
+    account::Entity::delete_many().exec(database).await?;
+    session::Entity::delete_many().exec(database).await?;
+    user::Entity::delete_many().exec(database).await?;
+
+    Ok(())
 }
 
 #[async_trait::async_trait]
@@ -451,10 +472,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .password_min_length(8);
 
     let database = Database::connect("sqlite::memory:").await?;
-    better_auth_seaorm::store::__private_test_support::migrator::run_migrations(
-        &database,
-    )
-    .await?;
+    better_auth_seaorm::store::__private_test_support::migrator::run_migrations(&database).await?;
+    let reset_database = database.clone();
 
     let reset_outbox = Arc::new(Mutex::new(HashMap::new()));
     let verification_outbox = Arc::new(Mutex::new(HashMap::new()));
@@ -531,6 +550,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let github_profile_for_emails = github_profile.clone();
     let social_id_token_valid_for_reset = social_id_token_valid.clone();
     let social_id_token_valid_for_set = social_id_token_valid.clone();
+    let database_for_reset = reset_database.clone();
     let auth_for_reset_seed = auth.clone();
     let auth_for_delete_seed = auth.clone();
     let auth_for_remove_credential = auth.clone();
@@ -607,7 +627,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let social_profile = social_profile_for_reset.clone();
                 let github_profile = github_profile_for_reset.clone();
                 let social_id_token_valid = social_id_token_valid_for_reset.clone();
+                let database = database_for_reset.clone();
                 async move {
+                    if let Err(error) = reset_database_state(&database).await {
+                        return (
+                            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(serde_json::json!({ "message": error.to_string() })),
+                        );
+                    }
                     reset_outbox.lock().await.clear();
                     verification_outbox.lock().await.clear();
                     change_email_outbox.lock().await.clear();
@@ -616,7 +643,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     *social_profile.lock().await = default_social_profile();
                     *github_profile.lock().await = default_github_profile();
                     *social_id_token_valid.lock().await = true;
-                    Json(serde_json::json!({ "status": true }))
+                    (
+                        axum::http::StatusCode::OK,
+                        Json(serde_json::json!({ "status": true })),
+                    )
                 }
             }),
         )

--- a/crates/api/src/plugins/admin/mod.rs
+++ b/crates/api/src/plugins/admin/mod.rs
@@ -1,8 +1,14 @@
 use std::collections::HashMap;
 
+use better_auth_core::entity::AuthUser;
 use better_auth_core::utils::cookie_utils::create_session_cookie;
+use better_auth_core::utils::username::{
+    UsernameValidationError, normalize_username_fields, validate_username,
+};
 use better_auth_core::wire::{SessionView, UserView};
-use better_auth_core::{AuthContext, AuthError, AuthRequest, AuthResponse, AuthResult};
+use better_auth_core::{
+    AuthContext, AuthError, AuthRequest, AuthResponse, AuthResult, ErrorCodeMessageResponse,
+};
 use validator::Validate;
 
 pub mod access;
@@ -27,6 +33,21 @@ const MESSAGE_DELETE_USERS: &str = "You are not allowed to delete users";
 const MESSAGE_SET_USER_PASSWORD: &str = "You are not allowed to set users password";
 const MESSAGE_GET_USER: &str = "You are not allowed to get user";
 const MESSAGE_UPDATE_USERS: &str = "You are not allowed to update users";
+const MESSAGE_USERNAME_IS_ALREADY_TAKEN: &str = "Username is already taken. Please try another.";
+const MESSAGE_USERNAME_TOO_SHORT: &str = "Username is too short";
+const MESSAGE_USERNAME_TOO_LONG: &str = "Username is too long";
+const MESSAGE_INVALID_USERNAME: &str = "Username is invalid";
+
+fn username_error_response(status: u16, code: &str, message: &str) -> AuthResult<AuthResponse> {
+    AuthResponse::json(
+        status,
+        &ErrorCodeMessageResponse {
+            code: code.to_string(),
+            message: message.to_string(),
+        },
+    )
+    .map_err(AuthError::from)
+}
 
 /// Admin plugin for user management operations.
 pub struct AdminPlugin {
@@ -184,10 +205,68 @@ impl AdminPlugin {
     ) -> AuthResult<AuthResponse> {
         let (user, _session) = self.require_session(req, ctx).await?;
         self.authorize(&user, "user", "update", MESSAGE_UPDATE_USERS)?;
-        let body: AdminUpdateUserRequest = match better_auth_core::validate_request_body(req) {
+        let mut body: AdminUpdateUserRequest = match better_auth_core::validate_request_body(req) {
             Ok(v) => v,
             Err(resp) => return Ok(resp),
         };
+        let (username, display_username) = normalize_username_fields(
+            body.data
+                .remove("username")
+                .and_then(|value| value.as_str().map(ToOwned::to_owned)),
+            body.data
+                .remove("displayUsername")
+                .and_then(|value| value.as_str().map(ToOwned::to_owned)),
+        );
+
+        if let Some(username) = username.as_deref() {
+            match validate_username(username) {
+                Ok(()) => {}
+                Err(UsernameValidationError::TooShort) => {
+                    return username_error_response(
+                        400,
+                        "USERNAME_TOO_SHORT",
+                        MESSAGE_USERNAME_TOO_SHORT,
+                    );
+                }
+                Err(UsernameValidationError::TooLong) => {
+                    return username_error_response(
+                        400,
+                        "USERNAME_IS_TOO_LONG",
+                        MESSAGE_USERNAME_TOO_LONG,
+                    );
+                }
+                Err(UsernameValidationError::Invalid) => {
+                    return username_error_response(
+                        400,
+                        "USERNAME_IS_INVALID",
+                        MESSAGE_INVALID_USERNAME,
+                    );
+                }
+            }
+
+            if let Some(existing_user) = ctx.database.get_user_by_username(username).await?
+                && AuthUser::id(&existing_user).as_ref() != body.user_id
+            {
+                return username_error_response(
+                    400,
+                    "USERNAME_IS_ALREADY_TAKEN",
+                    MESSAGE_USERNAME_IS_ALREADY_TAKEN,
+                );
+            }
+        }
+
+        if let Some(username) = username {
+            _ = body
+                .data
+                .insert("username".to_string(), serde_json::Value::String(username));
+        }
+        if let Some(display_username) = display_username {
+            _ = body.data.insert(
+                "displayUsername".to_string(),
+                serde_json::Value::String(display_username),
+            );
+        }
+
         let response = update_user_core(&body, &user, &self.config, ctx).await?;
         AuthResponse::json(200, &response).map_err(AuthError::from)
     }

--- a/crates/api/src/plugins/admin/mod.rs
+++ b/crates/api/src/plugins/admin/mod.rs
@@ -2,9 +2,7 @@ use std::collections::HashMap;
 
 use better_auth_core::entity::AuthUser;
 use better_auth_core::utils::cookie_utils::create_session_cookie;
-use better_auth_core::utils::username::{
-    UsernameValidationError, normalize_username_fields, validate_username,
-};
+use better_auth_core::utils::username::{UsernameValidationError, validate_username};
 use better_auth_core::wire::{SessionView, UserView};
 use better_auth_core::{
     AuthContext, AuthError, AuthRequest, AuthResponse, AuthResult, ErrorCodeMessageResponse,
@@ -209,14 +207,15 @@ impl AdminPlugin {
             Ok(v) => v,
             Err(resp) => return Ok(resp),
         };
-        let (username, display_username) = normalize_username_fields(
-            body.data
-                .remove("username")
-                .and_then(|value| value.as_str().map(ToOwned::to_owned)),
-            body.data
-                .remove("displayUsername")
-                .and_then(|value| value.as_str().map(ToOwned::to_owned)),
-        );
+        let username = body
+            .data
+            .remove("username")
+            .and_then(|value| value.as_str().map(ToOwned::to_owned))
+            .map(|value| value.to_lowercase());
+        let display_username = body
+            .data
+            .remove("displayUsername")
+            .and_then(|value| value.as_str().map(ToOwned::to_owned));
 
         if let Some(username) = username.as_deref() {
             match validate_username(username) {

--- a/crates/api/src/plugins/admin/types.rs
+++ b/crates/api/src/plugins/admin/types.rs
@@ -148,6 +148,9 @@ pub(crate) struct AdminUserView {
     pub created_at: DateTime<Utc>,
     #[serde(rename = "updatedAt")]
     pub updated_at: DateTime<Utc>,
+    pub username: Option<String>,
+    #[serde(rename = "displayUsername")]
+    pub display_username: Option<String>,
     pub role: Option<String>,
     pub banned: bool,
     #[serde(rename = "banReason")]
@@ -166,6 +169,8 @@ impl<T: better_auth_core::entity::AuthUser> From<&T> for AdminUserView {
             image: user.image().map(str::to_owned),
             created_at: user.created_at(),
             updated_at: user.updated_at(),
+            username: user.username().map(str::to_owned),
+            display_username: user.display_username().map(str::to_owned),
             role: user.role().map(str::to_owned),
             banned: user.banned(),
             ban_reason: user.ban_reason().map(str::to_owned),

--- a/crates/api/src/plugins/device_authorization/mod.rs
+++ b/crates/api/src/plugins/device_authorization/mod.rs
@@ -385,7 +385,10 @@ impl DeviceAuthorizationPlugin {
                 &DeviceTokenResponse {
                     access_token: session.token().to_string(),
                     token_type: "Bearer",
-                    expires_in: ctx.config.session.expires_in.num_seconds(),
+                    expires_in: (session.expires_at().timestamp_millis()
+                        - Utc::now().timestamp_millis())
+                    .div_euclid(1000)
+                    .max(0),
                     scope: device_code.scope.unwrap_or_default(),
                 },
             )?

--- a/crates/api/src/plugins/email_password.rs
+++ b/crates/api/src/plugins/email_password.rs
@@ -8,7 +8,7 @@ use better_auth_core::{AuthContext, AuthPlugin, AuthRoute};
 use better_auth_core::{AuthError, AuthResult};
 use better_auth_core::{
     AuthRequest, AuthResponse, CreateAccount, CreateSession, CreateUser, CreateVerification,
-    HttpMethod, RequestMeta,
+    ErrorCodeMessageResponse, HttpMethod, RequestMeta,
 };
 
 use super::email_verification::EmailVerificationPlugin;
@@ -17,6 +17,35 @@ use better_auth_core::utils::password::{self as password_utils, PasswordHasher};
 use better_auth_core::wire::UserView;
 
 use crate::plugins::helpers::apply_default_role;
+
+const USERNAME_MIN_LENGTH: usize = 3;
+const USERNAME_MAX_LENGTH: usize = 30;
+const MESSAGE_INVALID_USERNAME_OR_PASSWORD: &str = "Invalid username or password";
+const MESSAGE_EMAIL_NOT_VERIFIED: &str = "Email not verified";
+const MESSAGE_USERNAME_TOO_SHORT: &str = "Username is too short";
+const MESSAGE_USERNAME_TOO_LONG: &str = "Username is too long";
+const MESSAGE_INVALID_USERNAME: &str = "Username is invalid";
+
+fn username_error_response(status: u16, code: &str, message: &str) -> AuthResult<AuthResponse> {
+    AuthResponse::json(
+        status,
+        &ErrorCodeMessageResponse {
+            code: code.to_string(),
+            message: message.to_string(),
+        },
+    )
+    .map_err(AuthError::from)
+}
+
+fn normalize_username(username: &str) -> String {
+    username.to_lowercase()
+}
+
+fn username_is_valid(username: &str) -> bool {
+    username
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '.')
+}
 /// Email and password authentication plugin
 pub struct EmailPasswordPlugin {
     config: EmailPasswordConfig,
@@ -90,12 +119,12 @@ pub(crate) struct SignInRequest {
 #[derive(Debug, Deserialize, Validate)]
 #[expect(dead_code, reason = "fields deserialized from request body")]
 pub(crate) struct SignInUsernameRequest {
-    #[validate(length(min = 1, message = "Username is required"))]
     username: String,
-    #[validate(length(min = 1, message = "Password is required"))]
     password: String,
     #[serde(rename = "rememberMe")]
     remember_me: Option<bool>,
+    #[serde(rename = "callbackURL")]
+    callback_url: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -110,6 +139,12 @@ pub(crate) struct SignInResponse<U: Serialize> {
     token: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     url: Option<String>,
+    user: U,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct SignInUsernameResponse<U: Serialize> {
+    token: String,
     user: U,
 }
 
@@ -251,23 +286,60 @@ impl EmailPasswordPlugin {
             Err(resp) => return Ok(resp),
         };
 
+        if signin_req.username.is_empty() || signin_req.password.is_empty() {
+            return username_error_response(
+                401,
+                "INVALID_USERNAME_OR_PASSWORD",
+                MESSAGE_INVALID_USERNAME_OR_PASSWORD,
+            );
+        }
+
+        let username = normalize_username(&signin_req.username);
+
+        if username.len() < USERNAME_MIN_LENGTH {
+            return username_error_response(422, "USERNAME_TOO_SHORT", MESSAGE_USERNAME_TOO_SHORT);
+        }
+
+        if username.len() > USERNAME_MAX_LENGTH {
+            return username_error_response(422, "USERNAME_IS_TOO_LONG", MESSAGE_USERNAME_TOO_LONG);
+        }
+
+        if !username_is_valid(&username) {
+            return username_error_response(422, "USERNAME_IS_INVALID", MESSAGE_INVALID_USERNAME);
+        }
+
         let meta = RequestMeta::from_request(req);
         match sign_in_username_core(
             &signin_req,
+            &username,
             &self.config,
             self.email_verification.as_deref(),
             &meta,
             ctx,
         )
-        .await?
+        .await
         {
-            SignInCoreResult::Success(response, token) => {
+            Ok(SignInCoreResult::Success(response, token)) => {
                 let cookie_header = create_session_cookie(&token, &ctx.config);
-                Ok(AuthResponse::json(200, &response)?.with_header("Set-Cookie", cookie_header))
+                let username_response = SignInUsernameResponse {
+                    token: response.token,
+                    user: response.user,
+                };
+                Ok(AuthResponse::json(200, &username_response)?
+                    .with_header("Set-Cookie", cookie_header))
             }
-            SignInCoreResult::TwoFactorRedirect(redirect) => {
+            Ok(SignInCoreResult::TwoFactorRedirect(redirect)) => {
                 Ok(AuthResponse::json(200, &redirect)?)
             }
+            Err(SignInUsernameFailure::InvalidUsernameOrPassword) => username_error_response(
+                401,
+                "INVALID_USERNAME_OR_PASSWORD",
+                MESSAGE_INVALID_USERNAME_OR_PASSWORD,
+            ),
+            Err(SignInUsernameFailure::EmailNotVerified) => {
+                username_error_response(403, "EMAIL_NOT_VERIFIED", MESSAGE_EMAIL_NOT_VERIFIED)
+            }
+            Err(SignInUsernameFailure::Auth(error)) => Err(error),
         }
     }
 }
@@ -314,10 +386,12 @@ pub(crate) async fn sign_up_core(
         .with_name(&body.name);
     apply_default_role(ctx, &mut create_user);
     if let Some(ref username) = body.username {
-        create_user = create_user.with_username(username.clone());
+        create_user = create_user.with_username(normalize_username(username));
     }
     if let Some(ref display_username) = body.display_username {
         create_user.display_username = Some(display_username.clone());
+    } else if let Some(ref username) = body.username {
+        create_user.display_username = Some(username.clone());
     }
     let auto_sign_in = config.auto_sign_in;
     let expires_in = ctx.config.session.expires_in;
@@ -478,27 +552,78 @@ pub(crate) async fn sign_in_core(
 /// Core sign-in by username.
 pub(crate) async fn sign_in_username_core(
     body: &SignInUsernameRequest,
+    normalized_username: &str,
     config: &EmailPasswordConfig,
     email_verification: Option<&EmailVerificationPlugin>,
     meta: &RequestMeta,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
-) -> AuthResult<SignInCoreResult<UserView>> {
-    let user = ctx
+) -> Result<SignInCoreResult<UserView>, SignInUsernameFailure> {
+    let Some(user) = ctx
         .database
-        .get_user_by_username(&body.username)
-        .await?
-        .ok_or(AuthError::InvalidCredentials)?;
+        .get_user_by_username(normalized_username)
+        .await
+        .map_err(SignInUsernameFailure::Auth)?
+    else {
+        let _ = password_utils::hash_password(config.password_hasher.as_ref(), &body.password)
+            .await
+            .map_err(SignInUsernameFailure::Auth)?;
+        return Err(SignInUsernameFailure::InvalidUsernameOrPassword);
+    };
+
+    let stored_hash = ctx
+        .database
+        .get_user_accounts(&user.id())
+        .await
+        .map_err(SignInUsernameFailure::Auth)?
+        .into_iter()
+        .find(|account| account.provider_id() == "credential" && account.password().is_some())
+        .and_then(|account| account.password().map(str::to_string))
+        .ok_or(SignInUsernameFailure::InvalidUsernameOrPassword)?;
+
+    password_utils::verify_password(
+        config.password_hasher.as_ref(),
+        &body.password,
+        &stored_hash,
+    )
+    .await
+    .map_err(|error| match error {
+        AuthError::InvalidCredentials => SignInUsernameFailure::InvalidUsernameOrPassword,
+        other => SignInUsernameFailure::Auth(other),
+    })?;
+
+    if let Some(ev) = email_verification
+        && ev.is_verification_required()
+        && !user.email_verified()
+    {
+        if let Err(error) = ev
+            .send_verification_on_sign_in(&user, body.callback_url.as_deref(), ctx)
+            .await
+        {
+            tracing::warn!(
+                error = %error,
+                "Failed to send verification email on username sign-in"
+            );
+        }
+        return Err(SignInUsernameFailure::EmailNotVerified);
+    }
 
     sign_in_with_user_core(
         user,
         &body.password,
         config,
         email_verification,
-        None,
+        body.callback_url.as_deref(),
         meta,
         ctx,
     )
     .await
+    .map_err(SignInUsernameFailure::Auth)
+}
+
+pub(crate) enum SignInUsernameFailure {
+    InvalidUsernameOrPassword,
+    EmailNotVerified,
+    Auth(AuthError),
 }
 
 impl Default for EmailPasswordConfig {

--- a/crates/api/src/plugins/email_password.rs
+++ b/crates/api/src/plugins/email_password.rs
@@ -15,6 +15,8 @@ use super::email_verification::EmailVerificationPlugin;
 use better_auth_core::utils::cookie_utils::create_session_cookie;
 use better_auth_core::utils::password::{self as password_utils, PasswordHasher};
 use better_auth_core::wire::UserView;
+
+use crate::plugins::helpers::apply_default_role;
 /// Email and password authentication plugin
 pub struct EmailPasswordPlugin {
     config: EmailPasswordConfig,
@@ -310,12 +312,7 @@ pub(crate) async fn sign_up_core(
     let mut create_user = CreateUser::new()
         .with_email(&body.email)
         .with_name(&body.name);
-    if let Some(default_role) = ctx
-        .get_metadata("admin.default_role")
-        .and_then(|value| value.as_str())
-    {
-        create_user = create_user.with_role(default_role.to_string());
-    }
+    apply_default_role(ctx, &mut create_user);
     if let Some(ref username) = body.username {
         create_user = create_user.with_username(username.clone());
     }

--- a/crates/api/src/plugins/email_password.rs
+++ b/crates/api/src/plugins/email_password.rs
@@ -14,12 +14,13 @@ use better_auth_core::{
 use super::email_verification::EmailVerificationPlugin;
 use better_auth_core::utils::cookie_utils::create_session_cookie;
 use better_auth_core::utils::password::{self as password_utils, PasswordHasher};
+use better_auth_core::utils::username::{
+    UsernameValidationError, normalize_username, normalize_username_fields, validate_username,
+};
 use better_auth_core::wire::UserView;
 
 use crate::plugins::helpers::apply_default_role;
 
-const USERNAME_MIN_LENGTH: usize = 3;
-const USERNAME_MAX_LENGTH: usize = 30;
 const MESSAGE_INVALID_USERNAME_OR_PASSWORD: &str = "Invalid username or password";
 const MESSAGE_EMAIL_NOT_VERIFIED: &str = "Email not verified";
 const MESSAGE_USERNAME_TOO_SHORT: &str = "Username is too short";
@@ -35,16 +36,6 @@ fn username_error_response(status: u16, code: &str, message: &str) -> AuthResult
         },
     )
     .map_err(AuthError::from)
-}
-
-fn normalize_username(username: &str) -> String {
-    username.to_lowercase()
-}
-
-fn username_is_valid(username: &str) -> bool {
-    username
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '.')
 }
 /// Email and password authentication plugin
 pub struct EmailPasswordPlugin {
@@ -223,10 +214,44 @@ impl EmailPasswordPlugin {
         req: &AuthRequest,
         ctx: &AuthContext<impl better_auth_core::AuthSchema>,
     ) -> AuthResult<AuthResponse> {
-        let signup_req: SignUpRequest = match better_auth_core::validate_request_body(req) {
+        let mut signup_req: SignUpRequest = match better_auth_core::validate_request_body(req) {
             Ok(v) => v,
             Err(resp) => return Ok(resp),
         };
+
+        let (username, display_username) = normalize_username_fields(
+            signup_req.username.take(),
+            signup_req.display_username.take(),
+        );
+        signup_req.username = username;
+        signup_req.display_username = display_username;
+
+        if let Some(username) = signup_req.username.as_deref() {
+            match validate_username(username) {
+                Ok(()) => {}
+                Err(UsernameValidationError::TooShort) => {
+                    return username_error_response(
+                        400,
+                        "USERNAME_TOO_SHORT",
+                        MESSAGE_USERNAME_TOO_SHORT,
+                    );
+                }
+                Err(UsernameValidationError::TooLong) => {
+                    return username_error_response(
+                        400,
+                        "USERNAME_IS_TOO_LONG",
+                        MESSAGE_USERNAME_TOO_LONG,
+                    );
+                }
+                Err(UsernameValidationError::Invalid) => {
+                    return username_error_response(
+                        400,
+                        "USERNAME_IS_INVALID",
+                        MESSAGE_INVALID_USERNAME,
+                    );
+                }
+            }
+        }
 
         let meta = RequestMeta::from_request(req);
         let (response, session_token) = sign_up_core(&signup_req, &self.config, &meta, ctx).await?;
@@ -296,16 +321,29 @@ impl EmailPasswordPlugin {
 
         let username = normalize_username(&signin_req.username);
 
-        if username.len() < USERNAME_MIN_LENGTH {
-            return username_error_response(422, "USERNAME_TOO_SHORT", MESSAGE_USERNAME_TOO_SHORT);
-        }
-
-        if username.len() > USERNAME_MAX_LENGTH {
-            return username_error_response(422, "USERNAME_IS_TOO_LONG", MESSAGE_USERNAME_TOO_LONG);
-        }
-
-        if !username_is_valid(&username) {
-            return username_error_response(422, "USERNAME_IS_INVALID", MESSAGE_INVALID_USERNAME);
+        match validate_username(&username) {
+            Ok(()) => {}
+            Err(UsernameValidationError::TooShort) => {
+                return username_error_response(
+                    422,
+                    "USERNAME_TOO_SHORT",
+                    MESSAGE_USERNAME_TOO_SHORT,
+                );
+            }
+            Err(UsernameValidationError::TooLong) => {
+                return username_error_response(
+                    422,
+                    "USERNAME_IS_TOO_LONG",
+                    MESSAGE_USERNAME_TOO_LONG,
+                );
+            }
+            Err(UsernameValidationError::Invalid) => {
+                return username_error_response(
+                    422,
+                    "USERNAME_IS_INVALID",
+                    MESSAGE_INVALID_USERNAME,
+                );
+            }
         }
 
         let meta = RequestMeta::from_request(req);
@@ -403,7 +441,15 @@ pub(crate) async fn sign_up_core(
     better_auth_core::store::transaction(database.as_ref(), move |tx| {
         let _database = transaction_database.clone();
         Box::pin(async move {
-            let user = tx.create_user(create_user).await?;
+            let user = match tx.create_user(create_user).await {
+                Ok(user) => user,
+                Err(AuthError::Database(_)) => {
+                    return Err(AuthError::UnprocessableEntity(
+                        "Failed to create user".to_string(),
+                    ));
+                }
+                Err(error) => return Err(error),
+            };
 
             let _ = tx
                 .create_account(CreateAccount {

--- a/crates/api/src/plugins/email_password.rs
+++ b/crates/api/src/plugins/email_password.rs
@@ -454,29 +454,37 @@ pub(crate) async fn sign_up_core(
     .await
 }
 
-/// Shared sign-in logic after user lookup: verify password, check 2FA, create session.
-async fn sign_in_with_user_core(
-    user: impl AuthUser,
-    password: &str,
-    config: &EmailPasswordConfig,
-    email_verification: Option<&EmailVerificationPlugin>,
-    callback_url: Option<&str>,
-    meta: &RequestMeta,
+async fn load_credential_password_hash(
+    user: &impl AuthUser,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
-) -> AuthResult<SignInCoreResult<UserView>> {
-    // Verify password
-    let stored_hash = ctx
-        .database
+) -> AuthResult<String> {
+    ctx.database
         .get_user_accounts(&user.id())
         .await?
         .into_iter()
         .find(|account| account.provider_id() == "credential" && account.password().is_some())
         .and_then(|account| account.password().map(str::to_string))
-        .ok_or(AuthError::InvalidCredentials)?;
+        .ok_or(AuthError::InvalidCredentials)
+}
 
-    password_utils::verify_password(config.password_hasher.as_ref(), password, &stored_hash)
-        .await?;
+async fn verify_user_password(
+    user: &impl AuthUser,
+    password: &str,
+    config: &EmailPasswordConfig,
+    ctx: &AuthContext<impl better_auth_core::AuthSchema>,
+) -> AuthResult<()> {
+    let stored_hash = load_credential_password_hash(user, ctx).await?;
+    password_utils::verify_password(config.password_hasher.as_ref(), password, &stored_hash).await
+}
 
+/// Shared sign-in finalization logic after user lookup and credential verification.
+async fn finalize_sign_in_with_user_core(
+    user: impl AuthUser,
+    email_verification: Option<&EmailVerificationPlugin>,
+    callback_url: Option<&str>,
+    meta: &RequestMeta,
+    ctx: &AuthContext<impl better_auth_core::AuthSchema>,
+) -> AuthResult<SignInCoreResult<UserView>> {
     // Check if 2FA is enabled
     if user.two_factor_enabled() {
         let pending_token = format!("2fa_{}", uuid::Uuid::new_v4());
@@ -537,10 +545,10 @@ pub(crate) async fn sign_in_core(
         .await?
         .ok_or(AuthError::InvalidCredentials)?;
 
-    sign_in_with_user_core(
+    verify_user_password(&user, &body.password, config, ctx).await?;
+
+    finalize_sign_in_with_user_core(
         user,
-        &body.password,
-        config,
         email_verification,
         body.callback_url.as_deref(),
         meta,
@@ -570,26 +578,12 @@ pub(crate) async fn sign_in_username_core(
         return Err(SignInUsernameFailure::InvalidUsernameOrPassword);
     };
 
-    let stored_hash = ctx
-        .database
-        .get_user_accounts(&user.id())
+    verify_user_password(&user, &body.password, config, ctx)
         .await
-        .map_err(SignInUsernameFailure::Auth)?
-        .into_iter()
-        .find(|account| account.provider_id() == "credential" && account.password().is_some())
-        .and_then(|account| account.password().map(str::to_string))
-        .ok_or(SignInUsernameFailure::InvalidUsernameOrPassword)?;
-
-    password_utils::verify_password(
-        config.password_hasher.as_ref(),
-        &body.password,
-        &stored_hash,
-    )
-    .await
-    .map_err(|error| match error {
-        AuthError::InvalidCredentials => SignInUsernameFailure::InvalidUsernameOrPassword,
-        other => SignInUsernameFailure::Auth(other),
-    })?;
+        .map_err(|error| match error {
+            AuthError::InvalidCredentials => SignInUsernameFailure::InvalidUsernameOrPassword,
+            other => SignInUsernameFailure::Auth(other),
+        })?;
 
     if let Some(ev) = email_verification
         && ev.is_verification_required()
@@ -607,10 +601,8 @@ pub(crate) async fn sign_in_username_core(
         return Err(SignInUsernameFailure::EmailNotVerified);
     }
 
-    sign_in_with_user_core(
+    finalize_sign_in_with_user_core(
         user,
-        &body.password,
-        config,
         email_verification,
         body.callback_url.as_deref(),
         meta,
@@ -693,6 +685,7 @@ mod tests {
     use better_auth_core::config::AuthConfig;
     use std::collections::HashMap;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     type TestSchema =
         better_auth_seaorm::store::__private_test_support::bundled_schema::BundledSchema;
@@ -862,5 +855,68 @@ mod tests {
         );
         let err = plugin.handle_sign_in(&bad_req, &ctx).await.unwrap_err();
         assert_eq!(err.to_string(), AuthError::InvalidCredentials.to_string());
+    }
+
+    // Upstream reference: packages/better-auth/src/plugins/username/index.ts :: sign-in path verifies the password once before creating a session; adapted to ensure the Rust username path does not duplicate expensive password verification.
+    #[tokio::test]
+    async fn test_sign_in_username_verifies_password_once() {
+        struct CountingHasher {
+            verify_calls: Arc<AtomicUsize>,
+        }
+
+        #[async_trait]
+        impl PasswordHasher for CountingHasher {
+            async fn hash(&self, password: &str) -> AuthResult<String> {
+                Ok(format!("hashed:{password}"))
+            }
+
+            async fn verify(&self, hash: &str, password: &str) -> AuthResult<bool> {
+                self.verify_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(hash == format!("hashed:{password}"))
+            }
+        }
+
+        let verify_calls = Arc::new(AtomicUsize::new(0));
+        let hasher: Arc<dyn PasswordHasher> = Arc::new(CountingHasher {
+            verify_calls: verify_calls.clone(),
+        });
+        let plugin = EmailPasswordPlugin::new().password_hasher(hasher);
+        let ctx = create_test_context().await;
+
+        let signup_body = serde_json::json!({
+            "email": "username-counter@example.com",
+            "password": "Password123!",
+            "name": "Counter User",
+            "username": "Counter_User",
+        });
+        let signup_req = AuthRequest::from_parts(
+            HttpMethod::Post,
+            "/sign-up/email".to_string(),
+            HashMap::new(),
+            Some(signup_body.to_string().into_bytes()),
+            HashMap::new(),
+        );
+        let signup_response = plugin.handle_sign_up(&signup_req, &ctx).await.unwrap();
+        assert_eq!(signup_response.status, 200);
+
+        verify_calls.store(0, Ordering::SeqCst);
+
+        let signin_body = serde_json::json!({
+            "username": "COUNTER_USER",
+            "password": "Password123!",
+        });
+        let signin_req = AuthRequest::from_parts(
+            HttpMethod::Post,
+            "/sign-in/username".to_string(),
+            HashMap::new(),
+            Some(signin_body.to_string().into_bytes()),
+            HashMap::new(),
+        );
+        let signin_response = plugin
+            .handle_sign_in_username(&signin_req, &ctx)
+            .await
+            .unwrap();
+        assert_eq!(signin_response.status, 200);
+        assert_eq!(verify_calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/api/src/plugins/email_password.rs
+++ b/crates/api/src/plugins/email_password.rs
@@ -118,6 +118,16 @@ pub(crate) struct SignInUsernameRequest {
     callback_url: Option<String>,
 }
 
+#[derive(Debug, Deserialize, Validate)]
+struct IsUsernameAvailableRequest {
+    username: String,
+}
+
+#[derive(Debug, Serialize)]
+struct IsUsernameAvailableResponse {
+    available: bool,
+}
+
 #[derive(Debug, Serialize)]
 pub(crate) struct SignUpResponse<U: Serialize> {
     token: Option<String>,
@@ -379,6 +389,51 @@ impl EmailPasswordPlugin {
             }
             Err(SignInUsernameFailure::Auth(error)) => Err(error),
         }
+    }
+
+    async fn handle_is_username_available(
+        &self,
+        req: &AuthRequest,
+        ctx: &AuthContext<impl better_auth_core::AuthSchema>,
+    ) -> AuthResult<AuthResponse> {
+        let body: IsUsernameAvailableRequest = match better_auth_core::validate_request_body(req) {
+            Ok(v) => v,
+            Err(resp) => return Ok(resp),
+        };
+
+        match validate_username(&body.username) {
+            Ok(()) => {}
+            Err(UsernameValidationError::TooShort) => {
+                return username_error_response(
+                    422,
+                    "USERNAME_TOO_SHORT",
+                    MESSAGE_USERNAME_TOO_SHORT,
+                );
+            }
+            Err(UsernameValidationError::TooLong) => {
+                return username_error_response(
+                    422,
+                    "USERNAME_IS_TOO_LONG",
+                    MESSAGE_USERNAME_TOO_LONG,
+                );
+            }
+            Err(UsernameValidationError::Invalid) => {
+                return username_error_response(
+                    422,
+                    "USERNAME_IS_INVALID",
+                    MESSAGE_INVALID_USERNAME,
+                );
+            }
+        }
+
+        let normalized = normalize_username(&body.username);
+        let user = ctx.database.get_user_by_username(&normalized).await?;
+        let available = user.is_none();
+
+        Ok(AuthResponse::json(
+            200,
+            &IsUsernameAvailableResponse { available },
+        )?)
     }
 }
 
@@ -687,6 +742,7 @@ impl<S: better_auth_core::AuthSchema> AuthPlugin<S> for EmailPasswordPlugin {
         let mut routes = vec![
             AuthRoute::post("/sign-in/email", "sign_in_email"),
             AuthRoute::post("/sign-in/username", "sign_in_username"),
+            AuthRoute::post("/is-username-available", "is_username_available"),
         ];
 
         if self.config.enable_signup {
@@ -708,6 +764,9 @@ impl<S: better_auth_core::AuthSchema> AuthPlugin<S> for EmailPasswordPlugin {
             (HttpMethod::Post, "/sign-in/email") => Ok(Some(self.handle_sign_in(req, ctx).await?)),
             (HttpMethod::Post, "/sign-in/username") => {
                 Ok(Some(self.handle_sign_in_username(req, ctx).await?))
+            }
+            (HttpMethod::Post, "/is-username-available") => {
+                Ok(Some(self.handle_is_username_available(req, ctx).await?))
             }
             _ => Ok(None),
         }
@@ -964,5 +1023,121 @@ mod tests {
             .unwrap();
         assert_eq!(signin_response.status, 200);
         assert_eq!(verify_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_is_username_available_route_registered() {
+        let plugin = EmailPasswordPlugin::new();
+        let routes =
+            <EmailPasswordPlugin as better_auth_core::AuthPlugin<TestSchema>>::routes(&plugin);
+        assert!(
+            routes.iter().any(|r| r.path == "/is-username-available"),
+            "route /is-username-available should be registered"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_is_username_available_fresh() {
+        let plugin = EmailPasswordPlugin::new();
+        let ctx = create_test_context().await;
+
+        let body = serde_json::json!({ "username": "fresh_user" });
+        let req = AuthRequest::from_parts(
+            HttpMethod::Post,
+            "/is-username-available".to_string(),
+            HashMap::new(),
+            Some(body.to_string().into_bytes()),
+            HashMap::new(),
+        );
+        let response = plugin
+            .handle_is_username_available(&req, &ctx)
+            .await
+            .unwrap();
+        assert_eq!(response.status, 200);
+        let json: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(json["available"], true);
+    }
+
+    #[tokio::test]
+    async fn test_is_username_available_taken() {
+        let plugin = EmailPasswordPlugin::new();
+        let ctx = create_test_context().await;
+
+        // Sign up a user with a username
+        let signup_body = serde_json::json!({
+            "name": "Taken User",
+            "email": "taken@example.com",
+            "password": "Password123!",
+            "username": "taken_user",
+        });
+        let signup_req = AuthRequest::from_parts(
+            HttpMethod::Post,
+            "/sign-up/email".to_string(),
+            HashMap::new(),
+            Some(signup_body.to_string().into_bytes()),
+            HashMap::new(),
+        );
+        let resp = plugin.handle_sign_up(&signup_req, &ctx).await.unwrap();
+        assert_eq!(resp.status, 200);
+
+        let body = serde_json::json!({ "username": "taken_user" });
+        let req = AuthRequest::from_parts(
+            HttpMethod::Post,
+            "/is-username-available".to_string(),
+            HashMap::new(),
+            Some(body.to_string().into_bytes()),
+            HashMap::new(),
+        );
+        let response = plugin
+            .handle_is_username_available(&req, &ctx)
+            .await
+            .unwrap();
+        assert_eq!(response.status, 200);
+        let json: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(json["available"], false);
+    }
+
+    #[tokio::test]
+    async fn test_is_username_available_too_short() {
+        let plugin = EmailPasswordPlugin::new();
+        let ctx = create_test_context().await;
+
+        let body = serde_json::json!({ "username": "ab" });
+        let req = AuthRequest::from_parts(
+            HttpMethod::Post,
+            "/is-username-available".to_string(),
+            HashMap::new(),
+            Some(body.to_string().into_bytes()),
+            HashMap::new(),
+        );
+        let response = plugin
+            .handle_is_username_available(&req, &ctx)
+            .await
+            .unwrap();
+        assert_eq!(response.status, 422);
+        let json: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(json["code"], "USERNAME_TOO_SHORT");
+    }
+
+    #[tokio::test]
+    async fn test_is_username_available_invalid_chars() {
+        let plugin = EmailPasswordPlugin::new();
+        let ctx = create_test_context().await;
+
+        let body = serde_json::json!({ "username": "bad user!" });
+        let req = AuthRequest::from_parts(
+            HttpMethod::Post,
+            "/is-username-available".to_string(),
+            HashMap::new(),
+            Some(body.to_string().into_bytes()),
+            HashMap::new(),
+        );
+        let response = plugin
+            .handle_is_username_available(&req, &ctx)
+            .await
+            .unwrap();
+        assert_eq!(response.status, 422);
+        let json: serde_json::Value = serde_json::from_slice(&response.body).unwrap();
+        assert_eq!(json["code"], "USERNAME_IS_INVALID");
     }
 }

--- a/crates/api/src/plugins/helpers.rs
+++ b/crates/api/src/plugins/helpers.rs
@@ -3,7 +3,7 @@
 //! Extracted to avoid duplicating common patterns across plugins (DRY).
 
 use better_auth_core::entity::{AuthAccount, AuthApiKey, AuthUser};
-use better_auth_core::{AuthContext, AuthError, AuthResult};
+use better_auth_core::{AuthContext, AuthError, AuthResult, CreateUser};
 
 /// Convert an `expiresIn` value (**seconds** from now) into an RFC 3339
 /// `expires_at` timestamp string.
@@ -75,4 +75,22 @@ pub async fn user_has_password(
     user: &impl AuthUser,
 ) -> AuthResult<bool> {
     Ok(get_credential_password_hash(ctx, user).await?.is_some())
+}
+
+/// Apply the configured default admin role to a new user when the caller
+/// didn't set an explicit role.
+pub fn apply_default_role(
+    ctx: &AuthContext<impl better_auth_core::AuthSchema>,
+    create_user: &mut CreateUser,
+) {
+    if create_user.role.is_some() {
+        return;
+    }
+
+    if let Some(default_role) = ctx
+        .get_metadata("admin.default_role")
+        .and_then(|value| value.as_str())
+    {
+        create_user.role = Some(default_role.to_string());
+    }
 }

--- a/crates/api/src/plugins/oauth/handlers.rs
+++ b/crates/api/src/plugins/oauth/handlers.rs
@@ -30,6 +30,8 @@ use super::types::{
 };
 use better_auth_core::wire::{SessionView, UserView};
 
+use crate::plugins::helpers::apply_default_role;
+
 // ---------------------------------------------------------------------------
 // Shared helpers (DRY)
 // ---------------------------------------------------------------------------
@@ -818,6 +820,7 @@ async fn process_oauth_sign_in(
             .with_email(user_info.email.to_lowercase())
             .with_name(user_info.name.as_deref().unwrap_or(&user_info.email))
             .with_email_verified(user_info.email_verified);
+        apply_default_role(ctx, &mut create_user);
         create_user.image = user_info.image.clone();
 
         let created_user = ctx

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -19,41 +19,105 @@ pub mod core_paths {
     pub const CHANGE_EMAIL: &str = "/change-email";
     pub const DELETE_USER_CALLBACK: &str = "/delete-user/callback";
 
-    /// Build the HTML error page returned by `GET /error`.
-    ///
-    /// Matches the TS better-auth error page that displays the error code.
-    pub fn error_page_html(error_code: &str) -> String {
-        // Whitelist error codes to prevent reflected XSS.
-        // Matches the TS sanitization: /^[A-Za-z0-9_'-]+$/
-        let safe_code = if !error_code.is_empty()
-            && error_code
+    fn valid_error_code(input: &str) -> bool {
+        !input.is_empty()
+            && input
                 .chars()
                 .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '\'')
-        {
+    }
+
+    fn is_preserved_entity(input: &str) -> bool {
+        input.starts_with("amp;")
+            || input.starts_with("lt;")
+            || input.starts_with("gt;")
+            || input.starts_with("quot;")
+            || input.starts_with("#39;")
+            || input.strip_prefix("#x").is_some_and(|hex| {
+                let Some(hex) = hex.strip_suffix(';') else {
+                    return false;
+                };
+                !hex.is_empty() && hex.chars().all(|c| c.is_ascii_hexdigit())
+            })
+            || input.strip_prefix('#').is_some_and(|digits| {
+                let Some(digits) = digits.strip_suffix(';') else {
+                    return false;
+                };
+                !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit())
+            })
+    }
+
+    fn sanitize_html(input: &str) -> String {
+        let mut out = String::with_capacity(input.len());
+
+        for (idx, ch) in input.char_indices() {
+            match ch {
+                '<' => out.push_str("&lt;"),
+                '>' => out.push_str("&gt;"),
+                '"' => out.push_str("&quot;"),
+                '\'' => out.push_str("&#39;"),
+                '&' => {
+                    let rest = &input[idx + ch.len_utf8()..];
+                    if is_preserved_entity(rest) {
+                        out.push('&');
+                    } else {
+                        out.push_str("&amp;");
+                    }
+                }
+                _ => out.push(ch),
+            }
+        }
+
+        out
+    }
+
+    fn default_error_description(code: &str) -> String {
+        format!(
+            "We encountered an unexpected error. Please try again or return to the home page. If you're a developer, you can find more information about the error <a href='https://better-auth.com/docs/reference/errors/{code}' target='_blank' rel=\"noopener noreferrer\" style='color: var(--foreground); text-decoration: underline;'>here</a>."
+        )
+    }
+
+    /// Build the HTML error page returned by `GET /error`.
+    ///
+    /// Matches the current TS better-auth error page renderer.
+    pub fn error_page_html(error_code: &str) -> String {
+        error_page_html_with_description(error_code, None)
+    }
+
+    /// Build the HTML error page returned by `GET /error`, optionally
+    /// overriding the default description text.
+    pub fn error_page_html_with_description(
+        error_code: &str,
+        error_description: Option<&str>,
+    ) -> String {
+        let safe_code = if valid_error_code(error_code) {
             error_code
         } else {
             "UNKNOWN"
         };
-        let ask_ai_query = format!("What%20does%20the%20error%20code%20{}%20mean%3F", safe_code);
+        let description = error_description
+            .map(sanitize_html)
+            .unwrap_or_else(|| default_error_description(safe_code));
+        let ask_ai_query = format!("What%20does%20the%20error%20code%20{safe_code}%20mean%3F");
 
-        r#"<!DOCTYPE html>
+        format!(
+            r#"<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Error</title>
     <style>
-      * {
+      * {{
         box-sizing: border-box;
-      }
-      body {
+      }}
+      body {{
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
         background: var(--background);
         color: var(--foreground);
         margin: 0;
-      }
+      }}
       :root,
-      :host {
+      :host {{
         --spacing: 0.25rem;
         --container-md: 28rem;
         --text-sm: 0.875rem;
@@ -79,9 +143,9 @@ pub mod core_paths {
         --destructive: oklch(0.55 0.15 25.723);
         --muted-foreground: oklch(0.545 0 0);
         --corner-border: #404040;
-      }
+      }}
 
-      button, .btn {
+      button, .btn {{
         cursor: pointer;
         background: none;
         border: none;
@@ -89,22 +153,14 @@ pub mod core_paths {
         font: inherit;
         transition: all var(--default-transition-duration)
           var(--default-transition-timing-function);
-      }
-      button:hover, .btn:hover {
+      }}
+      button:hover, .btn:hover {{
         opacity: 0.8;
-      }
+      }}
 
-      h1 {
-        margin: 0;
-        font-size: inherit;
-        font-weight: inherit;
-        color: inherit;
-        letter-spacing: -0.02em;
-      }
-
-      @media (prefers-color-scheme: dark) {
+      @media (prefers-color-scheme: dark) {{
         :root,
-        :host {
+        :host {{
           --primary: white;
           --primary-foreground: black;
           --background: oklch(0.15 0 0);
@@ -113,21 +169,21 @@ pub mod core_paths {
           --destructive: oklch(0.65 0.15 25.723);
           --muted-foreground: oklch(0.65 0 0);
           --corner-border: #a0a0a0;
-        }
-      }
-      @media (max-width: 640px) {
-        :root, :host {
+        }}
+      }}
+      @media (max-width: 640px) {{
+        :root, :host {{
           --text-6xl: 2.5rem;
           --text-2xl: 1.25rem;
           --text-sm: 0.8125rem;
-        }
-      }
-      @media (max-width: 480px) {
-        :root, :host {
+        }}
+      }}
+      @media (max-width: 480px) {{
+        :root, :host {{
           --text-6xl: 2rem;
           --text-2xl: 1.125rem;
-        }
-      }
+        }}
+      }}
     </style>
   </head>
   <body style="width: 100vw; min-height: 100vh; overflow-x: hidden; overflow-y: auto;">
@@ -239,12 +295,19 @@ pub mod core_paths {
                 display: inline-block;
                 border: 2px solid var(--destructive);
                 padding: 0.375rem 1rem;
-                font-size: var(--text-6xl);
-                font-weight: var(--font-weight-semibold);
-                color: var(--foreground);
               "
             >
-              <h1>ERROR</h1>
+              <h1
+                style="
+                  font-size: var(--text-6xl);
+                  font-weight: var(--font-weight-semibold);
+                  color: var(--foreground);
+                  letter-spacing: -0.02em;
+                  margin: 0;
+                "
+              >
+                ERROR
+              </h1>
             </div>
             <div
               style="
@@ -272,18 +335,34 @@ pub mod core_paths {
             style="
                 display: inline-flex;
                 align-items: center;
+                gap: 0.5rem;
                 border: 2px solid var(--border);
                 background-color: var(--muted);
                 padding: 0.375rem 0.75rem;
                 margin: 0 0 1rem;
                 flex-wrap: wrap;
                 justify-content: center;
+            "
+            >
+            <span
+                style="
+                font-size: 0.75rem;
+                color: var(--muted-foreground);
+                font-weight: var(--font-weight-semibold);
+                "
+            >
+                CODE:
+            </span>
+            <span
+                style="
                 font-size: var(--text-sm);
                 font-family: var(--default-mono-font-family, monospace);
                 color: var(--foreground);
-            "
+                word-break: break-all;
+                "
             >
-                CODE: __CODE__
+                {safe_code}
+            </span>
             </div>
 
           <p
@@ -296,7 +375,7 @@ pub mod core_paths {
               text-wrap: pretty;
             "
           >
-            We encountered an unexpected error. Please try again or return to the home page. If you're a developer, you can find more information about the error <a href='https://better-auth.com/docs/reference/errors/__CODE__' target='_blank' rel="noopener noreferrer" style='color: var(--foreground); text-decoration: underline;'>here</a>.
+            {description}
           </p>
         </div>
 
@@ -330,7 +409,7 @@ pub mod core_paths {
             </div>
           </a>
           <a
-            href="https://better-auth.com/docs/reference/errors/__CODE__?askai=__ASK_AI__"
+            href="https://better-auth.com/docs/reference/errors/{safe_code}?askai={ask_ai_query}"
             target="_blank"
             rel="noopener noreferrer"
             style="
@@ -356,8 +435,7 @@ pub mod core_paths {
     </div>
   </body>
 </html>"#
-            .replace("__CODE__", safe_code)
-            .replace("__ASK_AI__", &ask_ai_query)
+        )
     }
 }
 

--- a/crates/core/src/test_store.rs
+++ b/crates/core/src/test_store.rs
@@ -80,6 +80,7 @@ impl UserStore<BundledSchema> for MemoryStore {
         let id = create_user
             .id
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let username = create_user.username.map(|username| username.to_lowercase());
         let user = UserView {
             id: id.clone(),
             name: create_user.name,
@@ -88,7 +89,7 @@ impl UserStore<BundledSchema> for MemoryStore {
             image: create_user.image,
             created_at: now,
             updated_at: now,
-            username: create_user.username,
+            username,
             display_username: create_user.display_username,
             two_factor_enabled: false,
             role: create_user.role,
@@ -125,12 +126,33 @@ impl UserStore<BundledSchema> for MemoryStore {
     }
 
     async fn get_user_by_username(&self, username: &str) -> AuthResult<Option<UserView>> {
-        Ok(self
-            .lock()
+        let normalized = username.to_lowercase();
+        let users = self.lock();
+
+        Ok(users
             .users
             .values()
-            .find(|user| user.username.as_deref() == Some(username))
-            .cloned())
+            .find(|user| user.username.as_deref() == Some(&normalized))
+            .cloned()
+            .or_else(|| {
+                if normalized != username {
+                    users
+                        .users
+                        .values()
+                        .find(|user| user.username.as_deref() == Some(username))
+                        .cloned()
+                } else {
+                    None
+                }
+            })
+            .or_else(|| {
+                users.users.values().find_map(|user| {
+                    user.username
+                        .as_deref()
+                        .filter(|stored| stored.eq_ignore_ascii_case(username))
+                        .map(|_| user.clone())
+                })
+            }))
     }
 
     async fn update_user(&self, id: &str, update: UpdateUser) -> AuthResult<UserView> {
@@ -149,7 +171,7 @@ impl UserStore<BundledSchema> for MemoryStore {
             user.email_verified = email_verified;
         }
         if let Some(username) = update.username {
-            user.username = Some(username);
+            user.username = Some(username.to_lowercase());
         }
         if let Some(display_username) = update.display_username {
             user.display_username = Some(display_username);

--- a/crates/core/src/test_store.rs
+++ b/crates/core/src/test_store.rs
@@ -127,32 +127,12 @@ impl UserStore<BundledSchema> for MemoryStore {
 
     async fn get_user_by_username(&self, username: &str) -> AuthResult<Option<UserView>> {
         let normalized = username.to_lowercase();
-        let users = self.lock();
-
-        Ok(users
+        Ok(self
+            .lock()
             .users
             .values()
             .find(|user| user.username.as_deref() == Some(&normalized))
-            .cloned()
-            .or_else(|| {
-                if normalized != username {
-                    users
-                        .users
-                        .values()
-                        .find(|user| user.username.as_deref() == Some(username))
-                        .cloned()
-                } else {
-                    None
-                }
-            })
-            .or_else(|| {
-                users.users.values().find_map(|user| {
-                    user.username
-                        .as_deref()
-                        .filter(|stored| stored.eq_ignore_ascii_case(username))
-                        .map(|_| user.clone())
-                })
-            }))
+            .cloned())
     }
 
     async fn update_user(&self, id: &str, update: UpdateUser) -> AuthResult<UserView> {

--- a/crates/core/src/utils/mod.rs
+++ b/crates/core/src/utils/mod.rs
@@ -3,3 +3,4 @@
 pub mod cookie_utils;
 pub(crate) mod email;
 pub mod password;
+pub mod username;

--- a/crates/core/src/utils/username.rs
+++ b/crates/core/src/utils/username.rs
@@ -1,0 +1,53 @@
+//! Shared username normalization and validation helpers.
+
+pub const USERNAME_MIN_LENGTH: usize = 3;
+pub const USERNAME_MAX_LENGTH: usize = 30;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsernameValidationError {
+    TooShort,
+    TooLong,
+    Invalid,
+}
+
+pub fn normalize_username(username: &str) -> String {
+    username.to_lowercase()
+}
+
+pub fn validate_username(username: &str) -> Result<(), UsernameValidationError> {
+    if username.len() < USERNAME_MIN_LENGTH {
+        return Err(UsernameValidationError::TooShort);
+    }
+
+    if username.len() > USERNAME_MAX_LENGTH {
+        return Err(UsernameValidationError::TooLong);
+    }
+
+    if username
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '.')
+    {
+        Ok(())
+    } else {
+        Err(UsernameValidationError::Invalid)
+    }
+}
+
+pub fn normalize_username_fields(
+    mut username: Option<String>,
+    mut display_username: Option<String>,
+) -> (Option<String>, Option<String>) {
+    if username.is_some() && display_username.is_none() {
+        display_username = username.clone();
+    }
+
+    if display_username.is_some() && username.is_none() {
+        username = display_username.clone();
+    }
+
+    if let Some(username_value) = username.as_mut() {
+        *username_value = normalize_username(username_value);
+    }
+
+    (username, display_username)
+}

--- a/crates/core/src/wire.rs
+++ b/crates/core/src/wire.rs
@@ -31,9 +31,8 @@ pub struct UserView {
     pub created_at: DateTime<Utc>,
     #[serde(rename = "updatedAt")]
     pub updated_at: DateTime<Utc>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
-    #[serde(rename = "displayUsername", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "displayUsername")]
     pub display_username: Option<String>,
     #[serde(rename = "twoFactorEnabled", skip_serializing_if = "is_false", default)]
     pub two_factor_enabled: bool,

--- a/crates/core/src/wire.rs
+++ b/crates/core/src/wire.rs
@@ -65,12 +65,9 @@ pub struct SessionView {
     pub user_agent: Option<String>,
     #[serde(rename = "userId")]
     pub user_id: String,
-    #[serde(rename = "impersonatedBy", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "impersonatedBy")]
     pub impersonated_by: Option<String>,
-    #[serde(
-        rename = "activeOrganizationId",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "activeOrganizationId")]
     pub active_organization_id: Option<String>,
     #[serde(skip)]
     pub active: bool,

--- a/crates/seaorm/src/store/users.rs
+++ b/crates/seaorm/src/store/users.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use better_auth_core::entity::AuthUser;
 use chrono::Utc;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseTransaction, EntityTrait,
@@ -118,36 +117,11 @@ where
         let Some(col) = <S::User as SeaOrmUserModel>::username_column() else {
             return Ok(None);
         };
-        let normalized = username.to_lowercase();
-
-        if let Some(user) = <S::User as SeaOrmUserModel>::Entity::find()
-            .filter(col.eq(&normalized))
+        <S::User as SeaOrmUserModel>::Entity::find()
+            .filter(col.eq(username.to_lowercase()))
             .one(self.connection())
             .await
-            .map_err(map_db_err)?
-        {
-            return Ok(Some(user));
-        }
-
-        if normalized != username
-            && let Some(user) = <S::User as SeaOrmUserModel>::Entity::find()
-                .filter(col.eq(username))
-                .one(self.connection())
-                .await
-                .map_err(map_db_err)?
-        {
-            return Ok(Some(user));
-        }
-
-        Ok(<S::User as SeaOrmUserModel>::Entity::find()
-            .all(self.connection())
-            .await
-            .map_err(map_db_err)?
-            .into_iter()
-            .find(|user| {
-                user.username()
-                    .is_some_and(|stored| stored.eq_ignore_ascii_case(username))
-            }))
+            .map_err(map_db_err)
     }
 
     async fn update_user(&self, id: &str, mut update: UpdateUser) -> AuthResult<S::User> {

--- a/crates/seaorm/src/store/users.rs
+++ b/crates/seaorm/src/store/users.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use better_auth_core::entity::AuthUser;
 use chrono::Utc;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseTransaction, EntityTrait,
@@ -38,6 +39,9 @@ where
             {
                 return Err(cancelled_by_hook("user creation"));
             }
+        }
+        if let Some(username) = create_user.username.as_mut() {
+            *username = username.to_lowercase();
         }
         let now = Utc::now();
         let user_id = create_user
@@ -114,11 +118,36 @@ where
         let Some(col) = <S::User as SeaOrmUserModel>::username_column() else {
             return Ok(None);
         };
-        <S::User as SeaOrmUserModel>::Entity::find()
-            .filter(col.eq(username))
+        let normalized = username.to_lowercase();
+
+        if let Some(user) = <S::User as SeaOrmUserModel>::Entity::find()
+            .filter(col.eq(&normalized))
             .one(self.connection())
             .await
-            .map_err(map_db_err)
+            .map_err(map_db_err)?
+        {
+            return Ok(Some(user));
+        }
+
+        if normalized != username
+            && let Some(user) = <S::User as SeaOrmUserModel>::Entity::find()
+                .filter(col.eq(username))
+                .one(self.connection())
+                .await
+                .map_err(map_db_err)?
+        {
+            return Ok(Some(user));
+        }
+
+        Ok(<S::User as SeaOrmUserModel>::Entity::find()
+            .all(self.connection())
+            .await
+            .map_err(map_db_err)?
+            .into_iter()
+            .find(|user| {
+                user.username()
+                    .is_some_and(|stored| stored.eq_ignore_ascii_case(username))
+            }))
     }
 
     async fn update_user(&self, id: &str, mut update: UpdateUser) -> AuthResult<S::User> {
@@ -133,6 +162,9 @@ where
             {
                 return Err(cancelled_by_hook("user update"));
             }
+        }
+        if let Some(username) = update.username.as_mut() {
+            *username = username.to_lowercase();
         }
         let Some(model) = <S::User as SeaOrmUserModel>::Entity::find()
             .filter(<S::User as SeaOrmUserModel>::id_column().eq(user_id))

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -339,7 +339,11 @@ impl<S: AuthSchema> BetterAuth<S> {
                     .get("error")
                     .cloned()
                     .unwrap_or_else(|| "UNKNOWN".to_string());
-                let html = core_paths::error_page_html(&error_code);
+                let error_description = req.query.get("error_description").map(String::as_str);
+                let html = better_auth_core::config::core_paths::error_page_html_with_description(
+                    &error_code,
+                    error_description,
+                );
                 Ok(Some(AuthResponse::html(200, html)))
             }
             (HttpMethod::Get, core_paths::OPENAPI_SPEC) => {

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -1,9 +1,13 @@
 use std::sync::Arc;
 
+use better_auth_core::utils::username::{
+    UsernameValidationError, normalize_username_fields, validate_username,
+};
 use better_auth_core::{
     AuthConfig, AuthContext, AuthError, AuthInitContext, AuthPlugin, AuthRequest, AuthResponse,
-    AuthResult, AuthSchema, AuthStore, BeforeRequestAction, EmailProvider, HttpMethod, OkResponse,
-    OpenApiBuilder, OpenApiSpec, SessionManager, UpdateUser, UpdateUserRequest, core_paths,
+    AuthResult, AuthSchema, AuthStore, BeforeRequestAction, EmailProvider,
+    ErrorCodeMessageResponse, HttpMethod, OkResponse, OpenApiBuilder, OpenApiSpec, SessionManager,
+    UpdateUser, UpdateUserRequest, core_paths,
     entity::{AuthSession, AuthUser},
     hooks::{RequestHookContext, with_request_hook_context_value},
     middleware::{
@@ -11,6 +15,17 @@ use better_auth_core::{
         CsrfMiddleware, Middleware, RateLimitConfig, RateLimitMiddleware,
     },
 };
+
+fn username_error_response(status: u16, code: &str, message: &str) -> AuthResult<AuthResponse> {
+    AuthResponse::json(
+        status,
+        &ErrorCodeMessageResponse {
+            code: code.to_string(),
+            message: message.to_string(),
+        },
+    )
+    .map_err(AuthError::from)
+}
 
 pub struct BetterAuth<S: AuthSchema> {
     config: Arc<AuthConfig>,
@@ -394,11 +409,50 @@ impl<S: AuthSchema> BetterAuth<S> {
         let update_req: UpdateUserRequest =
             serde_json::from_value(serde_json::Value::Object(body.clone()))
                 .map_err(|e| AuthError::bad_request(format!("Invalid JSON: {}", e)))?;
+        let (username, display_username) =
+            normalize_username_fields(update_req.username, update_req.display_username);
+
+        if let Some(username) = username.as_deref() {
+            match validate_username(username) {
+                Ok(()) => {}
+                Err(UsernameValidationError::TooShort) => {
+                    return username_error_response(
+                        400,
+                        "USERNAME_TOO_SHORT",
+                        "Username is too short",
+                    );
+                }
+                Err(UsernameValidationError::TooLong) => {
+                    return username_error_response(
+                        400,
+                        "USERNAME_IS_TOO_LONG",
+                        "Username is too long",
+                    );
+                }
+                Err(UsernameValidationError::Invalid) => {
+                    return username_error_response(
+                        400,
+                        "USERNAME_IS_INVALID",
+                        "Username is invalid",
+                    );
+                }
+            }
+
+            if let Some(existing_user) = self.store.get_user_by_username(username).await?
+                && existing_user.id() != current_user.id()
+            {
+                return username_error_response(
+                    400,
+                    "USERNAME_IS_ALREADY_TAKEN",
+                    "Username is already taken. Please try another.",
+                );
+            }
+        }
 
         let has_changes = update_req.name.is_some()
             || update_req.image.is_some()
-            || update_req.username.is_some()
-            || update_req.display_username.is_some()
+            || username.is_some()
+            || display_username.is_some()
             || update_req.role.is_some()
             || update_req.metadata.is_some();
         if !has_changes {
@@ -410,8 +464,8 @@ impl<S: AuthSchema> BetterAuth<S> {
             name: update_req.name,
             image: update_req.image,
             email_verified: None,
-            username: update_req.username,
-            display_username: update_req.display_username,
+            username,
+            display_username,
             role: update_req.role,
             banned: None,
             ban_reason: None,

--- a/tests/compatibility_tests.rs
+++ b/tests/compatibility_tests.rs
@@ -72,6 +72,7 @@ fn completed_phase_reference_surface(
         "/error",
         "/sign-up/email",
         "/sign-in/email",
+        "/sign-in/username",
         "/get-session",
         "/sign-out",
         "/list-sessions",
@@ -126,6 +127,12 @@ fn completed_phase_reference_surface(
     let _ = surface.insert(
         "/callback/{provider}".to_string(),
         HashSet::from(["get".to_string(), "post".to_string()]),
+    );
+    // The pinned TS runtime exposes `/sign-in/username` publicly when the
+    // username plugin is enabled, but the generated OpenAPI profile omits it.
+    let _ = surface.insert(
+        "/sign-in/username".to_string(),
+        HashSet::from(["post".to_string()]),
     );
 
     surface
@@ -351,6 +358,7 @@ async fn test_completed_phase_endpoints_present() {
         ("get", "/error"),
         ("post", "/sign-up/email"),
         ("post", "/sign-in/email"),
+        ("post", "/sign-in/username"),
         ("get", "/get-session"),
         ("post", "/sign-out"),
         ("post", "/update-user"),

--- a/tests/compatibility_tests.rs
+++ b/tests/compatibility_tests.rs
@@ -72,7 +72,6 @@ fn completed_phase_reference_surface(
         "/error",
         "/sign-up/email",
         "/sign-in/email",
-        "/sign-in/username",
         "/get-session",
         "/sign-out",
         "/list-sessions",

--- a/tests/compatibility_tests.rs
+++ b/tests/compatibility_tests.rs
@@ -127,10 +127,15 @@ fn completed_phase_reference_surface(
         "/callback/{provider}".to_string(),
         HashSet::from(["get".to_string(), "post".to_string()]),
     );
-    // The pinned TS runtime exposes `/sign-in/username` publicly when the
-    // username plugin is enabled, but the generated OpenAPI profile omits it.
+    // The pinned TS runtime exposes `/sign-in/username` and
+    // `/is-username-available` publicly when the username plugin is enabled,
+    // but the generated OpenAPI profile omits them.
     let _ = surface.insert(
         "/sign-in/username".to_string(),
+        HashSet::from(["post".to_string()]),
+    );
+    let _ = surface.insert(
+        "/is-username-available".to_string(),
         HashSet::from(["post".to_string()]),
     );
 
@@ -358,6 +363,7 @@ async fn test_completed_phase_endpoints_present() {
         ("post", "/sign-up/email"),
         ("post", "/sign-in/email"),
         ("post", "/sign-in/username"),
+        ("post", "/is-username-available"),
         ("get", "/get-session"),
         ("post", "/sign-out"),
         ("post", "/update-user"),

--- a/tests/compatibility_tests.rs
+++ b/tests/compatibility_tests.rs
@@ -503,8 +503,28 @@ async fn test_contract_error_endpoint() {
     let (status, body) = send_json_request(&auth, HttpMethod::Get, "/error", None).await;
     assert_eq!(status, 200);
     let html = body.as_str().expect("/error should return HTML text");
-    assert!(html.contains("<h1>ERROR</h1>"));
-    assert!(html.contains("CODE: UNKNOWN"));
+    // The HTML page uses inline-styled elements matching the TS template
+    // (not plain `<h1>ERROR</h1>` — both TS and Rust use styled tags).
+    assert!(
+        html.contains("<title>Error</title>"),
+        "error page should contain <title>Error</title>"
+    );
+    assert!(
+        html.contains("ERROR"),
+        "error page should contain ERROR heading"
+    );
+    assert!(
+        html.contains("UNKNOWN"),
+        "error page should contain the UNKNOWN error code"
+    );
+    assert!(
+        html.contains("CODE:"),
+        "error page should contain CODE: label"
+    );
+    assert!(
+        html.contains("Ask AI"),
+        "error page should contain Ask AI button"
+    );
 }
 
 /// POST /sign-up/email should return { token, user: { id, email, name, ... } }

--- a/tests/wire_compat_smoke_tests.rs
+++ b/tests/wire_compat_smoke_tests.rs
@@ -101,6 +101,89 @@ async fn wire_signout_clears_session_cookie() {
 }
 
 #[tokio::test]
+async fn wire_is_username_available_not_taken() {
+    let _lock = serial_lock().await;
+    if !ensure_reference_server_or_skip().await {
+        return;
+    }
+
+    let auth = create_default_test_auth().await;
+    let mut ref_client = RefClient::new();
+    let body = serde_json::json!({ "username": "fresh_user_xyz" });
+
+    let rust = rust_send(&auth, post_json("/is-username-available", body.clone())).await;
+    let reference = ref_client
+        .post_full("/is-username-available", &body)
+        .await
+        .unwrap_or_else(ref_error_response);
+
+    assert_report_pass(compare_full(
+        "POST /is-username-available (not taken)",
+        &rust,
+        &reference,
+    ));
+}
+
+#[tokio::test]
+async fn wire_is_username_available_taken() {
+    let _lock = serial_lock().await;
+    if !ensure_reference_server_or_skip().await {
+        return;
+    }
+
+    let auth = create_default_test_auth().await;
+    let mut ref_client = RefClient::new();
+
+    // Sign up a user with a username on both servers
+    let email = unique_email("wire_uname_taken");
+    let signup_body = serde_json::json!({
+        "name": "Username User",
+        "email": email,
+        "password": "password123",
+        "username": "taken_user",
+    });
+    let _ = rust_send(&auth, post_json("/sign-up/email", signup_body.clone())).await;
+    let _ = ref_client.post_full("/sign-up/email", &signup_body).await;
+
+    let body = serde_json::json!({ "username": "taken_user" });
+    let rust = rust_send(&auth, post_json("/is-username-available", body.clone())).await;
+    let reference = ref_client
+        .post_full("/is-username-available", &body)
+        .await
+        .unwrap_or_else(ref_error_response);
+
+    assert_report_pass(compare_full(
+        "POST /is-username-available (taken)",
+        &rust,
+        &reference,
+    ));
+}
+
+#[tokio::test]
+async fn wire_is_username_available_too_short() {
+    let _lock = serial_lock().await;
+    if !ensure_reference_server_or_skip().await {
+        return;
+    }
+
+    let auth = create_default_test_auth().await;
+    let mut ref_client = RefClient::new();
+    let body = serde_json::json!({ "username": "ab" });
+
+    let rust = rust_send(&auth, post_json("/is-username-available", body.clone())).await;
+    let reference = ref_client
+        .post_full("/is-username-available", &body)
+        .await
+        .unwrap_or_else(ref_error_response);
+
+    assert_report_pass(compare_full(
+        "POST /is-username-available (too short)",
+        &rust,
+        &reference,
+    ));
+}
+
+#[tokio::test]
 async fn wire_list_sessions_no_auth() {
     let _lock = serial_lock().await;
     if !ensure_reference_server_or_skip().await {


### PR DESCRIPTION
## Summary

This PR aligns the currently exposed phase 0-9 client contract with the pinned TypeScript runtime and folds the existing username sign-in surface into phase 0.

## What changed

- aligned shared session wire fields with TS nullability
- aligned the Rust `/error` page output with the current TS renderer
- fixed default-role behavior for Rust-owned user creation paths used by social sign-in
- fixed compat server reset endpoints so full client sweeps do not leak state across scenarios
- aligned username sign-in with the upstream username plugin surface that we already expose
- folded `/sign-in/username` into phase 0 in the roadmap and completed-surface checks
- updated phase 0 client compat coverage to exercise username sign-in against the real TS client
- kept the device authorization compat check stable at the client-visible contract level

## Why

The repo already exposed routes beyond the documented completed surface, and some of those routes were not yet aligned with the upstream TS behavior. The biggest sources of drift were:

- omitted nullable fields in user/session responses
- outdated error page markup
- mismatched social/default-role behavior
- cross-scenario state leakage in the compat harness
- username sign-in not being treated as part of phase 0 despite already existing in the Rust surface

## Impact

- phase 0 now explicitly includes username sign-in
- the phase 0-9 client compat sweep passes end to end
- the roadmap now reflects the exposed route ordering more accurately

## Validation

- `cargo test --test client_compat_tests phase0_client_compat -- --ignored --nocapture`
- `cargo test --test client_compat_tests full_client_compat -- --ignored --nocapture`
- `cargo test --test compatibility_tests test_completed_phase_surface_matches_reference_exactly -- --nocapture`
- `cargo test --test compatibility_tests test_completed_phase_endpoints_present -- --nocapture`
- `cargo test --workspace --lib`
- `cargo clippy --workspace`
- `cargo clippy --workspace --features axum`
