### PR TITLE
fix: add user agent to oauth handler

### DIFF
--- a/crates/api/src/plugins/oauth/handlers.rs
+++ b/crates/api/src/plugins/oauth/handlers.rs
@@ -483,6 +483,7 @@ pub(crate) async fn callback_core<DB: DatabaseAdapter>(
         .get(&provider.user_info_url)
         .bearer_auth(access_token)
         .header("Accept", "application/json")
+        .header("User-Agent", "better-auth")
         .send()
         .await
         .map_err(|e| AuthError::internal(format!("Failed to fetch user info: {}", e)))?;


### PR DESCRIPTION
This fixes [GitHub OAuth requiring a User-Agent header](https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api?apiVersion=2026-03-10#user-agent) in order to work properly.
Previously, this header was missing, and the OAuth flow failed, and this fixes that.
This also provides parity with [the JS version](https://github.com/better-auth/better-auth/blob/54fab084469a27257e66a0814523ebac7145ef5d/packages/core/src/social-providers/github.ts#L140).

I used this small example script to test that it does, in fact, work:
```rs
use better_auth::{
    AuthBuilder, AuthConfig,
    adapters::MemoryDatabaseAdapter,
    handlers::AxumIntegration,
    plugins::{
        AccountManagementPlugin, OAuthPlugin, SessionManagementPlugin, oauth::OAuthProvider,
    },
};
use std::sync::Arc;

const GITHUB_ID: &str = "********";
const GITHUB_SECRET: &str = "****************************";
const BASE_URL: &str = "http://localhost:3002";

#[tokio::main]
async fn main() {
    let auth = Arc::new(
        AuthBuilder::new(
            AuthConfig::new("your-very-secure-secret-key-at-least-32-chars-long")
                .base_url(format!("{BASE_URL}/auth")),
        )
        .database(MemoryDatabaseAdapter::new())
        .plugin(SessionManagementPlugin::new())
        .plugin(AccountManagementPlugin::new())
        .plugin(
            OAuthPlugin::new()
                .add_provider("github", OAuthProvider::github(GITHUB_ID, GITHUB_SECRET)),
        )
        .build()
        .await
        .unwrap(),
    );

    let router = axum::Router::new()
        .nest("/auth", auth.clone().axum_router())
        .with_state(auth);

    let listener = tokio::net::TcpListener::bind("0.0.0.0:3002").await.unwrap();

    tokio::spawn(async move {
        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
        let resp: serde_json::Value = reqwest::Client::new()
            .post(format!("{BASE_URL}/auth/sign-in/social"))
            .json(&serde_json::json!({"provider": "github"}))
            .send()
            .await
            .unwrap()
            .json()
            .await
            .unwrap();
        let _ = std::process::Command::new("xdg-open")
            .arg(resp["url"].as_str().unwrap())
            .spawn();
    });

    axum::serve(listener, router).await.unwrap();
}
```