### PR TITLE
Send a User-Agent on OAuth requests so GitHub sign-in works

### DIFF
--- a/crates/api/src/plugins/oauth/handlers.rs
+++ b/crates/api/src/plugins/oauth/handlers.rs
@@ -252,7 +252,10 @@ pub(crate) async fn refresh_token_core<DB: DatabaseAdapter>(
     let current_refresh_token = maybe_decrypt(account.refresh_token(), encrypt, secret)?
         .ok_or_else(|| AuthError::bad_request("No refresh token available for this provider"))?;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .user_agent(config.user_agent.clone())
+        .build()
+        .map_err(|e| AuthError::internal(format!("Failed to build HTTP client: {}", e)))?;
     let token_resp = client
         .post(&provider.token_url)
         .header("Accept", "application/json")
@@ -438,7 +441,10 @@ pub(crate) async fn callback_core<DB: DatabaseAdapter>(
         .ok_or_else(|| AuthError::bad_request(format!("Unknown provider: {}", provider_name)))?;
 
     // Exchange code for tokens
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .user_agent(config.user_agent.clone())
+        .build()
+        .map_err(|e| AuthError::internal(format!("Failed to build HTTP client: {}", e)))?;
     let token_resp = client
         .post(&provider.token_url)
         .header("Accept", "application/json")

--- a/crates/api/src/plugins/oauth/mod.rs
+++ b/crates/api/src/plugins/oauth/mod.rs
@@ -36,6 +36,13 @@ impl OAuthPlugin {
         self.config.providers.insert(name.to_string(), provider);
         self
     }
+
+    /// Set the User-Agent sent on OAuth HTTP requests (default `"better-auth"`).
+    /// Some provider APIs (notably GitHub) reject requests without one.
+    pub fn user_agent(mut self, user_agent: impl Into<String>) -> Self {
+        self.config.user_agent = user_agent.into();
+        self
+    }
 }
 
 impl Default for OAuthPlugin {

--- a/crates/api/src/plugins/oauth/providers.rs
+++ b/crates/api/src/plugins/oauth/providers.rs
@@ -12,13 +12,27 @@ pub enum OAuthStateStrategy {
 }
 
 /// Configuration for the OAuth plugin, containing all registered providers.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct OAuthConfig {
     pub providers: HashMap<String, OAuthProvider>,
     /// Skip state cookie verification (default: false) - SECURITY WARNING
     pub skip_state_cookie_check: bool,
     /// Where to store OAuth state: Cookie (stateless) or Database (default: Cookie)
     pub store_state_strategy: OAuthStateStrategy,
+    /// User-Agent sent on OAuth HTTP requests. Some provider APIs (notably
+    /// GitHub) reject requests without one. Defaults to `"better-auth"`.
+    pub user_agent: String,
+}
+
+impl Default for OAuthConfig {
+    fn default() -> Self {
+        Self {
+            providers: HashMap::new(),
+            skip_state_cookie_check: false,
+            store_state_strategy: OAuthStateStrategy::default(),
+            user_agent: "better-auth".to_string(),
+        }
+    }
 }
 
 /// User information extracted from an OAuth provider's user info endpoint.


### PR DESCRIPTION
GitHub's API rejects requests without a User-Agent header, which makes social sign-in fail on the user-info fetch, so this builds the OAuth reqwest client with a default User-Agent.