### PR TITLE
feat(admin): align phase 10 stateful flows

### DIFF
--- a/compat-tests/README.md
+++ b/compat-tests/README.md
@@ -57,6 +57,7 @@ bun test tests/phase6
 bun test tests/phase7
 bun test tests/phase8
 bun test tests/phase9
+bun test tests/phase10
 ```
 
 ### `compat-tests/rust-server/`
@@ -78,6 +79,7 @@ cargo test --test client_compat_tests phase6_client_compat -- --ignored --nocapt
 cargo test --test client_compat_tests phase7_client_compat -- --ignored --nocapture
 cargo test --test client_compat_tests phase8_client_compat -- --ignored --nocapture
 cargo test --test client_compat_tests phase9_client_compat -- --ignored --nocapture
+cargo test --test client_compat_tests phase10_client_compat -- --ignored --nocapture
 cargo test --test client_compat_tests full_client_compat -- --ignored --nocapture
 ```
 
@@ -100,5 +102,6 @@ bash compat-tests/client-tests/run-against-both.sh phase6
 bash compat-tests/client-tests/run-against-both.sh phase7
 bash compat-tests/client-tests/run-against-both.sh phase8
 bash compat-tests/client-tests/run-against-both.sh phase9
+bash compat-tests/client-tests/run-against-both.sh phase10
 bash compat-tests/client-tests/run-against-both.sh all
 ```

--- a/compat-tests/client-tests/package.json
+++ b/compat-tests/client-tests/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "bun test tests/phase0 tests/phase1 tests/phase2 tests/phase3 tests/phase4 tests/phase5 tests/phase6 tests/phase7 tests/phase8 tests/phase9",
+    "test": "bun test tests/phase0 tests/phase1 tests/phase2 tests/phase3 tests/phase4 tests/phase5 tests/phase6 tests/phase7 tests/phase8 tests/phase9 tests/phase10",
     "test:phase0": "bun test tests/phase0",
     "test:phase1": "bun test tests/phase1",
     "test:phase2": "bun test tests/phase2",
@@ -13,7 +13,8 @@
     "test:phase6": "bun test tests/phase6",
     "test:phase7": "bun test tests/phase7",
     "test:phase8": "bun test tests/phase8",
-    "test:phase9": "bun test tests/phase9"
+    "test:phase9": "bun test tests/phase9",
+    "test:phase10": "bun test tests/phase10"
   },
   "dependencies": {
     "@better-auth/passkey": "1.4.19",

--- a/compat-tests/client-tests/run-against-both.sh
+++ b/compat-tests/client-tests/run-against-both.sh
@@ -5,7 +5,7 @@ phase="all"
 
 for arg in "$@"; do
   case "$arg" in
-    phase0|phase1|phase2|phase3|phase4|phase5|phase6|phase7|phase8|phase9|all) phase="$arg" ;;
+    phase0|phase1|phase2|phase3|phase4|phase5|phase6|phase7|phase8|phase9|phase10|all) phase="$arg" ;;
     --skip-build) ;;
     *) echo "Unknown argument: $arg" >&2; exit 1 ;;
   esac
@@ -22,6 +22,7 @@ case "$phase" in
   phase7) test_name="phase7_client_compat" ;;
   phase8) test_name="phase8_client_compat" ;;
   phase9) test_name="phase9_client_compat" ;;
+  phase10) test_name="phase10_client_compat" ;;
   all) test_name="full_client_compat" ;;
 esac
 

--- a/compat-tests/client-tests/tests/phase10/admin-stateful.test.ts
+++ b/compat-tests/client-tests/tests/phase10/admin-stateful.test.ts
@@ -1,0 +1,218 @@
+import { compatScenario } from "../../support/scenario";
+import { adminActor, signUpAndPromoteAdmin } from "../phase9/helpers";
+
+function extractState(url: string | undefined) {
+  if (!url) {
+    throw new Error("missing OAuth URL");
+  }
+  const state = new URL(url).searchParams.get("state");
+  if (!state) {
+    throw new Error("missing OAuth state");
+  }
+  return state;
+}
+
+function summarizeLocation(location: string | null) {
+  if (!location) {
+    throw new Error("missing redirect location");
+  }
+  const url = new URL(location, "http://compat.local");
+  return {
+    pathname: url.pathname,
+    params: Object.fromEntries(url.searchParams.entries()),
+  };
+}
+
+compatScenario("admin ban, unban, and user-session routes match TS", async (ctx) => {
+  const admin = await signUpAndPromoteAdmin(ctx, "admin", "phase10-admin-stateful", "Phase 10 Admin");
+  const target = adminActor(ctx, "target");
+  const targetEmail = ctx.uniqueEmail("phase10-target");
+  const signUp = await target.client.signUp.email({
+    email: targetEmail,
+    password: "password123",
+    name: "Phase 10 Target",
+  });
+  const targetId = signUp.data?.user.id ?? "";
+
+  await target.client.signIn.email({
+    email: targetEmail,
+    password: "password123",
+  });
+
+  const listBeforeBan = await admin.adminClient.admin.listUserSessions({
+    userId: targetId,
+  });
+
+  const banUser = await admin.adminClient.admin.banUser({
+    userId: targetId,
+    banReason: "phase10 ban",
+    banExpiresIn: 60 * 60,
+  });
+
+  const listAfterBan = await admin.adminClient.admin.listUserSessions({
+    userId: targetId,
+  });
+
+  const unbanUser = await admin.adminClient.admin.unbanUser({
+    userId: targetId,
+  });
+
+  await target.client.signIn.email({
+    email: targetEmail,
+    password: "password123",
+  });
+  await target.client.signIn.email({
+    email: targetEmail,
+    password: "password123",
+  });
+
+  const listBeforeRevoke = await admin.adminClient.admin.listUserSessions({
+    userId: targetId,
+  });
+  const revokeSingle = await admin.adminClient.admin.revokeUserSession({
+    sessionToken: listBeforeRevoke.data?.sessions[0]?.token ?? "",
+  });
+  const listAfterSingle = await admin.adminClient.admin.listUserSessions({
+    userId: targetId,
+  });
+  const listMissing = await admin.adminClient.admin.listUserSessions({
+    userId: "missing-user",
+  });
+  const revokeMissing = await admin.adminClient.admin.revokeUserSessions({
+    userId: "missing-user",
+  });
+  const revokeAll = await admin.adminClient.admin.revokeUserSessions({
+    userId: targetId,
+  });
+  const listAfterAll = await admin.adminClient.admin.listUserSessions({
+    userId: targetId,
+  });
+
+  return {
+    listBeforeBan: ctx.snapshot(listBeforeBan),
+    banUser: ctx.snapshot(banUser),
+    listAfterBan: ctx.snapshot(listAfterBan),
+    unbanUser: ctx.snapshot(unbanUser),
+    listBeforeRevoke: ctx.snapshot(listBeforeRevoke),
+    revokeSingle: ctx.snapshot(revokeSingle),
+    listAfterSingle: ctx.snapshot(listAfterSingle),
+    listMissing: ctx.snapshot(listMissing),
+    revokeMissing: ctx.snapshot(revokeMissing),
+    revokeAll: ctx.snapshot(revokeAll),
+    listAfterAll: ctx.snapshot(listAfterAll),
+  };
+});
+
+compatScenario("banned users are denied email and social session creation", async (ctx) => {
+  const admin = await signUpAndPromoteAdmin(ctx, "admin", "phase10-banned", "Phase 10 Admin");
+  const target = adminActor(ctx, "target");
+  const targetEmail = ctx.uniqueEmail("phase10-banned-user");
+  const targetPassword = "password123";
+  const signUp = await target.client.signUp.email({
+    email: targetEmail,
+    password: targetPassword,
+    name: "Banned User",
+  });
+  const targetId = signUp.data?.user.id ?? "";
+
+  await admin.adminClient.admin.banUser({
+    userId: targetId,
+    banReason: "phase10 banned",
+  });
+
+  const emailSignIn = await target.client.signIn.email({
+    email: targetEmail,
+    password: targetPassword,
+  });
+
+  await ctx.setSocialProfile({
+    email: targetEmail,
+    sub: ctx.uniqueToken("phase10-banned-social"),
+    name: "Banned Social User",
+    emailVerified: true,
+    idTokenValid: true,
+  });
+
+  const socialSignIn = await target.client.signIn.social({
+    provider: "google",
+    callbackURL: "/dashboard",
+  });
+  const state = extractState(socialSignIn.data?.url);
+  const callback = await ctx.rawRequest({
+    actor: "target",
+    path: `/api/auth/callback/google?code=compat-code&state=${encodeURIComponent(state)}`,
+    redirect: "manual",
+  });
+  const callbackLocation = summarizeLocation(callback.location);
+  const session = await target.client.getSession();
+
+  return {
+    emailSignIn: ctx.snapshot(emailSignIn),
+    socialSignIn: {
+      redirect: socialSignIn.data?.redirect,
+      hasState: Boolean(state),
+    },
+    callback: {
+      status: callback.status,
+      pathname: callbackLocation.pathname,
+      params: callbackLocation.params,
+    },
+    session: ctx.snapshot(session),
+  };
+});
+
+compatScenario("admin impersonation restores the original admin session and hides impersonated sessions", async (ctx) => {
+  const admin = await signUpAndPromoteAdmin(ctx, "admin", "phase10-impersonate", "Phase 10 Admin");
+  const target = adminActor(ctx, "target");
+  const targetEmail = ctx.uniqueEmail("phase10-impersonated-user");
+  const targetPassword = "password123";
+  const signUp = await target.client.signUp.email({
+    email: targetEmail,
+    password: targetPassword,
+    name: "Impersonated User",
+  });
+  const targetId = signUp.data?.user.id ?? "";
+
+  const impersonate = await admin.adminClient.admin.impersonateUser({
+    userId: targetId,
+  });
+  const impersonatedSession = await admin.client.getSession();
+
+  const directSignIn = await target.client.signIn.email({
+    email: targetEmail,
+    password: targetPassword,
+  });
+  const listedSessions = await target.client.listSessions();
+
+  const stopImpersonating = await admin.adminClient.admin.stopImpersonating({});
+  const restoredSession = await admin.client.getSession();
+  const adminListUsers = await admin.adminClient.admin.listUsers({
+    query: {
+      filterField: "role",
+      filterOperator: "eq",
+      filterValue: "admin",
+    },
+  });
+
+  return {
+    impersonate: {
+      data: {
+        hasImpersonatedBy: Boolean(impersonate.data?.session?.impersonatedBy),
+        user: ctx.snapshot(impersonate.data?.user),
+      },
+      error: ctx.snapshot(impersonate.error),
+    },
+    impersonatedSession: {
+      data: {
+        hasImpersonatedBy: Boolean(impersonatedSession.data?.session?.impersonatedBy),
+        user: ctx.snapshot(impersonatedSession.data?.user),
+      },
+      error: ctx.snapshot(impersonatedSession.error),
+    },
+    directSignIn: ctx.snapshot(directSignIn),
+    listedSessions: ctx.snapshot(listedSessions),
+    stopImpersonating: ctx.snapshot(stopImpersonating),
+    restoredSession: ctx.snapshot(restoredSession),
+    adminListUsers: ctx.snapshot(adminListUsers),
+  };
+});

--- a/crates/api/src/plugins/admin/handlers.rs
+++ b/crates/api/src/plugins/admin/handlers.rs
@@ -1,4 +1,6 @@
 use chrono::{Duration, Utc};
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
+use serde::{Deserialize, Serialize};
 
 use better_auth_core::entity::{AuthAccount, AuthSession, AuthUser};
 use better_auth_core::wire::{SessionView, UserView};
@@ -18,6 +20,63 @@ const MESSAGE_INVALID_ROLE_TYPE: &str = "Invalid role type";
 const MESSAGE_NO_DATA_TO_UPDATE: &str = "No data to update";
 const MESSAGE_CHANGE_ROLE: &str = "You are not allowed to change users role";
 const MESSAGE_CANNOT_IMPERSONATE_ADMINS: &str = "You cannot impersonate admins";
+const MESSAGE_NOT_IMPERSONATING: &str = "You are not impersonating anyone";
+const MESSAGE_FAILED_TO_FIND_USER: &str = "Failed to find user";
+const MESSAGE_FAILED_TO_FIND_ADMIN_SESSION: &str = "Failed to find admin session";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AdminSessionCookieClaims {
+    #[serde(rename = "sessionToken")]
+    session_token: String,
+    #[serde(rename = "dontRemember")]
+    dont_remember: bool,
+    exp: usize,
+    iat: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AdminSessionCookiePayload {
+    pub session_token: String,
+    pub dont_remember: bool,
+}
+
+pub(crate) fn create_admin_session_cookie_value(
+    secret: &str,
+    payload: &AdminSessionCookiePayload,
+    max_age: Duration,
+) -> AuthResult<String> {
+    let now = Utc::now();
+    let claims = AdminSessionCookieClaims {
+        session_token: payload.session_token.clone(),
+        dont_remember: payload.dont_remember,
+        exp: (now + max_age).timestamp() as usize,
+        iat: now.timestamp() as usize,
+    };
+    Ok(encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )?)
+}
+
+pub(crate) fn decode_admin_session_cookie_value(
+    secret: &str,
+    token: &str,
+) -> AuthResult<AdminSessionCookiePayload> {
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.validate_exp = true;
+    let claims = decode::<AdminSessionCookieClaims>(
+        token,
+        &DecodingKey::from_secret(secret.as_bytes()),
+        &validation,
+    )?
+    .claims;
+
+    Ok(AdminSessionCookiePayload {
+        session_token: claims.session_token,
+        dont_remember: claims.dont_remember,
+    })
+}
 
 fn joined_role(role: &RoleInput) -> String {
     role.joined()
@@ -257,12 +316,6 @@ pub(crate) async fn list_user_sessions_core(
     body: &UserIdRequest,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
 ) -> AuthResult<ListSessionsResponse<SessionView>> {
-    let _target = ctx
-        .database
-        .get_user_by_id(&body.user_id)
-        .await?
-        .ok_or_else(|| AuthError::not_found(MESSAGE_USER_NOT_FOUND))?;
-
     let session_manager = ctx.session_manager();
     let sessions = session_manager.list_user_sessions(&body.user_id).await?;
     Ok(ListSessionsResponse {
@@ -350,7 +403,7 @@ pub(crate) async fn impersonate_user_core(
         return Err(AuthError::bad_request("Cannot impersonate yourself"));
     }
 
-    let target = ctx
+    let mut target = ctx
         .database
         .get_user_by_id(&body.user_id)
         .await?
@@ -360,6 +413,28 @@ pub(crate) async fn impersonate_user_core(
         && target_is_admin(Some(&body.user_id), target.role(), config)
     {
         return Err(AuthError::forbidden(MESSAGE_CANNOT_IMPERSONATE_ADMINS));
+    }
+
+    if target.banned() {
+        if target
+            .ban_expires()
+            .is_some_and(|expires| expires <= Utc::now())
+        {
+            target = ctx
+                .database
+                .update_user(
+                    &body.user_id,
+                    UpdateUser {
+                        banned: Some(false),
+                        ban_reason: None,
+                        ban_expires: None,
+                        ..Default::default()
+                    },
+                )
+                .await?;
+        } else {
+            return Err(AuthError::banned_user(config.banned_user_message.clone()));
+        }
     }
 
     let expires_at = Utc::now()
@@ -386,35 +461,34 @@ pub(crate) async fn impersonate_user_core(
 
 pub(crate) async fn stop_impersonating_core(
     session: &impl AuthSession,
-    session_token: &str,
-    ip_address: Option<&str>,
-    user_agent: Option<&str>,
+    admin_cookie: &AdminSessionCookiePayload,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
 ) -> AuthResult<(SessionUserResponse<SessionView, UserView>, String)> {
     let admin_id = session
         .impersonated_by()
-        .ok_or_else(|| AuthError::bad_request("You are not impersonating anyone"))?
+        .ok_or_else(|| AuthError::bad_request(MESSAGE_NOT_IMPERSONATING))?
         .to_string();
-
-    ctx.session_manager().delete_session(session_token).await?;
 
     let admin_user = ctx
         .database
         .get_user_by_id(&admin_id)
         .await?
-        .ok_or(AuthError::UserNotFound)?;
+        .ok_or_else(|| AuthError::internal(MESSAGE_FAILED_TO_FIND_USER))?;
 
-    let expires_at = Utc::now() + ctx.config.session.expires_in;
-    let create_session = CreateSession {
-        user_id: admin_id,
-        expires_at,
-        ip_address: ip_address.map(|value| value.to_string()),
-        user_agent: user_agent.map(|value| value.to_string()),
-        impersonated_by: None,
-        active_organization_id: None,
-    };
+    let admin_session = ctx
+        .database
+        .get_session(&admin_cookie.session_token)
+        .await?
+        .ok_or_else(|| AuthError::internal(MESSAGE_FAILED_TO_FIND_ADMIN_SESSION))?;
 
-    let admin_session = ctx.database.create_session(create_session).await?;
+    if admin_session.user_id() != admin_user.id() {
+        return Err(AuthError::internal(MESSAGE_FAILED_TO_FIND_ADMIN_SESSION));
+    }
+
+    ctx.session_manager()
+        .delete_session(session.token())
+        .await?;
+
     let token = admin_session.token().to_string();
     let response = SessionUserResponse {
         session: SessionView::from(&admin_session),
@@ -438,12 +512,6 @@ pub(crate) async fn revoke_user_sessions_core(
     body: &UserIdRequest,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
 ) -> AuthResult<SuccessResponse> {
-    let _target = ctx
-        .database
-        .get_user_by_id(&body.user_id)
-        .await?
-        .ok_or_else(|| AuthError::not_found(MESSAGE_USER_NOT_FOUND))?;
-
     let _ = ctx
         .session_manager()
         .revoke_all_user_sessions(&body.user_id)

--- a/crates/api/src/plugins/admin/mod.rs
+++ b/crates/api/src/plugins/admin/mod.rs
@@ -424,6 +424,9 @@ impl AdminPlugin {
             .await?
             .ok_or(AuthError::Unauthenticated)?;
         let session = SessionView::from(&session);
+        if session.impersonated_by.is_none() {
+            return Err(AuthError::bad_request("You are not impersonating anyone"));
+        }
 
         let admin_cookie_name = related_cookie_name(&ctx.config, "admin_session");
         let admin_cookie_value = get_cookie(req, &admin_cookie_name)

--- a/crates/api/src/plugins/admin/mod.rs
+++ b/crates/api/src/plugins/admin/mod.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 
 use better_auth_core::entity::AuthUser;
-use better_auth_core::utils::cookie_utils::create_session_cookie;
+use better_auth_core::utils::cookie_utils::{
+    create_clear_cookie, create_session_cookie_with_max_age, create_session_like_cookie,
+    related_cookie_name,
+};
 use better_auth_core::utils::username::{UsernameValidationError, validate_username};
 use better_auth_core::wire::{SessionView, UserView};
 use better_auth_core::{
@@ -16,6 +19,7 @@ pub(super) mod types;
 #[cfg(test)]
 mod tests;
 
+use crate::plugins::helpers::{delete_session_cookie_headers, get_cookie};
 use access::{has_permission, is_admin_role, is_admin_user_id};
 use handlers::*;
 use types::*;
@@ -110,9 +114,14 @@ better_auth_core::impl_auth_plugin! {
             &self,
             ctx: &mut better_auth_core::AuthInitContext<S>,
         ) -> better_auth_core::AuthResult<()> {
+            ctx.set_metadata("admin.enabled", serde_json::Value::Bool(true));
             ctx.set_metadata(
                 "admin.default_role",
                 serde_json::Value::String(self.config.default_role.clone()),
+            );
+            ctx.set_metadata(
+                "admin.banned_user_message",
+                serde_json::Value::String(self.config.banned_user_message.clone()),
             );
             Ok(())
         }
@@ -343,7 +352,7 @@ impl AdminPlugin {
         req: &AuthRequest,
         ctx: &AuthContext<impl better_auth_core::AuthSchema>,
     ) -> AuthResult<AuthResponse> {
-        let (user, _session) = self.require_session(req, ctx).await?;
+        let (user, session) = self.require_session(req, ctx).await?;
         self.authorize(&user, "user", "impersonate", MESSAGE_IMPERSONATE_USERS)?;
         let body: UserIdRequest = match better_auth_core::validate_request_body(req) {
             Ok(v) => v,
@@ -360,8 +369,45 @@ impl AdminPlugin {
             ctx,
         )
         .await?;
-        let cookie_header = create_session_cookie(&token, &ctx.config);
-        Ok(AuthResponse::json(200, &response)?.with_header("Set-Cookie", cookie_header))
+        let dont_remember =
+            get_cookie(req, &related_cookie_name(&ctx.config, "dont_remember")).is_some();
+        let admin_cookie = create_admin_session_cookie_value(
+            &ctx.config.secret,
+            &AdminSessionCookiePayload {
+                session_token: session.token.clone(),
+                dont_remember,
+            },
+            ctx.config.session.expires_in,
+        )?;
+        let admin_cookie_name = related_cookie_name(&ctx.config, "admin_session");
+
+        let mut auth_response = AuthResponse::json(200, &response)?;
+        for cookie in delete_session_cookie_headers(&ctx.config) {
+            auth_response = auth_response.with_appended_header("Set-Cookie", cookie);
+        }
+        auth_response = auth_response.with_appended_header(
+            "Set-Cookie",
+            create_session_like_cookie(
+                &admin_cookie_name,
+                &admin_cookie,
+                Some(ctx.config.session.expires_in.num_seconds()),
+                &ctx.config,
+            ),
+        );
+        auth_response = auth_response.with_appended_header(
+            "Set-Cookie",
+            create_session_cookie_with_max_age(Some(&token), None, &ctx.config),
+        );
+        auth_response = auth_response.with_appended_header(
+            "Set-Cookie",
+            create_session_like_cookie(
+                &related_cookie_name(&ctx.config, "dont_remember"),
+                "true",
+                None,
+                &ctx.config,
+            ),
+        );
+        Ok(auth_response)
     }
 
     async fn handle_stop_impersonating(
@@ -378,18 +424,45 @@ impl AdminPlugin {
             .await?
             .ok_or(AuthError::Unauthenticated)?;
         let session = SessionView::from(&session);
-        let (response, new_token) = stop_impersonating_core(
-            &session,
-            &token,
-            req.headers
-                .get("x-forwarded-for")
-                .map(|value| value.as_str()),
-            req.headers.get("user-agent").map(|value| value.as_str()),
-            ctx,
-        )
-        .await?;
-        let cookie_header = create_session_cookie(&new_token, &ctx.config);
-        Ok(AuthResponse::json(200, &response)?.with_header("Set-Cookie", cookie_header))
+
+        let admin_cookie_name = related_cookie_name(&ctx.config, "admin_session");
+        let admin_cookie_value = get_cookie(req, &admin_cookie_name)
+            .ok_or_else(|| AuthError::internal("Failed to find admin session"))?;
+        let admin_cookie =
+            decode_admin_session_cookie_value(&ctx.config.secret, &admin_cookie_value)
+                .map_err(|_| AuthError::internal("Failed to find admin session"))?;
+
+        let (response, new_token) = stop_impersonating_core(&session, &admin_cookie, ctx).await?;
+
+        let mut auth_response = AuthResponse::json(200, &response)?;
+        auth_response = auth_response.with_appended_header(
+            "Set-Cookie",
+            create_session_cookie_with_max_age(
+                Some(&new_token),
+                if admin_cookie.dont_remember {
+                    None
+                } else {
+                    Some(ctx.config.session.expires_in.num_seconds())
+                },
+                &ctx.config,
+            ),
+        );
+        if admin_cookie.dont_remember {
+            auth_response = auth_response.with_appended_header(
+                "Set-Cookie",
+                create_session_like_cookie(
+                    &related_cookie_name(&ctx.config, "dont_remember"),
+                    "true",
+                    None,
+                    &ctx.config,
+                ),
+            );
+        }
+        auth_response = auth_response.with_appended_header(
+            "Set-Cookie",
+            create_clear_cookie(&admin_cookie_name, &ctx.config),
+        );
+        Ok(auth_response)
     }
 
     async fn handle_revoke_user_session(

--- a/crates/api/src/plugins/admin/tests.rs
+++ b/crates/api/src/plugins/admin/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::plugins::test_helpers;
 use better_auth_core::entity::{AuthAccount, AuthSession};
+use better_auth_core::utils::cookie_utils::related_cookie_name;
 use better_auth_core::wire::{SessionView, UserView};
 use better_auth_core::{AuthPlugin, CreateSession, CreateUser, HttpMethod};
 use chrono::{Duration, Utc};
@@ -54,6 +55,16 @@ fn make_request(
 
 fn json_body(resp: &AuthResponse) -> serde_json::Value {
     serde_json::from_slice(&resp.body).unwrap()
+}
+
+fn set_cookie_value(resp: &AuthResponse, name: &str) -> Option<String> {
+    resp.headers.get_all("Set-Cookie").find_map(|header| {
+        let (cookie_name, remainder) = header.split_once('=')?;
+        if cookie_name != name {
+            return None;
+        }
+        Some(remainder.split(';').next().unwrap_or_default().to_string())
+    })
 }
 
 #[tokio::test]
@@ -213,6 +224,11 @@ async fn test_impersonation_session_tracks_admin_id() {
     );
 
     let resp = plugin.on_request(&req, &ctx).await.unwrap().unwrap();
+    let admin_cookie_name = related_cookie_name(&ctx.config, "admin_session");
+    assert!(
+        set_cookie_value(&resp, &admin_cookie_name).is_some(),
+        "impersonation should emit an admin_session cookie"
+    );
     let token = json_body(&resp)["session"]["token"]
         .as_str()
         .unwrap()
@@ -240,17 +256,28 @@ async fn test_stop_impersonating_restores_admin_session() {
         .as_str()
         .unwrap()
         .to_string();
+    let admin_cookie_name = related_cookie_name(&ctx.config, "admin_session");
+    let admin_cookie = set_cookie_value(&resp, &admin_cookie_name)
+        .expect("impersonation should set the admin_session cookie");
 
-    let req = make_request(
+    let mut req = make_request(
         HttpMethod::Post,
         "/admin/stop-impersonating",
         &impersonation_token,
         None,
     );
+    req.headers.insert(
+        "cookie".to_string(),
+        format!("{admin_cookie_name}={admin_cookie}"),
+    );
     let resp = plugin.on_request(&req, &ctx).await.unwrap().unwrap();
     let body = json_body(&resp);
 
     let restored_token = body["session"]["token"].as_str().unwrap();
+    assert_eq!(
+        restored_token, admin_session.token,
+        "stop-impersonating should restore the original admin session token"
+    );
     let restored_session = ctx
         .database
         .get_session(restored_token)
@@ -266,6 +293,53 @@ async fn test_stop_impersonating_restores_admin_session() {
             .unwrap()
             .is_none()
     );
+    let cleared_admin_cookie = resp
+        .headers
+        .get_all("Set-Cookie")
+        .find(|header| header.starts_with(&format!("{admin_cookie_name}=")))
+        .expect("stop-impersonating should clear admin_session");
+    assert!(
+        cleared_admin_cookie.contains("Max-Age=0"),
+        "admin_session should be cleared after stop-impersonating"
+    );
+}
+
+#[tokio::test]
+async fn test_list_user_sessions_missing_user_returns_empty_array() {
+    let (ctx, _admin, admin_session, _user, _user_session) = create_admin_context().await;
+    let plugin = AdminPlugin::new();
+
+    let req = make_request(
+        HttpMethod::Post,
+        "/admin/list-user-sessions",
+        &admin_session.token,
+        Some(serde_json::json!({
+            "userId": "missing-user",
+        })),
+    );
+    let resp = plugin.on_request(&req, &ctx).await.unwrap().unwrap();
+
+    assert_eq!(resp.status, 200);
+    assert_eq!(json_body(&resp), serde_json::json!({ "sessions": [] }));
+}
+
+#[tokio::test]
+async fn test_revoke_user_sessions_missing_user_still_succeeds() {
+    let (ctx, _admin, admin_session, _user, _user_session) = create_admin_context().await;
+    let plugin = AdminPlugin::new();
+
+    let req = make_request(
+        HttpMethod::Post,
+        "/admin/revoke-user-sessions",
+        &admin_session.token,
+        Some(serde_json::json!({
+            "userId": "missing-user",
+        })),
+    );
+    let resp = plugin.on_request(&req, &ctx).await.unwrap().unwrap();
+
+    assert_eq!(resp.status, 200);
+    assert_eq!(json_body(&resp), serde_json::json!({ "success": true }));
 }
 
 #[tokio::test]

--- a/crates/api/src/plugins/admin/tests.rs
+++ b/crates/api/src/plugins/admin/tests.rs
@@ -343,6 +343,29 @@ async fn test_revoke_user_sessions_missing_user_still_succeeds() {
 }
 
 #[tokio::test]
+async fn test_stop_impersonating_without_impersonated_session_returns_bad_request() {
+    let (ctx, _admin, admin_session, _user, _user_session) = create_admin_context().await;
+    let plugin = AdminPlugin::new();
+
+    let req = make_request(
+        HttpMethod::Post,
+        "/admin/stop-impersonating",
+        &admin_session.token,
+        None,
+    );
+    let err = plugin.on_request(&req, &ctx).await.unwrap_err();
+    let response = err.to_auth_response();
+    assert_eq!(response.status, 400);
+    assert_eq!(
+        json_body(&response),
+        serde_json::json!({
+            "code": "YOU_ARE_NOT_IMPERSONATING_ANYONE",
+            "message": "You are not impersonating anyone"
+        })
+    );
+}
+
+#[tokio::test]
 async fn test_remove_user_cleans_up_sessions_and_accounts() {
     let (ctx, _admin, admin_session, _user, _user_session) = create_admin_context().await;
     let plugin = AdminPlugin::new();

--- a/crates/api/src/plugins/admin/types.rs
+++ b/crates/api/src/plugins/admin/types.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
@@ -156,7 +156,7 @@ pub(crate) struct AdminUserView {
     #[serde(rename = "banReason")]
     pub ban_reason: Option<String>,
     #[serde(rename = "banExpires")]
-    pub ban_expires: Option<DateTime<Utc>>,
+    pub ban_expires: Option<String>,
 }
 
 impl<T: better_auth_core::entity::AuthUser> From<&T> for AdminUserView {
@@ -174,7 +174,9 @@ impl<T: better_auth_core::entity::AuthUser> From<&T> for AdminUserView {
             role: user.role().map(str::to_owned),
             banned: user.banned(),
             ban_reason: user.ban_reason().map(str::to_owned),
-            ban_expires: user.ban_expires(),
+            ban_expires: user
+                .ban_expires()
+                .map(|value| value.to_rfc3339_opts(SecondsFormat::Millis, true)),
         }
     }
 }

--- a/crates/api/src/plugins/device_authorization/mod.rs
+++ b/crates/api/src/plugins/device_authorization/mod.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use url::Url;
 
+use crate::plugins::helpers::{SessionIssueError, issue_user_session};
 use better_auth_core::entity::{AuthSession, AuthUser};
 use better_auth_core::{
     AuthContext, AuthError, AuthRequest, AuthResponse, AuthResult, CreateDeviceCode, RequestMeta,
@@ -363,22 +364,26 @@ impl DeviceAuthorizationPlugin {
             }
 
             let meta = RequestMeta::from_request(req);
-            let session = match ctx
-                .session_manager()
-                .create_session(&user, meta.ip_address, meta.user_agent)
-                .await
-            {
-                Ok(session) => session,
-                Err(error) => {
-                    tracing::error!(
-                        error = %error,
-                        device_code_id = %device_code.id,
-                        user_id,
-                        "failed to create session after device code redemption"
-                    );
-                    return device_error_response(500, "server_error", FAILED_TO_CREATE_SESSION);
-                }
-            };
+            let session =
+                match issue_user_session(ctx, &user.id(), meta.ip_address, meta.user_agent)
+                    .await
+                    .map_err(SessionIssueError::into_auth_error)
+                {
+                    Ok(issued) => issued.session,
+                    Err(error) => {
+                        tracing::error!(
+                            error = %error,
+                            device_code_id = %device_code.id,
+                            user_id,
+                            "failed to create session after device code redemption"
+                        );
+                        return device_error_response(
+                            500,
+                            "server_error",
+                            FAILED_TO_CREATE_SESSION,
+                        );
+                    }
+                };
 
             return Ok(AuthResponse::json(
                 200,

--- a/crates/api/src/plugins/email_password.rs
+++ b/crates/api/src/plugins/email_password.rs
@@ -19,7 +19,7 @@ use better_auth_core::utils::username::{
 };
 use better_auth_core::wire::UserView;
 
-use crate::plugins::helpers::apply_default_role;
+use crate::plugins::helpers::{SessionIssueError, apply_default_role, issue_user_session};
 
 const MESSAGE_INVALID_USERNAME_OR_PASSWORD: &str = "Invalid username or password";
 const MESSAGE_EMAIL_NOT_VERIFIED: &str = "Email not verified";
@@ -617,17 +617,22 @@ async fn finalize_sign_in_with_user_core(
         );
     }
 
-    let session = ctx
-        .session_manager()
-        .create_session(&user, meta.ip_address.clone(), meta.user_agent.clone())
-        .await?;
+    let issued = issue_user_session(
+        ctx,
+        &user.id(),
+        meta.ip_address.clone(),
+        meta.user_agent.clone(),
+    )
+    .await
+    .map_err(SessionIssueError::into_auth_error)?;
+    let session = issued.session;
     let token = session.token().to_string();
 
     let response = SignInResponse {
         redirect: false,
         token: token.clone(),
         url: None,
-        user: UserView::from(&user),
+        user: UserView::from(&issued.user),
     };
     Ok(SignInCoreResult::Success(response, token))
 }

--- a/crates/api/src/plugins/email_verification/handlers.rs
+++ b/crates/api/src/plugins/email_verification/handlers.rs
@@ -1,5 +1,6 @@
 use jsonwebtoken::errors::ErrorKind;
 
+use crate::plugins::helpers::{SessionIssueError, issue_user_session};
 use better_auth_core::wire::{SessionView, UserView};
 use better_auth_core::{AuthContext, AuthError, AuthResult, UpdateUser};
 use better_auth_core::{AuthSession, AuthUser};
@@ -192,10 +193,10 @@ where
                 let (_session_user, session): (UserView, SessionView) = match current_session {
                     Some((user, session)) => (user, session),
                     None => {
-                        let session = ctx
-                            .session_manager()
-                            .create_session(&user, ip_address, user_agent)
-                            .await?;
+                        let session = issue_user_session(ctx, &user.id(), ip_address, user_agent)
+                            .await
+                            .map_err(SessionIssueError::into_auth_error)?
+                            .session;
                         (UserView::from(&user), SessionView::from(&session))
                     }
                 };
@@ -320,18 +321,20 @@ where
                 Some(session.token().to_string())
             } else {
                 Some(
-                    ctx.session_manager()
-                        .create_session(&user, ip_address, user_agent)
-                        .await?
+                    issue_user_session(ctx, &user.id(), ip_address, user_agent)
+                        .await
+                        .map_err(SessionIssueError::into_auth_error)?
+                        .session
                         .token()
                         .to_string(),
                 )
             }
         } else {
             Some(
-                ctx.session_manager()
-                    .create_session(&user, ip_address, user_agent)
-                    .await?
+                issue_user_session(ctx, &user.id(), ip_address, user_agent)
+                    .await
+                    .map_err(SessionIssueError::into_auth_error)?
+                    .session
                     .token()
                     .to_string(),
             )

--- a/crates/api/src/plugins/helpers.rs
+++ b/crates/api/src/plugins/helpers.rs
@@ -2,8 +2,10 @@
 //!
 //! Extracted to avoid duplicating common patterns across plugins (DRY).
 
+use better_auth_core::config::OAuthStateStrategy;
 use better_auth_core::entity::{AuthAccount, AuthApiKey, AuthUser};
-use better_auth_core::{AuthContext, AuthError, AuthResult, CreateUser};
+use better_auth_core::{AuthContext, AuthError, AuthRequest, AuthResult, CreateUser, UpdateUser};
+use chrono::Utc;
 
 /// Convert an `expiresIn` value (**seconds** from now) into an RFC 3339
 /// `expires_at` timestamp string.
@@ -93,4 +95,151 @@ pub fn apply_default_role(
     {
         create_user.role = Some(default_role.to_string());
     }
+}
+
+/// Result of issuing a real session for a user.
+pub struct IssuedSession<S: better_auth_core::AuthSchema> {
+    pub user: S::User,
+    pub session: S::Session,
+}
+
+/// Session issuance failures that callers may need to surface differently from
+/// a generic auth error (for example OAuth callback redirects).
+pub enum SessionIssueError {
+    Auth(AuthError),
+    Banned { message: String },
+}
+
+impl SessionIssueError {
+    pub fn into_auth_error(self) -> AuthError {
+        match self {
+            Self::Auth(error) => error,
+            Self::Banned { message } => AuthError::banned_user(message),
+        }
+    }
+
+    pub fn banned_message(&self) -> Option<&str> {
+        match self {
+            Self::Banned { message } => Some(message.as_str()),
+            Self::Auth(_) => None,
+        }
+    }
+}
+
+impl From<AuthError> for SessionIssueError {
+    fn from(value: AuthError) -> Self {
+        Self::Auth(value)
+    }
+}
+
+/// Whether the admin plugin is active for this auth instance.
+pub fn admin_plugin_enabled(ctx: &AuthContext<impl better_auth_core::AuthSchema>) -> bool {
+    ctx.get_metadata("admin.enabled")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false)
+}
+
+/// Resolve the configured message shown when a banned user attempts to create
+/// a session.
+pub fn admin_banned_user_message(
+    ctx: &AuthContext<impl better_auth_core::AuthSchema>,
+) -> Option<String> {
+    ctx.get_metadata("admin.banned_user_message")
+        .and_then(|value| value.as_str())
+        .map(ToOwned::to_owned)
+}
+
+/// Issue a session for the given user, applying admin-plugin ban semantics
+/// when the admin plugin is enabled.
+pub async fn issue_user_session<S: better_auth_core::AuthSchema>(
+    ctx: &AuthContext<S>,
+    user_id: &str,
+    ip_address: Option<String>,
+    user_agent: Option<String>,
+) -> Result<IssuedSession<S>, SessionIssueError> {
+    let mut user = ctx
+        .database
+        .get_user_by_id(user_id)
+        .await?
+        .ok_or(AuthError::UserNotFound)?;
+
+    if admin_plugin_enabled(ctx) && user.banned() {
+        if user
+            .ban_expires()
+            .is_some_and(|expires| expires <= Utc::now())
+        {
+            user = ctx
+                .database
+                .update_user(
+                    user_id,
+                    UpdateUser {
+                        banned: Some(false),
+                        ban_reason: None,
+                        ban_expires: None,
+                        ..Default::default()
+                    },
+                )
+                .await?;
+        } else {
+            return Err(SessionIssueError::Banned {
+                message: admin_banned_user_message(ctx).unwrap_or_else(|| {
+                    "You have been banned from this application. Please contact support if you believe this is an error.".to_string()
+                }),
+            });
+        }
+    }
+
+    let session = ctx
+        .session_manager()
+        .create_session(&user, ip_address, user_agent)
+        .await?;
+
+    Ok(IssuedSession { user, session })
+}
+
+/// Parse a cookie value from the request's `Cookie` header.
+pub fn get_cookie(req: &AuthRequest, name: &str) -> Option<String> {
+    let header = req.headers.get("cookie")?;
+    header
+        .split(';')
+        .filter_map(|cookie| {
+            let trimmed = cookie.trim();
+            let (cookie_name, cookie_value) = trimmed.split_once('=')?;
+            (cookie_name == name).then_some(cookie_value.to_string())
+        })
+        .next()
+}
+
+/// TS-style cookie clearing used by `deleteSessionCookie`.
+pub fn delete_session_cookie_headers(config: &better_auth_core::AuthConfig) -> Vec<String> {
+    let mut cookies = vec![
+        better_auth_core::utils::cookie_utils::create_clear_session_cookie(config),
+        better_auth_core::utils::cookie_utils::create_clear_cookie(
+            &better_auth_core::utils::cookie_utils::related_cookie_name(config, "session_data"),
+            config,
+        ),
+        better_auth_core::utils::cookie_utils::create_clear_cookie(
+            &better_auth_core::utils::cookie_utils::related_cookie_name(config, "dont_remember"),
+            config,
+        ),
+    ];
+
+    if config.account.store_account_cookie {
+        cookies.push(better_auth_core::utils::cookie_utils::create_clear_cookie(
+            &better_auth_core::utils::cookie_utils::related_cookie_name(config, "account_data"),
+            config,
+        ));
+    }
+
+    if matches!(
+        config.account.store_state_strategy,
+        OAuthStateStrategy::Cookie
+    ) {
+        cookies.push(better_auth_core::utils::cookie_utils::create_clear_cookie(
+            &better_auth_core::utils::cookie_utils::related_cookie_name(config, "oauth_state"),
+            config,
+        ));
+    }
+
+    cookies
 }

--- a/crates/api/src/plugins/oauth/handlers.rs
+++ b/crates/api/src/plugins/oauth/handlers.rs
@@ -30,7 +30,7 @@ use super::types::{
 };
 use better_auth_core::wire::{SessionView, UserView};
 
-use crate::plugins::helpers::apply_default_role;
+use crate::plugins::helpers::{SessionIssueError, apply_default_role, issue_user_session};
 
 // ---------------------------------------------------------------------------
 // Shared helpers (DRY)
@@ -507,7 +507,7 @@ fn build_redirect_url(
             let _ = pairs.append_pair(key, value);
         }
     }
-    Ok(url.to_string())
+    Ok(url.to_string().replace('+', "%20"))
 }
 
 fn auth_base_url(ctx: &AuthContext<impl better_auth_core::AuthSchema>) -> String {
@@ -523,6 +523,42 @@ struct ProcessOAuthUserResult {
     user: UserView,
     is_register: bool,
     account_cookie: Option<AccountCookiePayload>,
+}
+
+enum OAuthSignInError {
+    Generic(String),
+    Banned(String),
+}
+
+impl OAuthSignInError {
+    fn into_auth_error(self) -> AuthError {
+        match self {
+            Self::Generic(message) => AuthError::forbidden(message),
+            Self::Banned(message) => AuthError::banned_user(message),
+        }
+    }
+
+    fn redirect_parts(&self) -> (String, Option<&str>) {
+        match self {
+            Self::Generic(message) => (message.replace(' ', "_"), None),
+            Self::Banned(message) => ("banned".to_string(), Some(message.as_str())),
+        }
+    }
+}
+
+impl From<String> for OAuthSignInError {
+    fn from(value: String) -> Self {
+        Self::Generic(value)
+    }
+}
+
+impl From<SessionIssueError> for OAuthSignInError {
+    fn from(value: SessionIssueError) -> Self {
+        match value {
+            SessionIssueError::Auth(error) => Self::Generic(error.to_string()),
+            SessionIssueError::Banned { message } => Self::Banned(message),
+        }
+    }
 }
 
 pub(crate) struct AccessTokenCoreResult {
@@ -584,9 +620,9 @@ async fn process_oauth_sign_in(
     disable_sign_up: bool,
     meta: &better_auth_core::RequestMeta,
     ctx: &AuthContext<impl better_auth_core::AuthSchema>,
-) -> Result<ProcessOAuthUserResult, String> {
+) -> Result<ProcessOAuthUserResult, OAuthSignInError> {
     if user_info.email.is_empty() {
-        return Err("email not found".to_string());
+        return Err(OAuthSignInError::Generic("email not found".to_string()));
     }
 
     let linked_account = ctx
@@ -670,11 +706,14 @@ async fn process_oauth_sign_in(
                 .map_err(|error| error.to_string())?;
         }
 
-        let session = ctx
-            .session_manager()
-            .create_session(&user, meta.ip_address.clone(), meta.user_agent.clone())
-            .await
-            .map_err(|error| error.to_string())?;
+        let issued = issue_user_session(
+            ctx,
+            &user.id(),
+            meta.ip_address.clone(),
+            meta.user_agent.clone(),
+        )
+        .await
+        .map_err(OAuthSignInError::from)?;
         let account_cookie =
             ctx.config
                 .account
@@ -705,8 +744,8 @@ async fn process_oauth_sign_in(
                 });
 
         return Ok(ProcessOAuthUserResult {
-            session: SessionView::from(&session),
-            user: UserView::from(&user),
+            session: SessionView::from(&issued.session),
+            user: UserView::from(&issued.user),
             is_register: false,
             account_cookie,
         });
@@ -729,7 +768,7 @@ async fn process_oauth_sign_in(
             || linking.disable_implicit_linking
             || (!trusted_provider && !user_info.email_verified)
         {
-            return Err("account not linked".to_string());
+            return Err(OAuthSignInError::Generic("account not linked".to_string()));
         }
 
         let mut linked_user = existing_user;
@@ -790,15 +829,14 @@ async fn process_oauth_sign_in(
                     .map_err(|error| error.to_string())?;
         }
 
-        let session = ctx
-            .session_manager()
-            .create_session(
-                &linked_user,
-                meta.ip_address.clone(),
-                meta.user_agent.clone(),
-            )
-            .await
-            .map_err(|error| error.to_string())?;
+        let issued = issue_user_session(
+            ctx,
+            &linked_user.id(),
+            meta.ip_address.clone(),
+            meta.user_agent.clone(),
+        )
+        .await
+        .map_err(OAuthSignInError::from)?;
         let account_cookie = ctx
             .config
             .account
@@ -806,14 +844,14 @@ async fn process_oauth_sign_in(
             .then(|| AccountCookiePayload::from_account(&created_account));
 
         Ok(ProcessOAuthUserResult {
-            session: SessionView::from(&session),
-            user: UserView::from(&linked_user),
+            session: SessionView::from(&issued.session),
+            user: UserView::from(&issued.user),
             is_register: false,
             account_cookie,
         })
     } else {
         if disable_sign_up {
-            return Err("signup disabled".to_string());
+            return Err(OAuthSignInError::Generic("signup disabled".to_string()));
         }
 
         let mut create_user = CreateUser::new()
@@ -846,15 +884,14 @@ async fn process_oauth_sign_in(
             .await
             .map_err(|_| "unable to create user".to_string())?;
 
-        let session = ctx
-            .session_manager()
-            .create_session(
-                &created_user,
-                meta.ip_address.clone(),
-                meta.user_agent.clone(),
-            )
-            .await
-            .map_err(|error| error.to_string())?;
+        let issued = issue_user_session(
+            ctx,
+            &created_user.id(),
+            meta.ip_address.clone(),
+            meta.user_agent.clone(),
+        )
+        .await
+        .map_err(OAuthSignInError::from)?;
         let account_cookie = ctx
             .config
             .account
@@ -862,8 +899,8 @@ async fn process_oauth_sign_in(
             .then(|| AccountCookiePayload::from_account(&created_account));
 
         Ok(ProcessOAuthUserResult {
-            session: SessionView::from(&session),
-            user: UserView::from(&created_user),
+            session: SessionView::from(&issued.session),
+            user: UserView::from(&issued.user),
             is_register: true,
             account_cookie,
         })
@@ -1009,7 +1046,7 @@ async fn sign_in_with_id_token_core(
         ctx,
     )
     .await
-    .map_err(AuthError::forbidden)?;
+    .map_err(OAuthSignInError::into_auth_error)?;
 
     Ok(SocialSignInResponse {
         url: None,
@@ -2044,7 +2081,10 @@ pub(crate) async fn handle_callback(
     .await
     {
         Ok(outcome) => outcome,
-        Err(error) => return Ok(redirect_on_error(&error.replace(' ', "_"), None)),
+        Err(error) => {
+            let (code, description) = error.redirect_parts();
+            return Ok(redirect_on_error(&code, description));
+        }
     };
 
     let redirect_target = if outcome.is_register {

--- a/crates/api/src/plugins/oauth/handlers.rs
+++ b/crates/api/src/plugins/oauth/handlers.rs
@@ -501,13 +501,24 @@ fn build_redirect_url(
         base.join("/error")
             .map_err(|error| AuthError::internal(format!("Invalid error URL: {error}")))?
     };
-    {
-        let mut pairs = url.query_pairs_mut();
-        for (key, value) in params {
-            let _ = pairs.append_pair(key, value);
+    if !params.is_empty() {
+        let mut query_segments = Vec::new();
+        if let Some(existing_query) = url.query()
+            && !existing_query.is_empty()
+        {
+            query_segments.push(existing_query.to_string());
         }
+        for (key, value) in params {
+            query_segments.push(format!(
+                "{}={}",
+                urlencoding::encode(key),
+                urlencoding::encode(value),
+            ));
+        }
+        let query = query_segments.join("&");
+        url.set_query(Some(&query));
     }
-    Ok(url.to_string().replace('+', "%20"))
+    Ok(url.to_string())
 }
 
 fn auth_base_url(ctx: &AuthContext<impl better_auth_core::AuthSchema>) -> String {
@@ -2263,5 +2274,20 @@ mod tests {
         let ctx = test_helpers::create_test_context().await;
 
         assert!(validate_redirect_target("/dashboard", &ctx, "Invalid callbackURL").is_ok());
+    }
+
+    #[test]
+    fn build_redirect_url_preserves_plus_in_path_and_encodes_spaces_in_query() {
+        let url = build_redirect_url(
+            "http://localhost:3000/api/auth",
+            Some("/dashboard+beta"),
+            &[("error_description", "space value")],
+        )
+        .expect("redirect URL should build");
+
+        assert_eq!(
+            url,
+            "http://localhost:3000/dashboard+beta?error_description=space%20value"
+        );
     }
 }

--- a/crates/api/src/plugins/passkey/handlers.rs
+++ b/crates/api/src/plugins/passkey/handlers.rs
@@ -11,6 +11,7 @@ use webauthn_rs::prelude::{
 };
 
 use crate::plugins::StatusResponse;
+use crate::plugins::helpers::{SessionIssueError, issue_user_session};
 
 use super::PasskeyConfig;
 use super::types::{
@@ -432,12 +433,11 @@ pub(super) async fn verify_authentication_core(
         return passkey_authentication_failure();
     }
 
-    let session = match ctx
-        .session_manager()
-        .create_session(&user, ip_address, user_agent)
+    let session = match issue_user_session(ctx, &user.id(), ip_address, user_agent)
         .await
+        .map_err(SessionIssueError::into_auth_error)
     {
-        Ok(session) => session,
+        Ok(issued) => issued.session,
         Err(error) => return Err(error),
     };
 

--- a/crates/api/src/plugins/password_management/handlers.rs
+++ b/crates/api/src/plugins/password_management/handlers.rs
@@ -9,7 +9,9 @@ use better_auth_core::{
     CreateAccount, RequestMeta, UpdateAccount,
 };
 
-use crate::plugins::helpers::{get_credential_account, get_credential_password_hash};
+use crate::plugins::helpers::{
+    SessionIssueError, get_credential_account, get_credential_password_hash, issue_user_session,
+};
 
 use super::types::*;
 use super::{PasswordManagementConfig, StatusResponse};
@@ -259,10 +261,15 @@ pub(crate) async fn change_password_core(
 
     let new_token = if body.revoke_other_sessions == Some(true) {
         ctx.database.delete_user_sessions(&user.id()).await?;
-        let session = ctx
-            .session_manager()
-            .create_session(user, meta.ip_address.clone(), meta.user_agent.clone())
-            .await?;
+        let session = issue_user_session(
+            ctx,
+            &user.id(),
+            meta.ip_address.clone(),
+            meta.user_agent.clone(),
+        )
+        .await
+        .map_err(SessionIssueError::into_auth_error)?
+        .session;
         Some(session.token().to_string())
     } else {
         None

--- a/crates/api/src/plugins/session_management.rs
+++ b/crates/api/src/plugins/session_management.rs
@@ -11,6 +11,7 @@ use better_auth_core::AuthResult;
 use better_auth_core::{AuthRequest, AuthResponse, HttpMethod};
 
 use super::StatusResponse;
+use super::helpers::{admin_plugin_enabled, delete_session_cookie_headers, get_cookie};
 use better_auth_core::SuccessResponse;
 
 /// Session management plugin for handling session operations
@@ -161,7 +162,17 @@ impl SessionManagementPlugin {
                 };
                 Ok(AuthResponse::json(200, &response)?)
             }
-            Err(_) => Ok(AuthResponse::json(200, &serde_json::Value::Null)?),
+            Err(_) => {
+                let mut response = AuthResponse::json(200, &serde_json::Value::Null)?;
+                if get_cookie(req, &ctx.config.session.cookie_name)
+                    .is_some_and(|value| !value.is_empty())
+                {
+                    for cookie in delete_session_cookie_headers(&ctx.config) {
+                        response.headers.append("Set-Cookie", cookie);
+                    }
+                }
+                Ok(response)
+            }
         }
     }
 
@@ -187,7 +198,10 @@ impl SessionManagementPlugin {
         ctx: &AuthContext<impl better_auth_core::AuthSchema>,
     ) -> AuthResult<AuthResponse> {
         let (user, _) = ctx.require_session(req).await?;
-        let sessions = list_sessions_core(user.id(), ctx).await?;
+        let mut sessions = list_sessions_core(user.id(), ctx).await?;
+        if admin_plugin_enabled(ctx) {
+            sessions.retain(|session| session.impersonated_by.is_none());
+        }
         Ok(AuthResponse::json(200, &sessions)?)
     }
 
@@ -455,6 +469,63 @@ mod tests {
         let body_str = String::from_utf8(response.body).unwrap();
         let sessions: Vec<SessionView> = serde_json::from_str(&body_str).unwrap();
         assert_eq!(sessions.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_list_sessions_filters_impersonated_sessions_when_admin_plugin_is_enabled() {
+        let plugin = SessionManagementPlugin::new();
+        let (mut ctx, user, session) = test_helpers::create_test_context_with_user(
+            CreateUser::new()
+                .with_email("test@example.com")
+                .with_name("Test User"),
+            Duration::hours(24),
+        )
+        .await;
+        ctx.set_metadata("admin.enabled", serde_json::Value::Bool(true));
+
+        let direct_session = CreateSession {
+            user_id: user.id.clone(),
+            expires_at: Utc::now() + Duration::hours(24),
+            ip_address: Some("192.168.1.1".to_string()),
+            user_agent: Some("another-agent".to_string()),
+            impersonated_by: None,
+            active_organization_id: None,
+        };
+        ctx.database.create_session(direct_session).await.unwrap();
+
+        let impersonated_session = CreateSession {
+            user_id: user.id.clone(),
+            expires_at: Utc::now() + Duration::hours(24),
+            ip_address: Some("10.0.0.5".to_string()),
+            user_agent: Some("impersonated-agent".to_string()),
+            impersonated_by: Some("admin-user".to_string()),
+            active_organization_id: None,
+        };
+        let impersonated = ctx
+            .database
+            .create_session(impersonated_session)
+            .await
+            .unwrap();
+
+        let req = test_helpers::create_auth_request_no_query(
+            HttpMethod::Get,
+            "/list-sessions",
+            Some(&session.token),
+            None,
+        );
+        let response = plugin.handle_list_sessions(&req, &ctx).await.unwrap();
+
+        assert_eq!(response.status, 200);
+
+        let body_str = String::from_utf8(response.body).unwrap();
+        let sessions: Vec<SessionView> = serde_json::from_str(&body_str).unwrap();
+        assert_eq!(sessions.len(), 2);
+        assert!(
+            sessions
+                .iter()
+                .all(|session| session.token != impersonated.token),
+            "impersonated sessions should not be returned from /list-sessions"
+        );
     }
 
     // Upstream reference: packages/better-auth/src/api/routes/session-api.test.ts :: describe("session") and packages/better-auth/src/api/routes/sign-out.test.ts :: describe("sign-out"); adapted to the Rust session-management plugin.

--- a/crates/api/src/plugins/two_factor.rs
+++ b/crates/api/src/plugins/two_factor.rs
@@ -11,7 +11,9 @@ use better_auth_core::{
 
 use better_auth_core::utils::cookie_utils::create_session_cookie;
 
-use crate::plugins::helpers::get_credential_password_hash;
+use crate::plugins::helpers::{
+    SessionIssueError, get_credential_password_hash, issue_user_session,
+};
 
 use super::StatusResponse;
 
@@ -373,10 +375,10 @@ async fn verify_totp_core(
     }
 
     // Code valid — create session
-    let session = ctx
-        .session_manager()
-        .create_session(user, None, None)
-        .await?;
+    let session = issue_user_session(ctx, &user.id(), None, None)
+        .await
+        .map_err(SessionIssueError::into_auth_error)?
+        .session;
 
     // Delete the pending verification
     ctx.database.delete_verification(verification_id).await?;
@@ -446,10 +448,10 @@ async fn verify_otp_core(
     }
 
     // Valid — create session
-    let session = ctx
-        .session_manager()
-        .create_session(user, None, None)
-        .await?;
+    let session = issue_user_session(ctx, &user.id(), None, None)
+        .await
+        .map_err(SessionIssueError::into_auth_error)?
+        .session;
 
     // Clean up verifications
     ctx.database
@@ -514,10 +516,10 @@ async fn verify_backup_code_core(
         .await?;
 
     // Create session
-    let session = ctx
-        .session_manager()
-        .create_session(user, None, None)
-        .await?;
+    let session = issue_user_session(ctx, &user.id(), None, None)
+        .await
+        .map_err(SessionIssueError::into_auth_error)?
+        .session;
 
     // Clean up pending verification
     ctx.database.delete_verification(verification_id).await?;

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -28,6 +28,9 @@ pub enum AuthError {
     #[error("{0}")]
     Forbidden(String),
 
+    #[error("{0}")]
+    BannedUser(String),
+
     #[error("Insufficient permissions")]
     Unauthorized,
 
@@ -80,7 +83,7 @@ impl AuthError {
             // 401
             Self::InvalidCredentials | Self::Unauthenticated | Self::SessionNotFound => 401,
             // 403
-            Self::Forbidden(_) | Self::Unauthorized => 403,
+            Self::Forbidden(_) | Self::BannedUser(_) | Self::Unauthorized => 403,
             // 404
             Self::UserNotFound | Self::NotFound(_) => 404,
             // 409
@@ -119,14 +122,20 @@ impl AuthError {
     /// to avoid leaking details.
     pub fn error_payload(&self) -> (u16, String, String) {
         let status = self.status_code();
-        let message = match status {
-            500 => {
-                tracing::error!(error = %self, "Internal server error");
-                "Internal server error".to_string()
+        let (code, message) = match self {
+            Self::BannedUser(message) => ("BANNED_USER".to_string(), message.clone()),
+            _ => {
+                let message = match status {
+                    500 => {
+                        tracing::error!(error = %self, "Internal server error");
+                        "Internal server error".to_string()
+                    }
+                    _ => self.to_string(),
+                };
+                let code = Self::code_from_message(&message);
+                (code, message)
             }
-            _ => self.to_string(),
         };
-        let code = Self::code_from_message(&message);
         (status, code, message)
     }
 
@@ -153,6 +162,10 @@ impl AuthError {
 
     pub fn forbidden(message: impl Into<String>) -> Self {
         Self::Forbidden(message.into())
+    }
+
+    pub fn banned_user(message: impl Into<String>) -> Self {
+        Self::BannedUser(message.into())
     }
 
     pub fn not_found(message: impl Into<String>) -> Self {

--- a/crates/core/src/utils/cookie_utils.rs
+++ b/crates/core/src/utils/cookie_utils.rs
@@ -10,48 +10,59 @@ use cookie::{Cookie, SameSite as CookieSameSite};
 /// Build a `Set-Cookie` header value for an arbitrary cookie using the auth
 /// config's session cookie attributes for consistency.
 pub fn create_cookie(name: &str, value: &str, max_age_seconds: i64, config: &AuthConfig) -> String {
-    let session_config = &config.session;
-    let expires_offset =
-        cookie::time::OffsetDateTime::now_utc() + cookie::time::Duration::seconds(max_age_seconds);
-    let same_site = map_same_site(&session_config.cookie_same_site);
-
-    let mut cookie = Cookie::build((name, value))
-        .path("/")
-        .expires(expires_offset)
-        .max_age(cookie::time::Duration::seconds(max_age_seconds))
-        .secure(session_config.cookie_secure)
-        .http_only(session_config.cookie_http_only)
-        .same_site(same_site);
-
-    if matches!(
-        session_config.cookie_same_site,
-        crate::config::SameSite::None
-    ) {
-        cookie = cookie.secure(true);
-    }
-
-    cookie.build().to_string()
+    create_session_like_cookie(name, value, Some(max_age_seconds), config)
 }
 
 /// Build a `Set-Cookie` header value for a session token using the `cookie`
 /// crate for correct formatting and escaping.
 pub fn create_session_cookie(token: &str, config: &AuthConfig) -> String {
+    create_session_cookie_with_max_age(
+        Some(token),
+        Some(config.session.expires_in.num_seconds()),
+        config,
+    )
+}
+
+/// Build a `Set-Cookie` header value for a session token using the session
+/// cookie attributes, optionally omitting `Max-Age` / `Expires` to create a
+/// browser-session cookie.
+pub fn create_session_cookie_with_max_age(
+    token: Option<&str>,
+    max_age_seconds: Option<i64>,
+    config: &AuthConfig,
+) -> String {
+    create_session_like_cookie(
+        &config.session.cookie_name,
+        token.unwrap_or(""),
+        max_age_seconds,
+        config,
+    )
+}
+
+/// Build a `Set-Cookie` header value using the session cookie attributes for
+/// an arbitrary cookie name.
+pub fn create_session_like_cookie(
+    name: &str,
+    value: &str,
+    max_age_seconds: Option<i64>,
+    config: &AuthConfig,
+) -> String {
     let session_config = &config.session;
-
-    let expires_offset = cookie::time::OffsetDateTime::now_utc()
-        + cookie::time::Duration::seconds(session_config.expires_in.num_seconds());
-
     let same_site = map_same_site(&session_config.cookie_same_site);
 
-    let mut cookie = Cookie::build((&*session_config.cookie_name, token))
+    let mut cookie = Cookie::build((name, value))
         .path("/")
-        .expires(expires_offset)
-        .max_age(cookie::time::Duration::seconds(
-            session_config.expires_in.num_seconds(),
-        ))
         .secure(session_config.cookie_secure)
         .http_only(session_config.cookie_http_only)
         .same_site(same_site);
+
+    if let Some(max_age_seconds) = max_age_seconds {
+        let expires_offset = cookie::time::OffsetDateTime::now_utc()
+            + cookie::time::Duration::seconds(max_age_seconds);
+        cookie = cookie
+            .expires(expires_offset)
+            .max_age(cookie::time::Duration::seconds(max_age_seconds));
+    }
 
     // SameSite=None requires the Secure attribute per the spec
     if matches!(
@@ -66,26 +77,7 @@ pub fn create_session_cookie(token: &str, config: &AuthConfig) -> String {
 
 /// Build a `Set-Cookie` header value that clears the session cookie.
 pub fn create_clear_session_cookie(config: &AuthConfig) -> String {
-    let session_config = &config.session;
-
-    let same_site = map_same_site(&session_config.cookie_same_site);
-
-    let mut cookie = Cookie::build((&*session_config.cookie_name, ""))
-        .path("/")
-        .expires(cookie::time::OffsetDateTime::UNIX_EPOCH)
-        .max_age(cookie::time::Duration::seconds(0))
-        .secure(session_config.cookie_secure)
-        .http_only(session_config.cookie_http_only)
-        .same_site(same_site);
-
-    if matches!(
-        session_config.cookie_same_site,
-        crate::config::SameSite::None
-    ) {
-        cookie = cookie.secure(true);
-    }
-
-    cookie.build().to_string()
+    create_session_cookie_with_max_age(None, Some(0), config)
 }
 
 /// Build a `Set-Cookie` header value that clears an arbitrary cookie by name,
@@ -111,6 +103,18 @@ pub fn create_clear_cookie(name: &str, config: &AuthConfig) -> String {
     }
 
     cookie.build().to_string()
+}
+
+/// Build a Better Auth related cookie name using the configured session cookie
+/// prefix. For example, `better-auth.session_token` + `session_data` becomes
+/// `better-auth.session_data`.
+pub fn related_cookie_name(config: &AuthConfig, suffix: &str) -> String {
+    config
+        .session
+        .cookie_name
+        .strip_suffix("session_token")
+        .map(|prefix| format!("{}{}", prefix, suffix))
+        .unwrap_or_else(|| format!("better-auth.{}", suffix))
 }
 
 fn map_same_site(s: &crate::config::SameSite) -> CookieSameSite {

--- a/tests/client_compat_tests.rs
+++ b/tests/client_compat_tests.rs
@@ -208,6 +208,12 @@ async fn phase9_client_compat() {
 
 #[tokio::test]
 #[ignore = "starts external TS and Rust servers"]
+async fn phase10_client_compat() {
+    run_client_compat(&["tests/phase10"]).await;
+}
+
+#[tokio::test]
+#[ignore = "starts external TS and Rust servers"]
 async fn full_client_compat() {
     run_client_compat(&[
         "tests/phase0",
@@ -220,6 +226,7 @@ async fn full_client_compat() {
         "tests/phase7",
         "tests/phase8",
         "tests/phase9",
+        "tests/phase10",
     ])
     .await;
 }

--- a/tests/compat_admin_stateful_tests.rs
+++ b/tests/compat_admin_stateful_tests.rs
@@ -1,0 +1,130 @@
+//! Compatibility tests for phase 10 admin stateful flows.
+//!
+//! Focused on the shared banned-user session gate and admin stateful semantics
+//! that cross route boundaries.
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "compat contract tests use direct assertions and JSON indexing for endpoint checks"
+)]
+
+mod compat;
+
+use better_auth::prelude::{AuthUser, UpdateUser};
+use chrono::{Duration, Utc};
+use compat::helpers::*;
+use serde_json::json;
+
+type TestSchema = better_auth_seaorm::store::__private_test_support::bundled_schema::BundledSchema;
+
+async fn setup_admin(auth: &better_auth::BetterAuth<TestSchema>) -> String {
+    let (token, _) = signup_user(auth, "admin-stateful@test.com", "password123", "Admin").await;
+
+    let user = auth
+        .store()
+        .get_user_by_email("admin-stateful@test.com")
+        .await
+        .unwrap()
+        .unwrap();
+
+    let _ = auth
+        .store()
+        .update_user(
+            &user.id(),
+            UpdateUser {
+                role: Some("admin".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    token
+}
+
+#[tokio::test]
+async fn test_banned_user_sign_in_returns_banned_user_code() {
+    let auth = create_test_auth().await;
+    let admin_token = setup_admin(&auth).await;
+
+    let (_, signup_json) = signup_user(
+        &auth,
+        "banned-stateful@test.com",
+        "password123",
+        "Banned User",
+    )
+    .await;
+    let user_id = signup_json["user"]["id"].as_str().unwrap();
+
+    let ban_req = post_json_with_auth(
+        "/admin/ban-user",
+        json!({
+            "userId": user_id,
+            "banReason": "stateful test",
+        }),
+        &admin_token,
+    );
+    let (ban_status, _ban_json) = send_request(&auth, ban_req).await;
+    assert_eq!(ban_status, 200);
+
+    let sign_in_req = post_json(
+        "/sign-in/email",
+        json!({
+            "email": "banned-stateful@test.com",
+            "password": "password123",
+        }),
+    );
+    let (status, body) = send_request(&auth, sign_in_req).await;
+
+    assert_eq!(status, 403);
+    assert_eq!(body["code"], "BANNED_USER");
+}
+
+#[tokio::test]
+async fn test_expired_ban_is_cleared_on_sign_in() {
+    let auth = create_test_auth().await;
+    let (_, signup_json) = signup_user(
+        &auth,
+        "expired-ban@test.com",
+        "password123",
+        "Expired Ban User",
+    )
+    .await;
+    let user_id = signup_json["user"]["id"].as_str().unwrap().to_string();
+
+    let _ = auth
+        .store()
+        .update_user(
+            &user_id,
+            UpdateUser {
+                banned: Some(true),
+                ban_reason: Some("expired".to_string()),
+                ban_expires: Some(Utc::now() - Duration::minutes(1)),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let sign_in_req = post_json(
+        "/sign-in/email",
+        json!({
+            "email": "expired-ban@test.com",
+            "password": "password123",
+        }),
+    );
+    let (status, body) = send_request(&auth, sign_in_req).await;
+    assert_eq!(status, 200, "expired ban sign-in should succeed: {}", body);
+    assert!(body["token"].is_string());
+
+    let user = auth
+        .store()
+        .get_user_by_id(&user_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(!user.banned());
+    assert!(user.ban_reason().is_none());
+    assert!(user.ban_expires().is_none());
+}


### PR DESCRIPTION
## Summary
- align phase 10 admin stateful flows with the TypeScript 1.4.19 behavior
- enforce banned-user session denial across all session-issuing flows
- restore TS-style admin impersonation cookie handoff and original-session recovery
- add phase 10 dual-server client compatibility coverage and focused Rust regression tests

## Why
Rust had drifted from the TS contract around banned-user handling, impersonation lifecycle, and phase 10 admin session semantics. This change moves the implementation back to client-visible parity while keeping the internal Rust structure cleaner.

## Impact
- `/admin/ban-user`, `/admin/unban-user`, `/admin/impersonate-user`, `/admin/stop-impersonating`, `/admin/list-user-sessions`, `/admin/revoke-user-session`, and `/admin/revoke-user-sessions` now match the expected TS behavior more closely
- banned users are blocked consistently from email, OAuth, passkey, device, verification, password-reset, and two-factor session issuance
- impersonated sessions are hidden from `/list-sessions` but still visible to admin list-user-sessions

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace`
- `cargo clippy --workspace --features axum`
- `cargo test --workspace --lib`
- `cargo test --test compat_admin_stateful_tests -- --nocapture`
- `cargo test --test client_compat_tests phase0_client_compat -- --ignored --nocapture`
- `cargo test --test client_compat_tests phase1_client_compat -- --ignored --nocapture`
- `cargo test --test client_compat_tests phase3_client_compat -- --ignored --nocapture`
- `cargo test --test client_compat_tests phase9_client_compat -- --ignored --nocapture`
- `cargo test --test client_compat_tests phase10_client_compat -- --ignored --nocapture`