### PR TITLE
fix: add options method handler

### DIFF
--- a/src/handlers/axum.rs
+++ b/src/handlers/axum.rs
@@ -109,6 +109,10 @@ impl<DB: DatabaseAdapter> AxumIntegration<DB> for Arc<BetterAuth<DB>> {
                         router =
                             router.route(&route.path, axum::routing::patch(handler_fn.clone()));
                     }
+                    HttpMethod::Options => {
+                        router =
+                            router.route(&route.path, axum::routing::options(handler_fn.clone()));
+                    }
                     _ => {} // Skip unsupported methods
                 }
             }


### PR DESCRIPTION
This pull request adds support for the HTTP OPTIONS method in the Axum router integration. Now, routes defined with the OPTIONS method will be correctly registered and handled.

Routing improvements:
* Added handling for the `HttpMethod::Options` variant in the Axum router, enabling support for OPTIONS requests (`src/handlers/axum.rs`).