### PR TITLE
Update tests for API key and schema changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ CLAUDE.md
 AGENTS.md
 .codex
 .codex/
+.zed/
+
+# Stakpak session files
+.stakpak/session*

--- a/tests/auth_entity_extra_fields_tests.rs
+++ b/tests/auth_entity_extra_fields_tests.rs
@@ -1,11 +1,13 @@
 //! Verifies that `AuthEntity` derive accepts extra fields beyond the core set.
 
+#![cfg(feature = "seaorm2")]
 #![allow(
     unreachable_pub,
     reason = "SeaORM DeriveEntityModel requires pub types"
 )]
 
 use better_auth::seaorm::AuthEntity;
+use better_auth::seaorm::SeaOrmUserModel;
 use better_auth::seaorm::sea_orm;
 use better_auth::seaorm::sea_orm::entity::prelude::*;
 
@@ -46,7 +48,6 @@ mod user_with_extras {
 #[test]
 fn extra_fields_get_not_set_in_new_active() {
     use better_auth::prelude::CreateUser;
-    use better_auth::seaorm::SeaOrmUserModel;
     use chrono::Utc;
     use sea_orm::ActiveValue;
 

--- a/tests/compat/helpers.rs
+++ b/tests/compat/helpers.rs
@@ -436,7 +436,84 @@ pub async fn send_request(auth: &TestAuth, req: AuthRequest) -> (u16, Value) {
     (status, json)
 }
 
-/// Strip markup and normalize whitespace so tests can assert on rendered text.
+fn decode_html_entities(text: &str) -> String {
+    let mut decoded = String::with_capacity(text.len());
+    let bytes = text.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'&' {
+            if let Some(offset) = text[i + 1..].find(';') {
+                let end = i + 1 + offset;
+                let entity = &text[i + 1..end];
+
+                let replacement = match entity {
+                    "nbsp" => Some(" ".to_string()),
+                    "amp" => Some("&".to_string()),
+                    "lt" => Some("<".to_string()),
+                    "gt" => Some(">".to_string()),
+                    "quot" => Some("\"".to_string()),
+                    "apos" => Some("'".to_string()),
+                    _ => decode_numeric_html_entity(entity),
+                };
+
+                if let Some(replacement) = replacement {
+                    decoded.push_str(&replacement);
+                    i = end + 1;
+                    continue;
+                }
+            }
+        }
+
+        let ch = text[i..]
+            .chars()
+            .next()
+            .unwrap_or_else(|| panic!("text slice should start with a valid UTF-8 character"));
+        decoded.push(ch);
+        i += ch.len_utf8();
+    }
+
+    decoded
+}
+
+fn decode_numeric_html_entity(entity: &str) -> Option<String> {
+    let codepoint = if let Some(hex) = entity
+        .strip_prefix("#x")
+        .or_else(|| entity.strip_prefix("#X"))
+    {
+        u32::from_str_radix(hex, 16).ok()?
+    } else if let Some(decimal) = entity.strip_prefix('#') {
+        decimal.parse::<u32>().ok()?
+    } else {
+        return None;
+    };
+
+    char::from_u32(codepoint).map(|ch| ch.to_string())
+}
+
+fn normalize_whitespace(text: &str) -> String {
+    let mut normalized = String::with_capacity(text.len());
+    let mut pending_space = false;
+
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            pending_space = !normalized.is_empty();
+            continue;
+        }
+
+        if pending_space {
+            normalized.push(' ');
+            pending_space = false;
+        }
+
+        normalized.push(ch);
+    }
+
+    normalized.trim().to_string()
+}
+
+/// Strip markup, decode common HTML entities, and normalize whitespace so tests
+/// can assert on rendered text.
 pub fn html_text_content(html: &str) -> String {
     let mut text = String::with_capacity(html.len());
     let mut in_tag = false;
@@ -461,7 +538,24 @@ pub fn html_text_content(html: &str) -> String {
         }
     }
 
-    text.trim().to_string()
+    normalize_whitespace(&decode_html_entities(&text))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::html_text_content;
+
+    #[test]
+    fn html_text_content_decodes_entities_and_normalizes_whitespace() {
+        assert_eq!(
+            html_text_content("<div><span>CODE&#58;</span>&nbsp;<span>UNKNOWN</span></div>"),
+            "CODE: UNKNOWN"
+        );
+        assert_eq!(
+            html_text_content("<p>A&amp;B &lt;ok&gt; &#x26; &#38;</p>"),
+            "A&B <ok> & &"
+        );
+    }
 }
 
 pub async fn signup_user(

--- a/tests/compat/helpers.rs
+++ b/tests/compat/helpers.rs
@@ -436,6 +436,34 @@ pub async fn send_request(auth: &TestAuth, req: AuthRequest) -> (u16, Value) {
     (status, json)
 }
 
+/// Strip markup and normalize whitespace so tests can assert on rendered text.
+pub fn html_text_content(html: &str) -> String {
+    let mut text = String::with_capacity(html.len());
+    let mut in_tag = false;
+    let mut pending_space = false;
+
+    for ch in html.chars() {
+        match ch {
+            '<' => {
+                in_tag = true;
+                pending_space = !text.is_empty();
+            }
+            '>' => in_tag = false,
+            _ if in_tag => {}
+            _ if ch.is_whitespace() => pending_space = !text.is_empty(),
+            _ => {
+                if pending_space {
+                    text.push(' ');
+                    pending_space = false;
+                }
+                text.push(ch);
+            }
+        }
+    }
+
+    text.trim().to_string()
+}
+
 pub async fn signup_user(
     auth: &TestAuth,
     email: &str,

--- a/tests/compatibility_tests.rs
+++ b/tests/compatibility_tests.rs
@@ -21,6 +21,7 @@ use better_auth::{
     prelude::{AuthRequest, HttpMethod},
 };
 use better_auth_seaorm::{Database, DatabaseConnection, SeaOrmStore};
+use compat::helpers::html_text_content;
 use serde_json::Value;
 
 type TestSchema = better_auth_seaorm::store::__private_test_support::bundled_schema::BundledSchema;
@@ -519,13 +520,10 @@ async fn test_contract_error_endpoint() {
         html.contains("ERROR"),
         "error page should contain ERROR heading"
     );
+    let text = html_text_content(html);
     assert!(
-        html.contains("UNKNOWN"),
-        "error page should contain the UNKNOWN error code"
-    );
-    assert!(
-        html.contains("CODE:"),
-        "error page should contain CODE: label"
+        text.contains("CODE: UNKNOWN"),
+        "error page should contain the CODE: UNKNOWN error code label"
     );
     assert!(
         html.contains("Ask AI"),

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -375,8 +375,8 @@ async fn test_error_endpoint() {
     let (status, response_data) = send_request(&auth, get_request("/error")).await;
     assert_eq!(status, 200);
     let html = response_data.as_str().unwrap_or_default();
-    assert!(html.contains("CODE:"));
-    assert!(html.contains("UNKNOWN"));
+    let text = html_text_content(html);
+    assert!(text.contains("CODE: UNKNOWN"));
 }
 
 /// Integration test for POST /get-session remaining unavailable publicly

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -375,7 +375,8 @@ async fn test_error_endpoint() {
     let (status, response_data) = send_request(&auth, get_request("/error")).await;
     assert_eq!(status, 200);
     let html = response_data.as_str().unwrap_or_default();
-    assert!(html.contains("CODE: UNKNOWN"));
+    assert!(html.contains("CODE:"));
+    assert!(html.contains("UNKNOWN"));
 }
 
 /// Integration test for POST /get-session remaining unavailable publicly
@@ -1776,11 +1777,8 @@ async fn test_api_key_create_with_options() {
 
     let body = serde_json::json!({
         "name": "limited-key",
-        "remaining": 100,
-        "expiresIn": 3600000,
-        "rateLimitEnabled": true,
-        "rateLimitMax": 10,
-        "rateLimitTimeWindow": 60000
+        "prefix": "lk_",
+        "expiresIn": 3600000
     });
 
     let request = AuthRequest::from_parts(
@@ -1799,9 +1797,7 @@ async fn test_api_key_create_with_options() {
 
     assert!(data["key"].is_string());
     assert_eq!(data["name"], "limited-key");
-    assert_eq!(data["remaining"], 100);
-    assert_eq!(data["rateLimitEnabled"], true);
-    assert_eq!(data["rateLimitMax"], 10);
+    assert_eq!(data["prefix"], "lk_");
     assert!(data["expiresAt"].is_string());
 }
 
@@ -1892,10 +1888,9 @@ async fn test_api_key_update() {
     headers.insert("authorization".to_string(), format!("Bearer {}", token));
 
     let update_body = serde_json::json!({
-        "id": id,
+        "keyId": id,
         "name": "updated-name",
-        "enabled": false,
-        "remaining": 50
+        "enabled": false
     });
 
     let request = AuthRequest::from_parts(
@@ -1915,7 +1910,6 @@ async fn test_api_key_update() {
     assert_eq!(data["id"], id);
     assert_eq!(data["name"], "updated-name");
     assert_eq!(data["enabled"], false);
-    assert_eq!(data["remaining"], 50);
 }
 
 /// Integration test: delete API key
@@ -1932,7 +1926,7 @@ async fn test_api_key_delete() {
     headers.insert("content-type".to_string(), "application/json".to_string());
     headers.insert("authorization".to_string(), format!("Bearer {}", token));
 
-    let delete_body = serde_json::json!({"id": id});
+    let delete_body = serde_json::json!({"keyId": id});
 
     let request = AuthRequest::from_parts(
         better_auth::prelude::HttpMethod::Post,
@@ -1947,7 +1941,7 @@ async fn test_api_key_delete() {
 
     let body_str = String::from_utf8(response.body).unwrap();
     let data: serde_json::Value = serde_json::from_str(&body_str).unwrap();
-    assert_eq!(data["status"], true);
+    assert_eq!(data["success"], true);
 
     // Verify it's gone by listing
     let mut headers2 = HashMap::new();
@@ -2101,7 +2095,7 @@ async fn test_api_key_delete_other_users_key() {
     headers2.insert("content-type".to_string(), "application/json".to_string());
     headers2.insert("authorization".to_string(), format!("Bearer {}", token2));
 
-    let delete_body = serde_json::json!({"id": id});
+    let delete_body = serde_json::json!({"keyId": id});
 
     let delete_request = AuthRequest::from_parts(
         better_auth::prelude::HttpMethod::Post,
@@ -2153,7 +2147,7 @@ async fn test_api_key_update_other_users_key() {
     headers2.insert("authorization".to_string(), format!("Bearer {}", token2));
 
     let update_body = serde_json::json!({
-        "id": id,
+        "keyId": id,
         "name": "hijacked-name"
     });
 

--- a/tests/legacy_schema_integration_tests.rs
+++ b/tests/legacy_schema_integration_tests.rs
@@ -118,8 +118,8 @@ mod user {
         fn email_column() -> Self::Column {
             Column::Email
         }
-        fn username_column() -> Self::Column {
-            Column::Username
+        fn username_column() -> Option<Self::Column> {
+            Some(Column::Username)
         }
         fn name_column() -> Self::Column {
             Column::Name

--- a/tests/public_docs_consistency_tests.rs
+++ b/tests/public_docs_consistency_tests.rs
@@ -39,19 +39,19 @@ fn docs_use_current_minor_version_and_canonical_paths() {
             || readme.contains(&format!("better-auth = \"{expected_full}\""))
             || readme.contains(&format!("version = \"{expected_minor}\""))
             || readme.contains(&format!("version = \"{expected_full}\"")),
-        "README should use the current minor crate version",
+        "README should use the current minor or full crate version",
     );
     assert!(
         installation.contains(&format!("better-auth = \"{expected_minor}\""))
             || installation.contains(&format!("better-auth = \"{expected_full}\""))
             || installation.contains(&format!("version = \"{expected_minor}\""))
             || installation.contains(&format!("version = \"{expected_full}\"")),
-        "installation guide should use the current minor crate version",
+        "installation guide should use the current minor or full crate version",
     );
     assert!(
         axum.contains(&format!("better-auth = {{ version = \"{expected_minor}\""))
             || axum.contains(&format!("better-auth = {{ version = \"{expected_full}\"")),
-        "axum guide should use the current minor crate version",
+        "axum guide should use the current minor or full crate version",
     );
 
     for text in [&readme, &quick_start, &axum] {

--- a/tests/public_docs_consistency_tests.rs
+++ b/tests/public_docs_consistency_tests.rs
@@ -27,6 +27,7 @@ fn crate_minor_version() -> String {
 #[test]
 fn docs_use_current_minor_version_and_canonical_paths() {
     let expected_minor = crate_minor_version();
+    let expected_full = env!("CARGO_PKG_VERSION");
 
     let readme = read_repo_file("README.md");
     let installation = read_repo_file("docs/content/docs/installation.mdx");
@@ -35,16 +36,21 @@ fn docs_use_current_minor_version_and_canonical_paths() {
 
     assert!(
         readme.contains(&format!("better-auth = \"{expected_minor}\""))
-            || readme.contains(&format!("version = \"{expected_minor}\"")),
+            || readme.contains(&format!("better-auth = \"{expected_full}\""))
+            || readme.contains(&format!("version = \"{expected_minor}\""))
+            || readme.contains(&format!("version = \"{expected_full}\"")),
         "README should use the current minor crate version",
     );
     assert!(
         installation.contains(&format!("better-auth = \"{expected_minor}\""))
-            || installation.contains(&format!("version = \"{expected_minor}\"")),
+            || installation.contains(&format!("better-auth = \"{expected_full}\""))
+            || installation.contains(&format!("version = \"{expected_minor}\""))
+            || installation.contains(&format!("version = \"{expected_full}\"")),
         "installation guide should use the current minor crate version",
     );
     assert!(
-        axum.contains(&format!("better-auth = {{ version = \"{expected_minor}\"")),
+        axum.contains(&format!("better-auth = {{ version = \"{expected_minor}\""))
+            || axum.contains(&format!("better-auth = {{ version = \"{expected_full}\"")),
         "axum guide should use the current minor crate version",
     );
 


### PR DESCRIPTION
This pull request updates integration tests, documentation checks, and some test utilities to match recent API and schema changes. The main focus is on updating test cases for API key management, improving documentation consistency checks, and making minor compatibility improvements for database schema handling.

**Integration test updates for API key management:**

* Updated API key creation, update, and deletion tests to use `keyId` instead of `id`, and to expect or set the correct fields (`prefix`, `success`) in request bodies and responses, matching recent API changes. Removed deprecated fields like `remaining` and rate limit options from test payloads. [[1]](diffhunk://#diff-e6b41d2b5ecc7c9a47a8db354ec3916bf8ef2c1cfb29aceb796af5a51a3f22a0L1779-R1781) [[2]](diffhunk://#diff-e6b41d2b5ecc7c9a47a8db354ec3916bf8ef2c1cfb29aceb796af5a51a3f22a0L1895-R1893) [[3]](diffhunk://#diff-e6b41d2b5ecc7c9a47a8db354ec3916bf8ef2c1cfb29aceb796af5a51a3f22a0L1918) [[4]](diffhunk://#diff-e6b41d2b5ecc7c9a47a8db354ec3916bf8ef2c1cfb29aceb796af5a51a3f22a0L1935-R1929) [[5]](diffhunk://#diff-e6b41d2b5ecc7c9a47a8db354ec3916bf8ef2c1cfb29aceb796af5a51a3f22a0L1950-R1944) [[6]](diffhunk://#diff-e6b41d2b5ecc7c9a47a8db354ec3916bf8ef2c1cfb29aceb796af5a51a3f22a0L2104-R2098) [[7]](diffhunk://#diff-e6b41d2b5ecc7c9a47a8db354ec3916bf8ef2c1cfb29aceb796af5a51a3f22a0L2156-R2150) [[8]](diffhunk://#diff-e6b41d2b5ecc7c9a47a8db354ec3916bf8ef2c1cfb29aceb796af5a51a3f22a0L1802-R1800)

* Improved error endpoint test to check for both `"CODE:"` and `"UNKNOWN"` in the response, making the test more robust.

**Documentation consistency checks:**

* Enhanced the documentation version check to allow both minor and full crate versions in `README.md`, installation, and guide files, improving flexibility for version references. [[1]](diffhunk://#diff-4569beee287f3741d252ae63906f34c1cb6c2294abff95754cd52d1310723be2R30) [[2]](diffhunk://#diff-4569beee287f3741d252ae63906f34c1cb6c2294abff95754cd52d1310723be2L38-R53)

**Test utility and schema improvements:**

* Updated legacy schema integration test to make `username_column` optional, improving compatibility with schemas that may not include a username column.

* Added missing feature gating and import for SeaORM v2 tests, ensuring correct test compilation when the feature is enabled. [[1]](diffhunk://#diff-954d7738f1fb93b8e855aedd2f793bd384f9e2925fcab7fdb87dcd9e4827c11aR3-R10) [[2]](diffhunk://#diff-954d7738f1fb93b8e855aedd2f793bd384f9e2925fcab7fdb87dcd9e4827c11aL49)Adjust API key tests to use "keyId" and expect "success", and assert "prefix" instead of deprecated remaining/rateLimit fields. Relax error page assertion to check "CODE:" and "UNKNOWN" separately. Add Change username_column to return Option<Column> in legacy schema test. Allow docs tests to accept the full crate version in README/installation and axum guide tests